### PR TITLE
Fix baseline bool comparison: normalize vera-style string bools

### DIFF
--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -102,6 +102,19 @@ class TestRunPythonBaseline:
         result = run_python_baseline(problem, SOLUTIONS_DIR, tmp_path)
         assert result.run_correct is None
 
+    def test_bool_string_normalization(self, tmp_path):
+        problem = {
+            "id": "VB-T4-003",
+            "entry_point": "is_even",
+            "test_cases": [
+                {"args": [4], "expected": "true"},
+                {"args": [7], "expected": "false"},
+            ],
+        }
+        result = run_python_baseline(problem, SOLUTIONS_DIR, tmp_path)
+        assert result.run_correct is True
+        assert result.tests_passed == 2
+
     def test_missing_file_returns_error(self, tmp_path):
         problem = {
             "id": "VB-T99-999",

--- a/vera_bench/baseline_runner.py
+++ b/vera_bench/baseline_runner.py
@@ -60,6 +60,9 @@ def _build_python_wrapper(
     for i, tc in enumerate(test_cases):
         args = tc.get("args", [])
         expected = tc.get("expected")
+        # Normalize vera-style bool strings to Python bools
+        if isinstance(expected, str) and expected in ("true", "false"):
+            expected = expected == "true"
         args_repr = repr(args)
         expected_repr = repr(expected)
         lines.extend(


### PR DESCRIPTION
## Summary

VB-T4-003 (is_even) test_cases use `"true"/"false"` strings (vera run output format), but the Python baseline returns native `bool`. The wrapper was comparing `True == "true"` which is `False`.

Now normalizes string bools to Python bools in the wrapper generator.

## Test plan

- [x] New test: `test_bool_string_normalization` verifies is_even with string-bool expected values
- [x] 298 tests pass
- [x] `vera-bench baselines` should now show 100% run_correct

Generated with [Claude Code](https://claude.com/claude-code)