### PR TITLE
Update Moonshot brand link to Kimi platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ vera-bench report results/
 python scripts/run_full_benchmark.py
 ```
 
-Supported providers: [Anthropic](https://anthropic.com) (Claude), [OpenAI](https://openai.com) (GPT), and [Moonshot](https://moonshot.ai) (Kimi). Set the appropriate API key environment variable (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `MOONSHOT_API_KEY`).
+Supported providers: [Anthropic](https://anthropic.com) (Claude), [OpenAI](https://openai.com) (GPT), and [Kimi](https://platform.kimi.ai) (Moonshot). Set the appropriate API key environment variable (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `MOONSHOT_API_KEY`).
 
 The Vera language reference ([SKILL.md](https://veralang.dev/SKILL.md)) is fetched automatically from veralang.dev when running Vera benchmarks. To use a local copy instead (e.g., for testing unreleased language features):
 


### PR DESCRIPTION
## Summary
- Moonshot rebranded their developer portal from `platform.moonshot.ai` to `platform.kimi.ai`
- Updated README provider link from `[Moonshot](https://moonshot.ai)` to `[Kimi](https://platform.kimi.ai)`
- API endpoint (`api.moonshot.ai/v1`) is unaffected per their migration notice — no code changes needed

## Test plan
- [x] Link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the Moonshot provider link in the supported providers section. Updated the provider branding from Moonshot to Kimi (Moonshot) with the correct platform URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->