### PR TITLE
Update ROADMAP to reflect v0.0.7 milestones and provider registry refactor

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,17 +6,19 @@
 
 ## Milestone 1: Publication-ready benchmark (current)
 
-- [ ] Run against 5+ models (Claude Opus/Sonnet, GPT-4o, DeepSeek, Gemini)
+- [x] Run against 6 models across 3 providers — Claude Opus 4 / Sonnet 4, GPT-4.1 / 4o, Kimi K2.5 / K2 Turbo (v0.0.7)
+- [ ] Expand provider coverage — Mistral, xAI Grok, DeepSeek, Gemini (issue [#24](https://github.com/aallan/vera-bench/issues/24))
+- [ ] Refactor `models.py` to a provider registry before adding more (issue [#45](https://github.com/aallan/vera-bench/issues/45))
 - [x] Run spec-from-NL mode comparison (issue #7)
 - [x] TypeScript baseline runner and LLM generation
-- [ ] Generate paper-quality figures (matplotlib/seaborn in analysis/)
+- [x] Generate paper-quality figures (matplotlib in `scripts/plot_results.py`, v0.0.7)
 - [ ] Hugging Face dataset export
-- [ ] CITATION.cff
+- [x] CITATION.cff
 - [ ] Expand to 75+ problems (15 per tier)
 - [x] Strengthen problem descriptions for slot ordering (issue #13)
 - [x] Strengthen postconditions to catch slot-swap bugs (issue #14)
 - [ ] Improve SKILL.md coverage of where blocks (issue #15)
-- [x] Increase test coverage to 83% (issue #5, ongoing)
+- [x] Increase test coverage to 85% (issue #5, ongoing — target 90%)
 
 ## Milestone 2: Longitudinal tracking
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,14 +6,14 @@
 
 ## Milestone 1: Publication-ready benchmark (current)
 
-- [x] Run against 6 models across 3 providers — Claude Opus 4 / Sonnet 4, GPT-4.1 / 4o, Kimi K2.5 / K2 Turbo (v0.0.7)
+- [x] Run against 6 models across 3 providers — Claude Opus 4 / Sonnet 4, GPT-4.1 / 4o, Kimi K2.5 / K2 Turbo ([v0.0.7 release](https://github.com/aallan/vera-bench/releases/tag/v0.0.7), [results section](README.md#results), [chart](assets/benchmark_v0.0.7.png))
 - [ ] Expand provider coverage — Mistral, xAI Grok, DeepSeek, Gemini (issue [#24](https://github.com/aallan/vera-bench/issues/24))
 - [ ] Refactor `models.py` to a provider registry before adding more (issue [#45](https://github.com/aallan/vera-bench/issues/45))
 - [x] Run spec-from-NL mode comparison (issue #7)
 - [x] TypeScript baseline runner and LLM generation
-- [x] Generate paper-quality figures (matplotlib in `scripts/plot_results.py`, v0.0.7)
+- [x] Generate paper-quality figures — [`scripts/plot_results.py`](scripts/plot_results.py) produces [`assets/benchmark_v0.0.7.png`](assets/benchmark_v0.0.7.png) with veralang.dev site palette (v0.0.7)
 - [ ] Hugging Face dataset export
-- [x] CITATION.cff
+- [x] [`CITATION.cff`](CITATION.cff)
 - [ ] Expand to 75+ problems (15 per tier)
 - [x] Strengthen problem descriptions for slot ordering (issue #13)
 - [x] Strengthen postconditions to catch slot-swap bugs (issue #14)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,7 +18,7 @@
 - [x] Strengthen problem descriptions for slot ordering (issue #13)
 - [x] Strengthen postconditions to catch slot-swap bugs (issue #14)
 - [ ] Improve SKILL.md coverage of where blocks (issue #15)
-- [x] Increase test coverage to 85% (issue #5, ongoing — target 90%)
+- [x] Test coverage ([issue #5](https://github.com/aallan/vera-bench/issues/5), ongoing — target 90%) — CI enforces 80% floor via `--cov-fail-under=80` in [ci.yml](.github/workflows/ci.yml), current coverage shown by [![codecov](https://codecov.io/gh/aallan/vera-bench/graph/badge.svg)](https://codecov.io/gh/aallan/vera-bench)
 
 ## Milestone 2: Longitudinal tracking
 


### PR DESCRIPTION
## Summary
- Mark 6-model benchmark runs as done (v0.0.7 shipped with Claude Opus 4/Sonnet 4, GPT-4.1/4o, Kimi K2.5/K2 Turbo)
- Mark CITATION.cff and paper-quality figures as done
- Add provider expansion line referencing [#24](https://github.com/aallan/vera-bench/issues/24) (Mistral, Grok, DeepSeek, Gemini)
- Add provider registry refactor as prerequisite ([#45](https://github.com/aallan/vera-bench/issues/45))
- Bump test coverage line from 83% to 85% (current, target 90%)

## Test plan
- [x] ROADMAP renders correctly as markdown
- [x] Issue links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded model support to 6 models across 3 providers, offering greater choice.
  * Paper-quality figures now available for clearer result visualisation.

* **Documentation**
  * Roadmap updated to reflect Milestone 1 completion and version v0.0.7.
  * Citation file added.

* **Tests**
  * Test coverage tracking formalised with CI enforcement and a 90% target; coverage badge added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->