### PR TITLE
Add Initial Results section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ First benchmark results from [VeraBench v0.0.4](https://github.com/aallan/vera-b
 
 **Writing contracts is harder than writing code.** The spec-from-NL mode (where the model must infer its own contracts from the natural language description) drops verify@1 by 10 points and halves fix@1. The implementation itself barely changes — check@1 holds at 94% — but getting the contracts right from NL alone is the real challenge.
 
-> **Note:** These are single-run results from one model. LLM outputs are non-deterministic — individual problems can flip between pass and fail across runs. Stable rates will require multiple trials (pass@k). More models and repeated runs are planned.
+> **Note:** These are single-run results from one model. LLM outputs are non-deterministic — individual problems can flip between pass and fail across runs. Stable rates will require multiple trials ([pass@k](https://arxiv.org/abs/2107.03374) — sample k independent outputs per problem, count as passed if any output succeeds). More models and repeated runs are planned.
 
 ## Overview
 


### PR DESCRIPTION
Front-and-centre the six-way comparison table from the first Claude Sonnet 4 benchmark run.

Highlights:
- Vera with contracts (83%) outperforms TypeScript without them (79%)
- Python remains strongest at 92%, but the gap to Vera is only 9 points
- Contract design (spec-from-NL) is harder than code generation
- Clear caveat about single-run non-determinism

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "Initial Results" section with first‑run benchmark numbers and comparison tables (Vera full‑spec vs spec‑from‑NL; Python/TypeScript LLM modes and baselines).
  * Added narrative bullets summarising relative performance and a note on non‑determinism recommending multi‑run stability (pass@k).
  * Clarified Results output: summary, per‑tier and per‑problem detail; generated result files are ignored in version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->