### PR TITLE
Add Aver language support + language-neutral problem descriptions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -48,10 +48,12 @@ reviews:
 
   path_filters:
     - "!**/*.vera"
+    - "!**/*.av"
     - "!context/**"
     - "!results/**/*.jsonl"
     - "!solutions/python/**"
     - "!solutions/typescript/**"
+    - "!solutions/aver/**"
 
   path_instructions:
     - path: "vera_bench/**/*.py"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Aver language support: generation, checking, execution, and fix-from-error
+- `description_neutral` field on all 50 problem JSONs for language-neutral prompts
+- Aver baseline runner (`vera-bench baselines --language aver`)
+
+### Changed
+
+- Python and TypeScript prompts now use `description_neutral` instead of
+  Vera-flavoured `description`. This improves fairness for non-Vera languages
+  but means results are not directly comparable to v0.0.7 runs which used
+  Vera-specific descriptions.
+
 ## [0.0.7] - 2026-04-07
 
 ### Added

--- a/problems/tier1/VB_T1_001_absolute_value.json
+++ b/problems/tier1/VB_T1_001_absolute_value.json
@@ -3,6 +3,7 @@
   "tier": 1,
   "title": "Absolute Value",
   "description": "Write a Vera function that computes the absolute value of an integer. The function should take a single Int parameter and return a Nat (non-negative integer). The postcondition should guarantee the result is non-negative and equals either the input or its negation.",
+  "description_neutral": "Compute the absolute value of an integer. Returns a non-negative integer that equals either the input or its negation.",
   "signature": "public fn absolute_value(@Int -> @Nat)",
   "contracts": {
     "requires": [

--- a/problems/tier1/VB_T1_002_clamp.json
+++ b/problems/tier1/VB_T1_002_clamp.json
@@ -3,6 +3,7 @@
   "tier": 1,
   "title": "Clamp",
   "description": "Write a Vera function that clamps an integer to a range [lo, hi]. Takes three Int parameters: value, lo, hi. Precondition: lo <= hi. Postconditions: result is within [lo, hi].",
+  "description_neutral": "Clamp an integer to a range [lo, hi]. Takes three parameters: value, lo, hi (where lo <= hi). Returns lo if value < lo, hi if value > hi, otherwise value.",
   "signature": "public fn clamp(@Int, @Int, @Int -> @Int)",
   "contracts": {
     "requires": [

--- a/problems/tier1/VB_T1_003_signum.json
+++ b/problems/tier1/VB_T1_003_signum.json
@@ -3,6 +3,7 @@
   "tier": 1,
   "title": "Signum",
   "description": "Write a Vera function that returns the sign of an integer: -1 for negative, 0 for zero, 1 for positive. The postcondition should guarantee the result is exactly one of {-1, 0, 1}.",
+  "description_neutral": "Return the sign of an integer: -1 for negative, 0 for zero, 1 for positive.",
   "signature": "public fn signum(@Int -> @Int)",
   "contracts": {
     "requires": [

--- a/problems/tier1/VB_T1_004_max_of_two.json
+++ b/problems/tier1/VB_T1_004_max_of_two.json
@@ -3,6 +3,7 @@
   "tier": 1,
   "title": "Maximum of Two",
   "description": "Write a Vera function that returns the larger of two integers. The postconditions should guarantee the result is greater than or equal to both inputs, and is equal to one of them.",
+  "description_neutral": "Return the larger of two integers.",
   "signature": "public fn max_of_two(@Int, @Int -> @Int)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier1/VB_T1_005_min_of_two.json
+++ b/problems/tier1/VB_T1_005_min_of_two.json
@@ -3,6 +3,7 @@
   "tier": 1,
   "title": "Minimum of Two",
   "description": "Write a Vera function that returns the smaller of two integers. The postconditions should guarantee the result is less than or equal to both inputs, and is equal to one of them.",
+  "description_neutral": "Return the smaller of two integers.",
   "signature": "public fn min_of_two(@Int, @Int -> @Int)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier1/VB_T1_006_is_positive.json
+++ b/problems/tier1/VB_T1_006_is_positive.json
@@ -3,6 +3,7 @@
   "tier": 1,
   "title": "Is Positive",
   "description": "Write a Vera function that returns true if the integer is strictly positive (greater than zero). The postcondition should express logical equivalence between the result and the comparison.",
+  "description_neutral": "Return true if the integer is strictly positive (greater than zero), false otherwise.",
   "signature": "public fn is_positive(@Int -> @Bool)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier1/VB_T1_007_safe_modulo.json
+++ b/problems/tier1/VB_T1_007_safe_modulo.json
@@ -3,6 +3,7 @@
   "tier": 1,
   "title": "Safe Modulo",
   "description": "Write a Vera function that computes a modulo b with a precondition that the divisor is non-zero. The postcondition should guarantee the result equals a % b.",
+  "description_neutral": "Compute a modulo b. The divisor must be non-zero.",
   "signature": "public fn safe_modulo(@Int, @Int -> @Int)",
   "contracts": {
     "requires": ["@Int.0 != 0"],

--- a/problems/tier1/VB_T1_008_distance.json
+++ b/problems/tier1/VB_T1_008_distance.json
@@ -3,6 +3,7 @@
   "tier": 1,
   "title": "Distance",
   "description": "Write a Vera function that computes the absolute difference between two integers, returning a Nat (non-negative integer). The postcondition should guarantee the result is non-negative.",
+  "description_neutral": "Compute the absolute difference between two integers. Returns a non-negative integer.",
   "signature": "public fn distance(@Int, @Int -> @Nat)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier1/VB_T1_009_max_of_three.json
+++ b/problems/tier1/VB_T1_009_max_of_three.json
@@ -3,6 +3,7 @@
   "tier": 1,
   "title": "Maximum of Three",
   "description": "Write a Vera function that returns the largest of three integers. The postconditions should guarantee the result is greater than or equal to all three inputs.",
+  "description_neutral": "Return the largest of three integers.",
   "signature": "public fn max_of_three(@Int, @Int, @Int -> @Int)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier1/VB_T1_010_double_or_nothing.json
+++ b/problems/tier1/VB_T1_010_double_or_nothing.json
@@ -3,6 +3,7 @@
   "tier": 1,
   "title": "Double or Nothing",
   "description": "Write a Vera function that doubles a positive integer and returns 0 for non-positive inputs. The postcondition should guarantee the result is non-negative.",
+  "description_neutral": "Double a positive integer. Return 0 for non-positive inputs.",
   "signature": "public fn double_or_nothing(@Int -> @Int)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier2/VB_T2_001_sum_array.json
+++ b/problems/tier2/VB_T2_001_sum_array.json
@@ -3,6 +3,7 @@
   "tier": 2,
   "title": "Sum Array",
   "description": "Write a Vera function that sums all elements of an integer array. Use the array_fold built-in function with an accumulator starting at 0.",
+  "description_neutral": "Sum all elements of an integer list.",
   "signature": "public fn sum_array(@Array<Int> -> @Int)",
   "contracts": {
     "requires": [

--- a/problems/tier2/VB_T2_002_filter_positives.json
+++ b/problems/tier2/VB_T2_002_filter_positives.json
@@ -3,6 +3,7 @@
   "tier": 2,
   "title": "Filter Positives",
   "description": "Write a Vera function that returns a new array containing only the positive elements from an integer array. Use the array_filter built-in.",
+  "description_neutral": "Return a new list containing only the positive elements from an integer list.",
   "signature": "public fn filter_positives(@Array<Int> -> @Array<Int>)",
   "contracts": {
     "requires": [

--- a/problems/tier2/VB_T2_003_greeting.json
+++ b/problems/tier2/VB_T2_003_greeting.json
@@ -3,6 +3,7 @@
   "tier": 2,
   "title": "Greeting",
   "description": "Write a Vera function that builds a greeting string. Given a name, return 'Hello, <name>!'. Use string_concat to build the result. The precondition should require the name is non-empty. The postcondition should guarantee the result is longer than 7 characters.",
+  "description_neutral": "Build a greeting string. Given a non-empty name, return 'Hello, <name>!'.",
   "signature": "public fn greet(@String -> @String)",
   "contracts": {
     "requires": [

--- a/problems/tier2/VB_T2_003_greeting.json
+++ b/problems/tier2/VB_T2_003_greeting.json
@@ -3,7 +3,7 @@
   "tier": 2,
   "title": "Greeting",
   "description": "Write a Vera function that builds a greeting string. Given a name, return 'Hello, <name>!'. Use string_concat to build the result. The precondition should require the name is non-empty. The postcondition should guarantee the result is longer than 7 characters.",
-  "description_neutral": "Build a greeting string. Given a non-empty name, return 'Hello, <name>!'.",
+  "description_neutral": "Build a greeting string. Given a name, return 'Hello, <name>!'. The name is guaranteed to be non-empty.",
   "signature": "public fn greet(@String -> @String)",
   "contracts": {
     "requires": [

--- a/problems/tier2/VB_T2_004_is_empty_string.json
+++ b/problems/tier2/VB_T2_004_is_empty_string.json
@@ -3,6 +3,7 @@
   "tier": 2,
   "title": "Is Empty String",
   "description": "Write a Vera function that checks if a string is empty by comparing its length to zero. Use the string_length built-in function.",
+  "description_neutral": "Check if a string is empty by comparing its length to zero.",
   "signature": "public fn is_empty_string(@String -> @Bool)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier2/VB_T2_005_contains_substring.json
+++ b/problems/tier2/VB_T2_005_contains_substring.json
@@ -3,6 +3,7 @@
   "tier": 2,
   "title": "Contains Substring",
   "description": "Write a Vera function that checks if the first string contains the second string as a substring. Use the string_contains built-in function. The first parameter is the haystack, the second is the needle.",
+  "description_neutral": "Check if the first string contains the second string as a substring.",
   "signature": "public fn contains_substring(@String, @String -> @Bool)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier2/VB_T2_006_join_strings.json
+++ b/problems/tier2/VB_T2_006_join_strings.json
@@ -3,6 +3,7 @@
   "tier": 2,
   "title": "Join Strings",
   "description": "Write a Vera function that joins an array of strings with a separator string. Use the string_join built-in function.",
+  "description_neutral": "Join a list of strings with a separator string.",
   "signature": "public fn join_strings(@Array<String>, @String -> @String)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier2/VB_T2_007_double_elements.json
+++ b/problems/tier2/VB_T2_007_double_elements.json
@@ -3,6 +3,7 @@
   "tier": 2,
   "title": "Double Elements",
   "description": "Write a Vera function that doubles every element in an integer array. Use the array_map built-in function with an inline closure.",
+  "description_neutral": "Double every element in an integer list.",
   "signature": "public fn double_elements(@Array<Int> -> @Array<Int>)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier2/VB_T2_008_count_positives.json
+++ b/problems/tier2/VB_T2_008_count_positives.json
@@ -3,6 +3,7 @@
   "tier": 2,
   "title": "Count Positives",
   "description": "Write a Vera function that counts how many positive elements are in an integer array. Use array_filter to select positive elements, then array_length to count them.",
+  "description_neutral": "Count how many positive elements are in an integer list.",
   "signature": "public fn count_positives(@Array<Int> -> @Nat)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier2/VB_T2_009_to_upper.json
+++ b/problems/tier2/VB_T2_009_to_upper.json
@@ -3,6 +3,7 @@
   "tier": 2,
   "title": "To Upper Case",
   "description": "Write a Vera function that converts a string to uppercase. Use the string_upper built-in function.",
+  "description_neutral": "Convert a string to uppercase.",
   "signature": "public fn to_upper(@String -> @String)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier2/VB_T2_010_sum_positives.json
+++ b/problems/tier2/VB_T2_010_sum_positives.json
@@ -3,6 +3,7 @@
   "tier": 2,
   "title": "Sum Positives",
   "description": "Write a Vera function that sums only the positive elements in an integer array. Use array_filter to select positive elements, then array_fold to sum them.",
+  "description_neutral": "Sum only the positive elements in an integer list.",
   "signature": "public fn sum_positives(@Array<Int> -> @Int)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier3/VB_T3_001_list_length.json
+++ b/problems/tier3/VB_T3_001_list_length.json
@@ -3,6 +3,7 @@
   "tier": 3,
   "title": "List Length",
   "description": "Define a linked list ADT with Nil and Cons constructors, then write a function that computes its length. The function must be recursive with a decreases clause for termination.",
+  "description_neutral": "Define a linked list type with nil and cons constructors, then write a function that computes its length.",
   "signature": "public fn list_length(@List -> @Nat)",
   "contracts": {
     "requires": [

--- a/problems/tier3/VB_T3_002_tree_depth.json
+++ b/problems/tier3/VB_T3_002_tree_depth.json
@@ -3,6 +3,7 @@
   "tier": 3,
   "title": "Tree Depth",
   "description": "Define a binary tree ADT with Leaf(Int) and Branch(Tree, Tree) constructors, then write a function that computes the depth (height). A leaf has depth 1. Use the max built-in for comparing branch depths.",
+  "description_neutral": "Define a binary tree type with leaf and branch constructors, then write a function that computes the depth. A leaf has depth 1.",
   "signature": "public fn tree_depth(@Tree -> @Nat)",
   "contracts": {
     "requires": [

--- a/problems/tier3/VB_T3_003_expression_evaluator.json
+++ b/problems/tier3/VB_T3_003_expression_evaluator.json
@@ -3,6 +3,7 @@
   "tier": 3,
   "title": "Expression Evaluator",
   "description": "Define an expression ADT with Lit(Int), Add(Expr, Expr), and Neg(Expr) constructors. Write a function that evaluates the expression to an Int. Add evaluates both sub-expressions and sums them. Neg negates the sub-expression.",
+  "description_neutral": "Define an expression type with literal, addition, and negation constructors. Write a function that evaluates the expression to an integer.",
   "signature": "public fn eval_expr(@Expr -> @Int)",
   "contracts": {
     "requires": [

--- a/problems/tier3/VB_T3_004_list_sum.json
+++ b/problems/tier3/VB_T3_004_list_sum.json
@@ -3,6 +3,7 @@
   "tier": 3,
   "title": "List Sum",
   "description": "Define a linked list ADT with Nil and Cons(Int, List) constructors, then write a function that sums all elements. The base case (Nil) returns 0. The recursive case adds the head to the sum of the tail.",
+  "description_neutral": "Define a linked list type with nil and cons constructors, then write a function that sums all elements.",
   "signature": "public fn list_sum(@List -> @Int)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier3/VB_T3_005_tree_sum.json
+++ b/problems/tier3/VB_T3_005_tree_sum.json
@@ -3,6 +3,7 @@
   "tier": 3,
   "title": "Tree Sum",
   "description": "Define a binary tree ADT with Leaf(Int) and Branch(Tree, Tree) constructors, then write a function that sums all leaf values. Leaf returns its value, Branch sums both subtrees.",
+  "description_neutral": "Define a binary tree type with leaf and branch constructors, then write a function that sums all leaf values.",
   "signature": "public fn tree_sum(@Tree -> @Int)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier3/VB_T3_006_option_unwrap_or.json
+++ b/problems/tier3/VB_T3_006_option_unwrap_or.json
@@ -3,6 +3,7 @@
   "tier": 3,
   "title": "Option Unwrap Or",
   "description": "Define an Option ADT with None and Some(Int) constructors. Write a function that unwraps the Option, returning the contained value for Some and a provided default value for None. The function takes two parameters: the Option and the default Int.",
+  "description_neutral": "Define an option type with none and some constructors. Write a function that unwraps the option, returning the contained value or a default integer.",
   "signature": "public fn option_unwrap_or(@Option, @Int -> @Int)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier3/VB_T3_007_list_contains.json
+++ b/problems/tier3/VB_T3_007_list_contains.json
@@ -3,6 +3,7 @@
   "tier": 3,
   "title": "List Contains",
   "description": "Define a linked list ADT with Nil and Cons(Int, List) constructors. Write a function that returns true if the list contains a given target value. The function takes two parameters: the list and the target integer.",
+  "description_neutral": "Define a linked list type with nil and cons constructors. Write a function that returns true if the list contains a given target integer.",
   "signature": "public fn list_contains(@List, @Int -> @Bool)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier3/VB_T3_008_tree_count_leaves.json
+++ b/problems/tier3/VB_T3_008_tree_count_leaves.json
@@ -3,6 +3,7 @@
   "tier": 3,
   "title": "Tree Count Leaves",
   "description": "Define a binary tree ADT with Leaf(Int) and Branch(Tree, Tree) constructors. Write a function that counts the number of leaf nodes. The postcondition should guarantee the result is at least 1 (every tree has at least one leaf).",
+  "description_neutral": "Define a binary tree type with leaf and branch constructors. Write a function that counts the number of leaf nodes.",
   "signature": "public fn tree_count_leaves(@Tree -> @Nat)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier3/VB_T3_008_tree_count_leaves.json
+++ b/problems/tier3/VB_T3_008_tree_count_leaves.json
@@ -3,7 +3,7 @@
   "tier": 3,
   "title": "Tree Count Leaves",
   "description": "Define a binary tree ADT with Leaf(Int) and Branch(Tree, Tree) constructors. Write a function that counts the number of leaf nodes. The postcondition should guarantee the result is at least 1 (every tree has at least one leaf).",
-  "description_neutral": "Define a binary tree type with leaf and branch constructors. Write a function that counts the number of leaf nodes.",
+  "description_neutral": "Define a binary tree type with leaf and branch constructors. Write a function that counts the number of leaf nodes. The result is always at least 1 (every tree has at least one leaf).",
   "signature": "public fn tree_count_leaves(@Tree -> @Nat)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier3/VB_T3_009_list_append.json
+++ b/problems/tier3/VB_T3_009_list_append.json
@@ -3,6 +3,7 @@
   "tier": 3,
   "title": "List Append",
   "description": "Define a linked list ADT with Nil and Cons(Int, List) constructors. Write a function that concatenates two lists. Traverse the first list recursively and build a new list ending with the second list.",
+  "description_neutral": "Define a linked list type with nil and cons constructors. Write a function that concatenates two lists.",
   "signature": "public fn list_append(@List, @List -> @List)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier3/VB_T3_010_list_last.json
+++ b/problems/tier3/VB_T3_010_list_last.json
@@ -3,6 +3,7 @@
   "tier": 3,
   "title": "List Last",
   "description": "Define a linked list ADT with Nil and Cons(Int, List) constructors, and an Option ADT with None and Some(Int). Write a function that returns the last element of the list as Some(Int), or None for an empty list.",
+  "description_neutral": "Define a linked list type and an option type. Write a function that returns the last element of the list, or none if the list is empty.",
   "signature": "public fn list_last(@List -> @Option)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier4/VB_T4_001_fibonacci.json
+++ b/problems/tier4/VB_T4_001_fibonacci.json
@@ -3,6 +3,7 @@
   "tier": 4,
   "title": "Fibonacci",
   "description": "Write a Vera function that computes the nth Fibonacci number. fib(0) = 0, fib(1) = 1, fib(n) = fib(n-1) + fib(n-2). The function must include a decreases clause proving termination.",
+  "description_neutral": "Compute the nth Fibonacci number. fib(0) = 0, fib(1) = 1, fib(n) = fib(n-1) + fib(n-2).",
   "signature": "public fn fibonacci(@Nat -> @Nat)",
   "contracts": {
     "requires": [

--- a/problems/tier4/VB_T4_002_greatest_common_divisor.json
+++ b/problems/tier4/VB_T4_002_greatest_common_divisor.json
@@ -3,6 +3,7 @@
   "tier": 4,
   "title": "Greatest Common Divisor",
   "description": "Write a Vera function that computes the GCD of two natural numbers using Euclid's algorithm: gcd(a, 0) = a, gcd(a, b) = gcd(b, a mod b). The function takes two parameters: gcd(a, b) where @Nat.0 is b (the second/rightmost parameter) and @Nat.1 is a (the first). Include a decreases clause — the second parameter decreases on each recursive call.",
+  "description_neutral": "Compute the GCD of two non-negative integers using Euclid's algorithm: gcd(a, 0) = a, gcd(a, b) = gcd(b, a mod b).",
   "signature": "public fn gcd(@Nat, @Nat -> @Nat)",
   "contracts": {
     "requires": [

--- a/problems/tier4/VB_T4_003_even_odd_mutual_recursion.json
+++ b/problems/tier4/VB_T4_003_even_odd_mutual_recursion.json
@@ -3,6 +3,7 @@
   "tier": 4,
   "title": "Even/Odd (Mutual Recursion)",
   "description": "Write a function is_even that determines if a natural number is even using mutual recursion with is_odd. Use a where block to define the mutually recursive helper. Both functions need decreases clauses.",
+  "description_neutral": "Determine if a non-negative integer is even using mutual recursion with an is_odd helper. is_even(0) = true, is_even(n) = is_odd(n-1). is_odd(0) = false, is_odd(n) = is_even(n-1).",
   "signature": "public fn is_even(@Nat -> @Bool)",
   "contracts": {
     "requires": [

--- a/problems/tier4/VB_T4_004_power.json
+++ b/problems/tier4/VB_T4_004_power.json
@@ -3,6 +3,7 @@
   "tier": 4,
   "title": "Power",
   "description": "Write a Vera function that computes base raised to the power of exponent using repeated multiplication. The function takes two parameters: power(base, exp) where @Nat.0 is the exponent (rightmost) and @Nat.1 is the base. Use a decreases clause on the exponent. power(base, 0) = 1, power(base, n) = base * power(base, n-1).",
+  "description_neutral": "Compute base raised to the power of exponent using repeated multiplication. power(base, 0) = 1, power(base, exp) = base * power(base, exp-1).",
   "signature": "public fn power(@Nat, @Nat -> @Nat)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier4/VB_T4_005_sum_to_n.json
+++ b/problems/tier4/VB_T4_005_sum_to_n.json
@@ -3,6 +3,7 @@
   "tier": 4,
   "title": "Sum to N",
   "description": "Write a Vera function that computes the sum 0 + 1 + 2 + ... + n. Use recursion with a decreases clause.",
+  "description_neutral": "Compute the sum 0 + 1 + 2 + ... + n using recursion.",
   "signature": "public fn sum_to_n(@Nat -> @Nat)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier4/VB_T4_006_list_reverse.json
+++ b/problems/tier4/VB_T4_006_list_reverse.json
@@ -3,6 +3,7 @@
   "tier": 4,
   "title": "List Reverse",
   "description": "Define a linked list ADT with Nil and Cons(Int, List) constructors. Write a function that reverses the list. Use an accumulator-based helper function with a where block. The helper should have its own decreases clause.",
+  "description_neutral": "Define a linked list type with nil and cons constructors. Write a function that reverses the list using an accumulator pattern.",
   "signature": "public fn list_reverse(@List -> @List)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier4/VB_T4_007_count_digits.json
+++ b/problems/tier4/VB_T4_007_count_digits.json
@@ -3,6 +3,7 @@
   "tier": 4,
   "title": "Count Digits",
   "description": "Write a Vera function that counts the number of decimal digits in a natural number. The number 0 has 1 digit. For n >= 10, recursively count digits of n / 10 and add 1. The postcondition should guarantee the result is at least 1.",
+  "description_neutral": "Count the number of decimal digits in a non-negative integer. The number 0 has 1 digit.",
   "signature": "public fn count_digits(@Nat -> @Nat)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier4/VB_T4_008_multiply.json
+++ b/problems/tier4/VB_T4_008_multiply.json
@@ -3,6 +3,7 @@
   "tier": 4,
   "title": "Multiply",
   "description": "Write a Vera function that multiplies two natural numbers using repeated addition. multiply(a, 0) = 0, multiply(a, b) = a + multiply(a, b-1). Include a decreases clause on the second parameter.",
+  "description_neutral": "Multiply two non-negative integers using repeated addition. multiply(a, 0) = 0, multiply(a, b) = a + multiply(a, b-1).",
   "signature": "public fn multiply(@Nat, @Nat -> @Nat)",
   "contracts": {
     "requires": [

--- a/problems/tier4/VB_T4_009_list_nth.json
+++ b/problems/tier4/VB_T4_009_list_nth.json
@@ -3,6 +3,7 @@
   "tier": 4,
   "title": "List Nth",
   "description": "Define a linked list ADT with Nil and Cons(Int, List) constructors. Write a function that returns the nth element (0-indexed), or -1 if the index is out of bounds. The decreases clause should be on the list parameter.",
+  "description_neutral": "Define a linked list type with nil and cons constructors. Write a function that returns the nth element (0-indexed), or -1 if the index is out of bounds.",
   "signature": "public fn list_nth(@List, @Nat -> @Int)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier4/VB_T4_010_div_natural.json
+++ b/problems/tier4/VB_T4_010_div_natural.json
@@ -3,6 +3,7 @@
   "tier": 4,
   "title": "Natural Division",
   "description": "Write a Vera function that computes integer division via repeated subtraction. div_natural(a, b) counts how many times b fits into a. Precondition: b > 0. The tricky part: the decreases clause must be on the dividend (first parameter), not the divisor.",
+  "description_neutral": "Compute integer division via repeated subtraction. div_natural(a, b) counts how many times b can be subtracted from a. Precondition: b > 0.",
   "signature": "public fn div_natural(@Nat, @Nat -> @Nat)",
   "contracts": {
     "requires": [

--- a/problems/tier5/VB_T5_001_counter.json
+++ b/problems/tier5/VB_T5_001_counter.json
@@ -3,6 +3,7 @@
   "tier": 5,
   "title": "Counter",
   "description": "Write a counter using Vera's State<Int> effect. Create a pure helper function next_count that adds 1 to an Int (with a postcondition ensuring the result equals input + 1). Then write a function count_three that uses handle[State<Int>] to run three increments and return the final count (should be 3). The handler should initialise state to 0.",
+  "description_neutral": "Create a counter that increments three times starting from 0 and returns the final count (3). Use a helper function next_count that adds 1 to an integer.",
   "signature": "public fn count_three(@Unit -> @Int)",
   "contracts": {
     "requires": [

--- a/problems/tier5/VB_T5_002_greeter_io_boundary.json
+++ b/problems/tier5/VB_T5_002_greeter_io_boundary.json
@@ -3,6 +3,7 @@
   "tier": 5,
   "title": "Greeter (IO Boundary)",
   "description": "Write two functions: a pure function build_greeting that takes a non-empty String and returns 'Hello, <name>!\\n' using string_concat, and an IO function greet that calls build_greeting and prints the result with IO.print. The IO effect must be declared explicitly. Include a minimal IO effect declaration with only the print operation.",
+  "description_neutral": "Write two functions: a pure function build_greeting that takes a non-empty string and returns 'Hello, <name>!\n', and a function greet that prints the result.",
   "signature": "public fn greet(@String -> @Unit)",
   "contracts": {
     "requires": [

--- a/problems/tier5/VB_T5_003_safe_division_exceptions.json
+++ b/problems/tier5/VB_T5_003_safe_division_exceptions.json
@@ -3,6 +3,7 @@
   "tier": 5,
   "title": "Safe Division (Exceptions)",
   "description": "Write a division function that uses exceptions for error handling. Define the Exn<E> effect with a throw operation. Write checked_div(a, b) that computes a / b and throws -1 (written as `0 - 1` in Vera, which has no unary minus) when the divisor is zero. In checked_div, @Int.0 is b (divisor, rightmost) and @Int.1 is a (dividend). Write safe_div that calls checked_div and handles the exception using handle[Exn<Int>], returning the thrown value on error. In safe_div(dividend, divisor), @Int.0 is the divisor and @Int.1 is the dividend. safe_div should be pure (the handler discharges the effect).",
+  "description_neutral": "Write a safe division function. A helper checked_div(a, b) computes a / b but signals an error when the divisor is zero. The main safe_div function handles the error and returns -1 on division by zero.",
   "signature": "public fn safe_div(@Int, @Int -> @Int)",
   "contracts": {
     "requires": [

--- a/problems/tier5/VB_T5_004_accumulator.json
+++ b/problems/tier5/VB_T5_004_accumulator.json
@@ -3,6 +3,7 @@
   "tier": 5,
   "title": "Accumulator",
   "description": "Write a function that sums the integers from 1 to n using State<Int> effect. Create a pure helper function for addition. The main function should use handle[State<Int>] to manage state, with get and put operations inlined in the handler. Use a where block for the loop helper that has effects(<State<Int>>).",
+  "description_neutral": "Compute the sum of integers from 1 to n using a stateful accumulator pattern. Use a helper function for addition.",
   "signature": "public fn sum_with_state(@Nat -> @Int)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier5/VB_T5_005_checked_index.json
+++ b/problems/tier5/VB_T5_005_checked_index.json
@@ -3,6 +3,7 @@
   "tier": 5,
   "title": "Checked Array Index",
   "description": "Write a function that safely accesses an array element by index. Define the Exn<E> effect with a throw operation. Write a helper checked_get that throws -1 when the index is out of bounds, and safe_index that handles the exception using handle[Exn<Int>]. safe_index should be pure.",
+  "description_neutral": "Safely access a list element by index. Return -1 if the index is out of bounds.",
   "signature": "public fn safe_index(@Array<Int>, @Nat -> @Int)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier5/VB_T5_005_checked_index.json
+++ b/problems/tier5/VB_T5_005_checked_index.json
@@ -3,7 +3,7 @@
   "tier": 5,
   "title": "Checked Array Index",
   "description": "Write a function that safely accesses an array element by index. Define the Exn<E> effect with a throw operation. Write a helper checked_get that throws -1 when the index is out of bounds, and safe_index that handles the exception using handle[Exn<Int>]. safe_index should be pure.",
-  "description_neutral": "Safely access a list element by index. Return -1 if the index is out of bounds.",
+  "description_neutral": "Safely access an array element by index. Return -1 if the index is out of bounds.",
   "signature": "public fn safe_index(@Array<Int>, @Nat -> @Int)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier5/VB_T5_006_state_double.json
+++ b/problems/tier5/VB_T5_006_state_double.json
@@ -3,6 +3,7 @@
   "tier": 5,
   "title": "State Double",
   "description": "Write a function that initializes State<Int> with the input value, doubles the state using a pure helper, and returns the result. The main function should use handle[State<Int>] with get/put operations. Create a pure helper double that multiplies by 2.",
+  "description_neutral": "Double an integer. Takes x, returns x * 2.",
   "signature": "public fn state_double(@Int -> @Int)",
   "contracts": {
     "requires": [

--- a/problems/tier5/VB_T5_007_exn_negate.json
+++ b/problems/tier5/VB_T5_007_exn_negate.json
@@ -3,6 +3,7 @@
   "tier": 5,
   "title": "Exception on Negative",
   "description": "Write a function that throws an exception if the input is negative, with a handler that catches and returns 0. Define the Exn<E> effect. Write require_non_negative that throws the input value if negative, and safe_non_negative that handles the exception. The postcondition should guarantee the result is non-negative.",
+  "description_neutral": "Return the input if it is non-negative, otherwise return 0.",
   "signature": "public fn safe_non_negative(@Int -> @Int)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier5/VB_T5_008_print_numbers.json
+++ b/problems/tier5/VB_T5_008_print_numbers.json
@@ -3,6 +3,7 @@
   "tier": 5,
   "title": "Print Numbers",
   "description": "Write a function that prints the numbers 1 through n, each on its own line. Declare the IO effect with a print operation. Use a pure helper to format each number as a string. The main function should have effects(<IO>) and use a recursive loop helper via a where block.",
+  "description_neutral": "Print the numbers 1 through n, each on its own line.",
   "signature": "public fn print_numbers(@Nat -> @Unit)",
   "contracts": {
     "requires": ["@Nat.0 >= 0"],

--- a/problems/tier5/VB_T5_009_state_max.json
+++ b/problems/tier5/VB_T5_009_state_max.json
@@ -3,6 +3,7 @@
   "tier": 5,
   "title": "State Max",
   "description": "Write a function that finds the maximum value among the integers 1 through n using State<Int>. Create a pure max helper. The main function uses handle[State<Int>] initialized to 0, with a loop that updates state to max(current, i) for each i from 1 to n.",
+  "description_neutral": "Find the maximum value among the integers 1 through n. For n >= 1, the result equals n.",
   "signature": "public fn state_max(@Nat -> @Int)",
   "contracts": {
     "requires": [

--- a/problems/tier5/VB_T5_010_safe_head.json
+++ b/problems/tier5/VB_T5_010_safe_head.json
@@ -3,6 +3,7 @@
   "tier": 5,
   "title": "Safe Head",
   "description": "Write a function that returns the first element of an array, or -1 if the array is empty. Define the Exn<E> effect with a throw operation. Write head_or_throw that throws -1 for empty arrays, and safe_head that handles the exception using handle[Exn<Int>]. safe_head should be pure.",
+  "description_neutral": "Return the first element of a list, or -1 if the list is empty.",
   "signature": "public fn safe_head(@Array<Int> -> @Int)",
   "contracts": {
     "requires": ["true"],

--- a/problems/tier5/VB_T5_010_safe_head.json
+++ b/problems/tier5/VB_T5_010_safe_head.json
@@ -3,7 +3,7 @@
   "tier": 5,
   "title": "Safe Head",
   "description": "Write a function that returns the first element of an array, or -1 if the array is empty. Define the Exn<E> effect with a throw operation. Write head_or_throw that throws -1 for empty arrays, and safe_head that handles the exception using handle[Exn<Int>]. safe_head should be pure.",
-  "description_neutral": "Return the first element of a list, or -1 if the list is empty.",
+  "description_neutral": "Return the first element of an array, or -1 if the array is empty.",
   "signature": "public fn safe_head(@Array<Int> -> @Int)",
   "contracts": {
     "requires": ["true"],

--- a/solutions/aver/VB_T1_001_absolute_value.av
+++ b/solutions/aver/VB_T1_001_absolute_value.av
@@ -1,0 +1,23 @@
+module AbsoluteValue
+    intent = "Computes the absolute value of an integer."
+
+fn absolute_value(x: Int) -> Int
+    ? "Returns |x|. Uses match on comparison since Aver has no unary minus."
+    match x < 0
+        true  -> 0 - x
+        false -> x
+
+verify absolute_value
+    absolute_value(0)    => 0
+    absolute_value(42)   => 42
+    absolute_value(-42)  => 42
+    absolute_value(1)    => 1
+    absolute_value(-1)   => 1
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(absolute_value(0))
+    Console.print(absolute_value(42))
+    Console.print(absolute_value(-42))
+    Console.print(absolute_value(1))
+    Console.print(absolute_value(-1))

--- a/solutions/aver/VB_T1_002_clamp.av
+++ b/solutions/aver/VB_T1_002_clamp.av
@@ -1,0 +1,23 @@
+module Clamp
+    intent = "Clamps an integer value to a given range [lo, hi]."
+
+fn clamp(value: Int, lo: Int, hi: Int) -> Int
+    ? "Returns lo if value < lo, hi if value > hi, otherwise value."
+    match value < lo
+        true  -> lo
+        false -> match value > hi
+            true  -> hi
+            false -> value
+
+verify clamp
+    clamp(50, 0, 100)   => 50
+    clamp(-5, 0, 100)   => 0
+    clamp(150, 0, 100)  => 100
+    clamp(0, 0, 0)      => 0
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(clamp(50, 0, 100))
+    Console.print(clamp(-5, 0, 100))
+    Console.print(clamp(150, 0, 100))
+    Console.print(clamp(0, 0, 0))

--- a/solutions/aver/VB_T1_003_signum.av
+++ b/solutions/aver/VB_T1_003_signum.av
@@ -1,0 +1,21 @@
+module Signum
+    intent = "Returns the sign of an integer: -1, 0, or 1."
+
+fn signum(x: Int) -> Int
+    ? "Returns 1 for positive, -1 for negative, 0 for zero."
+    match x > 0
+        true  -> 1
+        false -> match x < 0
+            true  -> 0 - 1
+            false -> 0
+
+verify signum
+    signum(42)  => 1
+    signum(-7)  => -1
+    signum(0)   => 0
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(signum(42))
+    Console.print(signum(-7))
+    Console.print(signum(0))

--- a/solutions/aver/VB_T1_004_max_of_two.av
+++ b/solutions/aver/VB_T1_004_max_of_two.av
@@ -1,0 +1,23 @@
+module MaxOfTwo
+    intent = "Returns the maximum of two integers."
+
+fn max_of_two(a: Int, b: Int) -> Int
+    ? "Returns the larger of a and b."
+    match a > b
+        true  -> a
+        false -> b
+
+verify max_of_two
+    max_of_two(3, 7)    => 7
+    max_of_two(7, 3)    => 7
+    max_of_two(5, 5)    => 5
+    max_of_two(-1, -5)  => -1
+    max_of_two(0, 0)    => 0
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(max_of_two(3, 7))
+    Console.print(max_of_two(7, 3))
+    Console.print(max_of_two(5, 5))
+    Console.print(max_of_two(-1, -5))
+    Console.print(max_of_two(0, 0))

--- a/solutions/aver/VB_T1_005_min_of_two.av
+++ b/solutions/aver/VB_T1_005_min_of_two.av
@@ -1,0 +1,21 @@
+module MinOfTwo
+    intent = "Returns the minimum of two integers."
+
+fn min_of_two(a: Int, b: Int) -> Int
+    ? "Returns the smaller of a and b."
+    match a < b
+        true  -> a
+        false -> b
+
+verify min_of_two
+    min_of_two(3, 7)    => 3
+    min_of_two(7, 3)    => 3
+    min_of_two(5, 5)    => 5
+    min_of_two(-1, -5)  => -5
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(min_of_two(3, 7))
+    Console.print(min_of_two(7, 3))
+    Console.print(min_of_two(5, 5))
+    Console.print(min_of_two(-1, -5))

--- a/solutions/aver/VB_T1_006_is_positive.av
+++ b/solutions/aver/VB_T1_006_is_positive.av
@@ -1,0 +1,19 @@
+module IsPositive
+    intent = "Checks whether an integer is strictly positive."
+
+fn is_positive(x: Int) -> Bool
+    ? "Returns true if x > 0, false otherwise."
+    x > 0
+
+verify is_positive
+    is_positive(5)   => true
+    is_positive(-3)  => false
+    is_positive(0)   => false
+    is_positive(1)   => true
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(is_positive(5))
+    Console.print(is_positive(-3))
+    Console.print(is_positive(0))
+    Console.print(is_positive(1))

--- a/solutions/aver/VB_T1_007_safe_modulo.av
+++ b/solutions/aver/VB_T1_007_safe_modulo.av
@@ -1,0 +1,19 @@
+module SafeModulo
+    intent = "Computes the remainder of integer division (a % b)."
+
+fn safe_modulo(a: Int, b: Int) -> Int
+    ? "Returns a modulo b. Assumes b != 0."
+    a - (a / b) * b
+
+verify safe_modulo
+    safe_modulo(10, 3) => 1
+    safe_modulo(7, 2)  => 1
+    safe_modulo(6, 3)  => 0
+    safe_modulo(5, 7)  => 5
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(safe_modulo(10, 3))
+    Console.print(safe_modulo(7, 2))
+    Console.print(safe_modulo(6, 3))
+    Console.print(safe_modulo(5, 7))

--- a/solutions/aver/VB_T1_008_distance.av
+++ b/solutions/aver/VB_T1_008_distance.av
@@ -1,0 +1,22 @@
+module Distance
+    intent = "Computes the absolute distance between two integers."
+
+fn distance(a: Int, b: Int) -> Int
+    ? "Returns |a - b|."
+    diff = a - b
+    match diff < 0
+        true  -> 0 - diff
+        false -> diff
+
+verify distance
+    distance(3, 7)   => 4
+    distance(7, 3)   => 4
+    distance(5, 5)   => 0
+    distance(-3, 3)  => 6
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(distance(3, 7))
+    Console.print(distance(7, 3))
+    Console.print(distance(5, 5))
+    Console.print(distance(-3, 3))

--- a/solutions/aver/VB_T1_008_distance.av
+++ b/solutions/aver/VB_T1_008_distance.av
@@ -1,5 +1,6 @@
 module Distance
     intent = "Computes the absolute distance between two integers."
+    exposes [distance]
 
 fn distance(a: Int, b: Int) -> Int
     ? "Returns |a - b|."

--- a/solutions/aver/VB_T1_009_max_of_three.av
+++ b/solutions/aver/VB_T1_009_max_of_three.av
@@ -1,0 +1,32 @@
+module MaxOfThree
+    intent = "Returns the maximum of three integers."
+
+fn max2(a: Int, b: Int) -> Int
+    ? "Returns the larger of two integers."
+    match a > b
+        true  -> a
+        false -> b
+
+verify max2
+    max2(3, 7) => 7
+    max2(7, 3) => 7
+    max2(5, 5) => 5
+
+fn max_of_three(a: Int, b: Int, c: Int) -> Int
+    ? "Returns the largest of a, b, and c."
+    max2(max2(a, b), c)
+
+verify max_of_three
+    max_of_three(3, 7, 5)      => 7
+    max_of_three(9, 1, 4)      => 9
+    max_of_three(2, 2, 8)      => 8
+    max_of_three(5, 5, 5)      => 5
+    max_of_three(-1, -2, -3)   => -1
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(max_of_three(3, 7, 5))
+    Console.print(max_of_three(9, 1, 4))
+    Console.print(max_of_three(2, 2, 8))
+    Console.print(max_of_three(5, 5, 5))
+    Console.print(max_of_three(-1, -2, -3))

--- a/solutions/aver/VB_T1_010_double_or_nothing.av
+++ b/solutions/aver/VB_T1_010_double_or_nothing.av
@@ -1,0 +1,21 @@
+module DoubleOrNothing
+    intent = "Doubles positive integers, returns zero otherwise."
+
+fn double_or_nothing(x: Int) -> Int
+    ? "Returns x * 2 when x is positive, 0 otherwise."
+    match x > 0
+        true  -> x * 2
+        false -> 0
+
+verify double_or_nothing
+    double_or_nothing(5)   => 10
+    double_or_nothing(0)   => 0
+    double_or_nothing(-3)  => 0
+    double_or_nothing(1)   => 2
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(double_or_nothing(5))
+    Console.print(double_or_nothing(0))
+    Console.print(double_or_nothing(-3))
+    Console.print(double_or_nothing(1))

--- a/solutions/aver/VB_T2_001_sum_array.av
+++ b/solutions/aver/VB_T2_001_sum_array.av
@@ -1,0 +1,22 @@
+module SumArray
+    intent = "Sums all elements of an integer list using recursion."
+    exposes [sum_array]
+
+fn sum_array(xs: List<Int>) -> Int
+    ? "Returns the sum of all elements in the list."
+    match xs
+        [] -> 0
+        [h, ..t] -> h + sum_array(t)
+
+verify sum_array
+    sum_array([]) => 0
+    sum_array([1]) => 1
+    sum_array([1, 2, 3]) => 6
+    sum_array([10, -3, 5]) => 12
+    sum_array([-1, -2, -3]) => -6
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(sum_array([]))
+    Console.print(sum_array([1, 2, 3]))
+    Console.print(sum_array([10, -3, 5]))

--- a/solutions/aver/VB_T2_002_filter_positives.av
+++ b/solutions/aver/VB_T2_002_filter_positives.av
@@ -1,0 +1,23 @@
+module FilterPositives
+    intent = "Filters positive elements from an integer list using recursion."
+    exposes [filter_positives]
+
+fn filter_positives(xs: List<Int>) -> List<Int>
+    ? "Returns a list containing only elements greater than zero."
+    match xs
+        [] -> []
+        [h, ..t] -> match h > 0
+            true -> List.prepend(h, filter_positives(t))
+            false -> filter_positives(t)
+
+verify filter_positives
+    filter_positives([]) => []
+    filter_positives([1, -2, 3, -4, 5]) => [1, 3, 5]
+    filter_positives([-1, -2, -3]) => []
+    filter_positives([0, 1, 2]) => [1, 2]
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(filter_positives([]))
+    Console.print(filter_positives([1, -2, 3, -4, 5]))
+    Console.print(filter_positives([-1, -2, -3]))

--- a/solutions/aver/VB_T2_003_greeting.av
+++ b/solutions/aver/VB_T2_003_greeting.av
@@ -1,0 +1,18 @@
+module Greeting
+    intent = "Generates a greeting string from a name using string interpolation."
+    exposes [greeting]
+
+fn greeting(name: String) -> String
+    ? "Returns a greeting in the form Hello, <name>!"
+    "Hello, {name}!"
+
+verify greeting
+    greeting("Alice") => "Hello, Alice!"
+    greeting("World") => "Hello, World!"
+    greeting("Aver") => "Hello, Aver!"
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(greeting("Alice"))
+    Console.print(greeting("World"))
+    Console.print(greeting("Aver"))

--- a/solutions/aver/VB_T2_004_is_empty_string.av
+++ b/solutions/aver/VB_T2_004_is_empty_string.av
@@ -1,0 +1,18 @@
+module IsEmptyString
+    intent = "Checks whether a string is empty using String.len."
+    exposes [is_empty_string]
+
+fn is_empty_string(s: String) -> Bool
+    ? "Returns true when the string has zero length."
+    String.len(s) == 0
+
+verify is_empty_string
+    is_empty_string("") => true
+    is_empty_string("hello") => false
+    is_empty_string(" ") => false
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(is_empty_string(""))
+    Console.print(is_empty_string("hello"))
+    Console.print(is_empty_string(" "))

--- a/solutions/aver/VB_T2_005_contains_substring.av
+++ b/solutions/aver/VB_T2_005_contains_substring.av
@@ -1,0 +1,20 @@
+module ContainsSubstring
+    intent = "Checks if a string contains a given substring."
+    exposes [contains_substring]
+
+fn contains_substring(haystack: String, needle: String) -> Bool
+    ? "Returns true when haystack contains needle."
+    String.contains(haystack, needle)
+
+verify contains_substring
+    contains_substring("hello world", "world") => true
+    contains_substring("hello world", "mars") => false
+    contains_substring("abcdef", "cde") => true
+    contains_substring("abc", "") => true
+    contains_substring("", "a") => false
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(contains_substring("hello world", "world"))
+    Console.print(contains_substring("hello world", "mars"))
+    Console.print(contains_substring("abcdef", "cde"))

--- a/solutions/aver/VB_T2_006_join_strings.av
+++ b/solutions/aver/VB_T2_006_join_strings.av
@@ -1,0 +1,19 @@
+module JoinStrings
+    intent = "Joins a list of strings with a separator using String.join."
+    exposes [join_strings]
+
+fn join_strings(xs: List<String>, sep: String) -> String
+    ? "Joins all strings in the list with the given separator."
+    String.join(xs, sep)
+
+verify join_strings
+    join_strings(["a", "b", "c"], ", ") => "a, b, c"
+    join_strings(["hello"], "-") => "hello"
+    join_strings([], ",") => ""
+    join_strings(["x", "y"], "") => "xy"
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(join_strings(["a", "b", "c"], ", "))
+    Console.print(join_strings(["hello"], "-"))
+    Console.print(join_strings([], ","))

--- a/solutions/aver/VB_T2_007_double_elements.av
+++ b/solutions/aver/VB_T2_007_double_elements.av
@@ -1,0 +1,20 @@
+module DoubleElements
+    intent = "Doubles each element in an integer list using recursion."
+    exposes [double_elements]
+
+fn double_elements(xs: List<Int>) -> List<Int>
+    ? "Returns a new list where each element is multiplied by two."
+    match xs
+        [] -> []
+        [h, ..t] -> List.prepend(h * 2, double_elements(t))
+
+verify double_elements
+    double_elements([]) => []
+    double_elements([1, 2, 3]) => [2, 4, 6]
+    double_elements([0, -1, 5]) => [0, -2, 10]
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(double_elements([]))
+    Console.print(double_elements([1, 2, 3]))
+    Console.print(double_elements([0, -1, 5]))

--- a/solutions/aver/VB_T2_008_count_positives.av
+++ b/solutions/aver/VB_T2_008_count_positives.av
@@ -1,0 +1,23 @@
+module CountPositives
+    intent = "Counts the number of positive elements in an integer list."
+    exposes [count_positives]
+
+fn count_positives(xs: List<Int>) -> Int
+    ? "Returns how many elements are greater than zero."
+    match xs
+        [] -> 0
+        [h, ..t] -> match h > 0
+            true -> 1 + count_positives(t)
+            false -> count_positives(t)
+
+verify count_positives
+    count_positives([]) => 0
+    count_positives([1, -2, 3, 0, 5]) => 3
+    count_positives([-1, -2, -3]) => 0
+    count_positives([1, 2, 3]) => 3
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(count_positives([]))
+    Console.print(count_positives([1, -2, 3, 0, 5]))
+    Console.print(count_positives([-1, -2, -3]))

--- a/solutions/aver/VB_T2_009_to_upper.av
+++ b/solutions/aver/VB_T2_009_to_upper.av
@@ -1,0 +1,19 @@
+module ToUpper
+    intent = "Converts a string to uppercase using String.toUpper."
+    exposes [to_upper]
+
+fn to_upper(s: String) -> String
+    ? "Returns the input string converted to uppercase."
+    String.toUpper(s)
+
+verify to_upper
+    to_upper("hello") => "HELLO"
+    to_upper("World") => "WORLD"
+    to_upper("") => ""
+    to_upper("ABC") => "ABC"
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(to_upper("hello"))
+    Console.print(to_upper("World"))
+    Console.print(to_upper(""))

--- a/solutions/aver/VB_T2_010_sum_positives.av
+++ b/solutions/aver/VB_T2_010_sum_positives.av
@@ -1,0 +1,23 @@
+module SumPositives
+    intent = "Sums only the positive elements of an integer list."
+    exposes [sum_positives]
+
+fn sum_positives(xs: List<Int>) -> Int
+    ? "Returns the sum of elements greater than zero."
+    match xs
+        [] -> 0
+        [h, ..t] -> match h > 0
+            true -> h + sum_positives(t)
+            false -> sum_positives(t)
+
+verify sum_positives
+    sum_positives([]) => 0
+    sum_positives([1, -2, 3, -4, 5]) => 9
+    sum_positives([-1, -2, -3]) => 0
+    sum_positives([0, 1, 2]) => 3
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(sum_positives([]))
+    Console.print(sum_positives([1, -2, 3, -4, 5]))
+    Console.print(sum_positives([-1, -2, -3]))

--- a/solutions/aver/VB_T2_010_sum_positives.av
+++ b/solutions/aver/VB_T2_010_sum_positives.av
@@ -21,3 +21,4 @@ fn main() -> Unit
     Console.print(sum_positives([]))
     Console.print(sum_positives([1, -2, 3, -4, 5]))
     Console.print(sum_positives([-1, -2, -3]))
+    Console.print(sum_positives([0, 1, 2]))

--- a/solutions/aver/VB_T3_001_list_length.av
+++ b/solutions/aver/VB_T3_001_list_length.av
@@ -1,0 +1,27 @@
+module ListLength
+    intent = "Computes the length of a user-defined linked list."
+    exposes [MyList, list_length]
+
+type MyList
+    Nil
+    Cons(Int, MyList)
+
+fn list_length(xs: MyList) -> Int
+    ? "Returns the number of elements in a MyList."
+    match xs
+        MyList.Nil -> 0
+        MyList.Cons(_, rest) -> 1 + list_length(rest)
+
+verify list_length
+    list_length(MyList.Nil) => 0
+    list_length(MyList.Cons(1, MyList.Nil)) => 1
+    list_length(MyList.Cons(1, MyList.Cons(2, MyList.Cons(3, MyList.Nil)))) => 3
+
+fn main() -> Unit
+    ! [Console.print]
+    empty = MyList.Nil
+    one = MyList.Cons(1, MyList.Nil)
+    three = MyList.Cons(1, MyList.Cons(2, MyList.Cons(3, MyList.Nil)))
+    Console.print(list_length(empty))
+    Console.print(list_length(one))
+    Console.print(list_length(three))

--- a/solutions/aver/VB_T3_002_tree_depth.av
+++ b/solutions/aver/VB_T3_002_tree_depth.av
@@ -1,0 +1,38 @@
+module TreeDepth
+    intent = "Computes the depth of a binary tree using recursive pattern matching."
+    exposes [Tree, tree_depth]
+
+type Tree
+    Leaf(Int)
+    Branch(Tree, Tree)
+
+fn max_int(a: Int, b: Int) -> Int
+    ? "Returns the larger of two integers."
+    match a >= b
+        true -> a
+        false -> b
+
+verify max_int
+    max_int(1, 2) => 2
+    max_int(5, 3) => 5
+    max_int(0, 0) => 0
+
+fn tree_depth(t: Tree) -> Int
+    ? "Returns the depth of the tree. A leaf has depth 1."
+    match t
+        Tree.Leaf(_) -> 1
+        Tree.Branch(l, r) -> 1 + max_int(tree_depth(l), tree_depth(r))
+
+verify tree_depth
+    tree_depth(Tree.Leaf(1)) => 1
+    tree_depth(Tree.Branch(Tree.Leaf(1), Tree.Leaf(2))) => 2
+    tree_depth(Tree.Branch(Tree.Branch(Tree.Leaf(1), Tree.Leaf(2)), Tree.Leaf(3))) => 3
+
+fn main() -> Unit
+    ! [Console.print]
+    leaf = Tree.Leaf(42)
+    shallow = Tree.Branch(Tree.Leaf(1), Tree.Leaf(2))
+    deep = Tree.Branch(Tree.Branch(Tree.Leaf(1), Tree.Leaf(2)), Tree.Leaf(3))
+    Console.print(tree_depth(leaf))
+    Console.print(tree_depth(shallow))
+    Console.print(tree_depth(deep))

--- a/solutions/aver/VB_T3_003_expression_evaluator.av
+++ b/solutions/aver/VB_T3_003_expression_evaluator.av
@@ -1,0 +1,29 @@
+module ExpressionEvaluator
+    intent = "Evaluates a simple expression tree with literals, addition, and negation."
+    exposes [Expr, eval_expr]
+
+type Expr
+    Lit(Int)
+    Add(Expr, Expr)
+    Neg(Expr)
+
+fn eval_expr(e: Expr) -> Int
+    ? "Recursively evaluates an expression tree to an integer."
+    match e
+        Expr.Lit(n) -> n
+        Expr.Add(a, b) -> eval_expr(a) + eval_expr(b)
+        Expr.Neg(inner) -> 0 - eval_expr(inner)
+
+verify eval_expr
+    eval_expr(Expr.Lit(5)) => 5
+    eval_expr(Expr.Add(Expr.Lit(2), Expr.Lit(3))) => 5
+    eval_expr(Expr.Neg(Expr.Lit(7))) => -7
+    eval_expr(Expr.Add(Expr.Lit(10), Expr.Neg(Expr.Lit(3)))) => 7
+    eval_expr(Expr.Neg(Expr.Neg(Expr.Lit(4)))) => 4
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(eval_expr(Expr.Lit(5)))
+    Console.print(eval_expr(Expr.Add(Expr.Lit(2), Expr.Lit(3))))
+    Console.print(eval_expr(Expr.Neg(Expr.Lit(7))))
+    Console.print(eval_expr(Expr.Add(Expr.Lit(10), Expr.Neg(Expr.Lit(3)))))

--- a/solutions/aver/VB_T3_004_list_sum.av
+++ b/solutions/aver/VB_T3_004_list_sum.av
@@ -1,0 +1,27 @@
+module ListSum
+    intent = "Sums all elements in a user-defined linked list."
+    exposes [MyList, list_sum]
+
+type MyList
+    Nil
+    Cons(Int, MyList)
+
+fn list_sum(xs: MyList) -> Int
+    ? "Returns the sum of all elements in a MyList."
+    match xs
+        MyList.Nil -> 0
+        MyList.Cons(h, rest) -> h + list_sum(rest)
+
+verify list_sum
+    list_sum(MyList.Nil) => 0
+    list_sum(MyList.Cons(5, MyList.Nil)) => 5
+    list_sum(MyList.Cons(1, MyList.Cons(2, MyList.Cons(3, MyList.Nil)))) => 6
+
+fn main() -> Unit
+    ! [Console.print]
+    empty = MyList.Nil
+    single = MyList.Cons(5, MyList.Nil)
+    triple = MyList.Cons(1, MyList.Cons(2, MyList.Cons(3, MyList.Nil)))
+    Console.print(list_sum(empty))
+    Console.print(list_sum(single))
+    Console.print(list_sum(triple))

--- a/solutions/aver/VB_T3_005_tree_sum.av
+++ b/solutions/aver/VB_T3_005_tree_sum.av
@@ -1,0 +1,27 @@
+module TreeSum
+    intent = "Sums all values in the leaf nodes of a binary tree."
+    exposes [Tree, tree_sum]
+
+type Tree
+    Leaf(Int)
+    Branch(Tree, Tree)
+
+fn tree_sum(t: Tree) -> Int
+    ? "Returns the sum of all leaf values in the tree."
+    match t
+        Tree.Leaf(v) -> v
+        Tree.Branch(l, r) -> tree_sum(l) + tree_sum(r)
+
+verify tree_sum
+    tree_sum(Tree.Leaf(5)) => 5
+    tree_sum(Tree.Branch(Tree.Leaf(1), Tree.Leaf(2))) => 3
+    tree_sum(Tree.Branch(Tree.Branch(Tree.Leaf(1), Tree.Leaf(2)), Tree.Leaf(3))) => 6
+
+fn main() -> Unit
+    ! [Console.print]
+    leaf = Tree.Leaf(5)
+    pair = Tree.Branch(Tree.Leaf(1), Tree.Leaf(2))
+    nested = Tree.Branch(Tree.Branch(Tree.Leaf(1), Tree.Leaf(2)), Tree.Leaf(3))
+    Console.print(tree_sum(leaf))
+    Console.print(tree_sum(pair))
+    Console.print(tree_sum(nested))

--- a/solutions/aver/VB_T3_006_option_unwrap_or.av
+++ b/solutions/aver/VB_T3_006_option_unwrap_or.av
@@ -1,0 +1,21 @@
+module OptionUnwrapOr
+    intent = "Unwraps an Option with a default value using built-in Option type."
+    exposes [option_unwrap_or]
+
+fn option_unwrap_or(opt: Option<Int>, default: Int) -> Int
+    ? "Returns the contained value or the provided default."
+    match opt
+        Option.Some(v) -> v
+        Option.None -> default
+
+verify option_unwrap_or
+    option_unwrap_or(Option.Some(42), 0) => 42
+    option_unwrap_or(Option.None, 0) => 0
+    option_unwrap_or(Option.Some(7), 99) => 7
+    option_unwrap_or(Option.None, -1) => -1
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(option_unwrap_or(Option.Some(42), 0))
+    Console.print(option_unwrap_or(Option.None, 0))
+    Console.print(option_unwrap_or(Option.Some(7), 99))

--- a/solutions/aver/VB_T3_007_list_contains.av
+++ b/solutions/aver/VB_T3_007_list_contains.av
@@ -1,0 +1,28 @@
+module ListContains
+    intent = "Checks if a user-defined linked list contains a given value."
+    exposes [MyList, list_contains]
+
+type MyList
+    Nil
+    Cons(Int, MyList)
+
+fn list_contains(xs: MyList, value: Int) -> Bool
+    ? "Returns true if the list contains the given value."
+    match xs
+        MyList.Nil -> false
+        MyList.Cons(h, rest) -> match h == value
+            true -> true
+            false -> list_contains(rest, value)
+
+verify list_contains
+    list_contains(MyList.Nil, 1) => false
+    list_contains(MyList.Cons(1, MyList.Cons(2, MyList.Cons(3, MyList.Nil))), 2) => true
+    list_contains(MyList.Cons(1, MyList.Cons(2, MyList.Cons(3, MyList.Nil))), 4) => false
+    list_contains(MyList.Cons(5, MyList.Nil), 5) => true
+
+fn main() -> Unit
+    ! [Console.print]
+    xs = MyList.Cons(1, MyList.Cons(2, MyList.Cons(3, MyList.Nil)))
+    Console.print(list_contains(xs, 2))
+    Console.print(list_contains(xs, 4))
+    Console.print(list_contains(MyList.Nil, 1))

--- a/solutions/aver/VB_T3_008_tree_count_leaves.av
+++ b/solutions/aver/VB_T3_008_tree_count_leaves.av
@@ -1,0 +1,27 @@
+module TreeCountLeaves
+    intent = "Counts the number of leaf nodes in a binary tree."
+    exposes [Tree, tree_count_leaves]
+
+type Tree
+    Leaf(Int)
+    Branch(Tree, Tree)
+
+fn tree_count_leaves(t: Tree) -> Int
+    ? "Returns the total number of leaf nodes in the tree."
+    match t
+        Tree.Leaf(_) -> 1
+        Tree.Branch(l, r) -> tree_count_leaves(l) + tree_count_leaves(r)
+
+verify tree_count_leaves
+    tree_count_leaves(Tree.Leaf(1)) => 1
+    tree_count_leaves(Tree.Branch(Tree.Leaf(1), Tree.Leaf(2))) => 2
+    tree_count_leaves(Tree.Branch(Tree.Branch(Tree.Leaf(1), Tree.Leaf(2)), Tree.Leaf(3))) => 3
+
+fn main() -> Unit
+    ! [Console.print]
+    leaf = Tree.Leaf(1)
+    pair = Tree.Branch(Tree.Leaf(1), Tree.Leaf(2))
+    nested = Tree.Branch(Tree.Branch(Tree.Leaf(1), Tree.Leaf(2)), Tree.Leaf(3))
+    Console.print(tree_count_leaves(leaf))
+    Console.print(tree_count_leaves(pair))
+    Console.print(tree_count_leaves(nested))

--- a/solutions/aver/VB_T3_009_list_append.av
+++ b/solutions/aver/VB_T3_009_list_append.av
@@ -1,0 +1,27 @@
+module ListAppend
+    intent = "Concatenates two user-defined linked lists."
+    exposes [MyList, list_append]
+
+type MyList
+    Nil
+    Cons(Int, MyList)
+
+fn list_append(xs: MyList, ys: MyList) -> MyList
+    ? "Appends ys to the end of xs by recursing through xs."
+    match xs
+        MyList.Nil -> ys
+        MyList.Cons(h, rest) -> MyList.Cons(h, list_append(rest, ys))
+
+verify list_append
+    list_append(MyList.Nil, MyList.Nil) => MyList.Nil
+    list_append(MyList.Nil, MyList.Cons(1, MyList.Nil)) => MyList.Cons(1, MyList.Nil)
+    list_append(MyList.Cons(1, MyList.Nil), MyList.Cons(2, MyList.Nil)) => MyList.Cons(1, MyList.Cons(2, MyList.Nil))
+    list_append(MyList.Cons(1, MyList.Cons(2, MyList.Nil)), MyList.Cons(3, MyList.Nil)) => MyList.Cons(1, MyList.Cons(2, MyList.Cons(3, MyList.Nil)))
+
+fn main() -> Unit
+    ! [Console.print]
+    xs = MyList.Cons(1, MyList.Cons(2, MyList.Nil))
+    ys = MyList.Cons(3, MyList.Cons(4, MyList.Nil))
+    Console.print(list_append(MyList.Nil, MyList.Nil))
+    Console.print(list_append(xs, ys))
+    Console.print(list_append(MyList.Nil, ys))

--- a/solutions/aver/VB_T3_010_list_last.av
+++ b/solutions/aver/VB_T3_010_list_last.av
@@ -1,0 +1,29 @@
+module ListLast
+    intent = "Returns the last element of a user-defined linked list, or None."
+    exposes [MyList, list_last]
+
+type MyList
+    Nil
+    Cons(Int, MyList)
+
+fn list_last(xs: MyList) -> Option<Int>
+    ? "Returns the last element wrapped in Some, or None for an empty list."
+    match xs
+        MyList.Nil -> Option.None
+        MyList.Cons(h, rest) -> match rest
+            MyList.Nil -> Option.Some(h)
+            MyList.Cons(_, _) -> list_last(rest)
+
+verify list_last
+    list_last(MyList.Nil) => Option.None
+    list_last(MyList.Cons(42, MyList.Nil)) => Option.Some(42)
+    list_last(MyList.Cons(1, MyList.Cons(2, MyList.Cons(3, MyList.Nil)))) => Option.Some(3)
+
+fn main() -> Unit
+    ! [Console.print]
+    empty = MyList.Nil
+    single = MyList.Cons(42, MyList.Nil)
+    triple = MyList.Cons(1, MyList.Cons(2, MyList.Cons(3, MyList.Nil)))
+    Console.print(list_last(empty))
+    Console.print(list_last(single))
+    Console.print(list_last(triple))

--- a/solutions/aver/VB_T4_001_fibonacci.av
+++ b/solutions/aver/VB_T4_001_fibonacci.av
@@ -1,0 +1,25 @@
+module Fibonacci
+    intent =
+        "Computes the nth Fibonacci number using naive recursion."
+        "fib(0)=0, fib(1)=1, fib(n)=fib(n-1)+fib(n-2)."
+    exposes [fib]
+
+fn fib(n: Int) -> Int
+    ? "Returns the nth Fibonacci number."
+    match n
+        0 -> 0
+        1 -> 1
+        _ -> fib(n - 1) + fib(n - 2)
+
+verify fib
+    fib(0)  => 0
+    fib(1)  => 1
+    fib(5)  => 5
+    fib(10) => 55
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(fib(0))
+    Console.print(fib(1))
+    Console.print(fib(5))
+    Console.print(fib(10))

--- a/solutions/aver/VB_T4_002_greatest_common_divisor.av
+++ b/solutions/aver/VB_T4_002_greatest_common_divisor.av
@@ -1,0 +1,24 @@
+module GreatestCommonDivisor
+    intent =
+        "Computes the greatest common divisor using Euclid's algorithm."
+        "gcd(a,0)=a, gcd(a,b)=gcd(b, a%b)."
+    exposes [gcd]
+
+fn gcd(a: Int, b: Int) -> Int
+    ? "Returns the greatest common divisor of a and b."
+    match b
+        0 -> a
+        _ -> gcd(b, a - (a / b) * b)
+
+verify gcd
+    gcd(12, 8)   => 4
+    gcd(7, 0)    => 7
+    gcd(0, 5)    => 5
+    gcd(100, 75) => 25
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(gcd(12, 8))
+    Console.print(gcd(7, 0))
+    Console.print(gcd(0, 5))
+    Console.print(gcd(100, 75))

--- a/solutions/aver/VB_T4_002_greatest_common_divisor.av
+++ b/solutions/aver/VB_T4_002_greatest_common_divisor.av
@@ -14,6 +14,7 @@ verify gcd
     gcd(12, 8)   => 4
     gcd(7, 0)    => 7
     gcd(0, 5)    => 5
+    gcd(0, 0)    => 0
     gcd(100, 75) => 25
 
 fn main() -> Unit

--- a/solutions/aver/VB_T4_003_even_odd_mutual_recursion.av
+++ b/solutions/aver/VB_T4_003_even_odd_mutual_recursion.av
@@ -1,0 +1,36 @@
+module EvenOddMutualRecursion
+    intent =
+        "Determines if a number is even using mutual recursion between is_even and is_odd."
+        "is_even(0)=true, is_even(n)=is_odd(n-1); is_odd(0)=false, is_odd(n)=is_even(n-1)."
+    exposes [is_even, is_odd]
+
+fn is_even(n: Int) -> Bool
+    ? "Returns true if n is even, using mutual recursion with is_odd."
+    match n
+        0 -> true
+        _ -> is_odd(n - 1)
+
+fn is_odd(n: Int) -> Bool
+    ? "Returns true if n is odd, using mutual recursion with is_even."
+    match n
+        0 -> false
+        _ -> is_even(n - 1)
+
+verify is_odd
+    is_odd(0) => false
+    is_odd(1) => true
+    is_odd(4) => false
+    is_odd(7) => true
+
+verify is_even
+    is_even(0) => true
+    is_even(1) => false
+    is_even(4) => true
+    is_even(7) => false
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(is_even(0))
+    Console.print(is_even(1))
+    Console.print(is_even(4))
+    Console.print(is_even(7))

--- a/solutions/aver/VB_T4_004_power.av
+++ b/solutions/aver/VB_T4_004_power.av
@@ -1,0 +1,25 @@
+module Power
+    intent =
+        "Computes base raised to the power of exp by repeated multiplication."
+    exposes [power]
+
+fn power(base: Int, exp: Int) -> Int
+    ? "Returns base^exp using recursive repeated multiplication."
+    match exp
+        0 -> 1
+        _ -> base * power(base, exp - 1)
+
+verify power
+    power(2, 10)  => 1024
+    power(3, 0)   => 1
+    power(5, 1)   => 5
+    power(2, 0)   => 1
+    power(1, 100) => 1
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(power(2, 10))
+    Console.print(power(3, 0))
+    Console.print(power(5, 1))
+    Console.print(power(2, 0))
+    Console.print(power(1, 100))

--- a/solutions/aver/VB_T4_005_sum_to_n.av
+++ b/solutions/aver/VB_T4_005_sum_to_n.av
@@ -1,0 +1,23 @@
+module SumToN
+    intent =
+        "Computes the sum 0+1+...+n using recursion."
+    exposes [sum_to_n]
+
+fn sum_to_n(n: Int) -> Int
+    ? "Returns the sum of integers from 0 to n."
+    match n
+        0 -> 0
+        _ -> n + sum_to_n(n - 1)
+
+verify sum_to_n
+    sum_to_n(0)  => 0
+    sum_to_n(1)  => 1
+    sum_to_n(5)  => 15
+    sum_to_n(10) => 55
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(sum_to_n(0))
+    Console.print(sum_to_n(1))
+    Console.print(sum_to_n(5))
+    Console.print(sum_to_n(10))

--- a/solutions/aver/VB_T4_006_list_reverse.av
+++ b/solutions/aver/VB_T4_006_list_reverse.av
@@ -1,0 +1,29 @@
+module ListReverse
+    intent =
+        "Reverses a list using the accumulator pattern."
+    exposes [list_reverse]
+
+fn reverse_acc(xs: List<Int>, acc: List<Int>) -> List<Int>
+    ? "Tail-recursive helper that moves elements from xs to acc one at a time."
+    match xs
+        [] -> acc
+        [h, ..t] -> reverse_acc(t, List.prepend(h, acc))
+
+verify reverse_acc
+    reverse_acc([1, 2, 3], []) => [3, 2, 1]
+    reverse_acc([], [5])       => [5]
+
+fn list_reverse(xs: List<Int>) -> List<Int>
+    ? "Reverses a list using an accumulator."
+    reverse_acc(xs, [])
+
+verify list_reverse
+    list_reverse([1, 2, 3]) => [3, 2, 1]
+    list_reverse([])         => []
+    list_reverse([42])       => [42]
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(list_reverse([1, 2, 3]))
+    Console.print(list_reverse([]))
+    Console.print(list_reverse([42]))

--- a/solutions/aver/VB_T4_007_count_digits.av
+++ b/solutions/aver/VB_T4_007_count_digits.av
@@ -1,0 +1,26 @@
+module CountDigits
+    intent =
+        "Counts the number of digits in a non-negative integer."
+        "0 has 1 digit."
+    exposes [count_digits]
+
+fn count_digits(n: Int) -> Int
+    ? "Returns the number of digits in n. Handles 0 as having 1 digit."
+    match n < 10
+        true  -> 1
+        false -> 1 + count_digits(n / 10)
+
+verify count_digits
+    count_digits(0)       => 1
+    count_digits(9)       => 1
+    count_digits(42)      => 2
+    count_digits(12345)   => 5
+    count_digits(1000000) => 7
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(count_digits(0))
+    Console.print(count_digits(9))
+    Console.print(count_digits(42))
+    Console.print(count_digits(12345))
+    Console.print(count_digits(1000000))

--- a/solutions/aver/VB_T4_008_multiply.av
+++ b/solutions/aver/VB_T4_008_multiply.av
@@ -1,0 +1,23 @@
+module Multiply
+    intent =
+        "Multiplies two non-negative integers by repeated addition."
+    exposes [multiply]
+
+fn multiply(a: Int, b: Int) -> Int
+    ? "Returns a*b using recursive repeated addition."
+    match b
+        0 -> 0
+        _ -> a + multiply(a, b - 1)
+
+verify multiply
+    multiply(7, 6) => 42
+    multiply(0, 5) => 0
+    multiply(3, 0) => 0
+    multiply(1, 1) => 1
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(multiply(7, 6))
+    Console.print(multiply(0, 5))
+    Console.print(multiply(3, 0))
+    Console.print(multiply(1, 1))

--- a/solutions/aver/VB_T4_008_multiply.av
+++ b/solutions/aver/VB_T4_008_multiply.av
@@ -5,9 +5,9 @@ module Multiply
 
 fn multiply(a: Int, b: Int) -> Int
     ? "Returns a*b using recursive repeated addition."
-    match b
-        0 -> 0
-        _ -> a + multiply(a, b - 1)
+    match b <= 0
+        true  -> 0
+        false -> a + multiply(a, b - 1)
 
 verify multiply
     multiply(7, 6) => 42

--- a/solutions/aver/VB_T4_009_list_nth.av
+++ b/solutions/aver/VB_T4_009_list_nth.av
@@ -1,0 +1,23 @@
+module ListNth
+    intent =
+        "Returns the element at a 0-based index in a list, or -1 if out of bounds."
+    exposes [list_nth]
+
+fn list_nth(xs: List<Int>, index: Int) -> Int
+    ? "Returns the element at index, or -1 if out of bounds."
+    match xs
+        [] -> 0 - 1
+        [h, ..t] -> match index
+            0 -> h
+            _ -> list_nth(t, index - 1)
+
+verify list_nth
+    list_nth([10, 20, 30], 0) => 10
+    list_nth([10, 20, 30], 2) => 30
+    list_nth([], 0)           => 0 - 1
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(list_nth([10, 20, 30], 0))
+    Console.print(list_nth([10, 20, 30], 2))
+    Console.print(list_nth([], 0))

--- a/solutions/aver/VB_T4_009_list_nth.av
+++ b/solutions/aver/VB_T4_009_list_nth.av
@@ -5,11 +5,13 @@ module ListNth
 
 fn list_nth(xs: List<Int>, index: Int) -> Int
     ? "Returns the element at index, or -1 if out of bounds."
-    match xs
-        [] -> 0 - 1
-        [h, ..t] -> match index
-            0 -> h
-            _ -> list_nth(t, index - 1)
+    match index < 0
+        true -> 0 - 1
+        false -> match xs
+            [] -> 0 - 1
+            [h, ..t] -> match index
+                0 -> h
+                _ -> list_nth(t, index - 1)
 
 verify list_nth
     list_nth([10, 20, 30], 0) => 10

--- a/solutions/aver/VB_T4_010_div_natural.av
+++ b/solutions/aver/VB_T4_010_div_natural.av
@@ -1,0 +1,25 @@
+module DivNatural
+    intent =
+        "Integer division by repeated subtraction."
+    exposes [div_natural]
+
+fn div_natural(a: Int, b: Int) -> Int
+    ? "Returns a divided by b using repeated subtraction."
+    match a < b
+        true  -> 0
+        false -> 1 + div_natural(a - b, b)
+
+verify div_natural
+    div_natural(17, 5) => 3
+    div_natural(10, 3) => 3
+    div_natural(0, 1)  => 0
+    div_natural(7, 7)  => 1
+    div_natural(3, 10) => 0
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(div_natural(17, 5))
+    Console.print(div_natural(10, 3))
+    Console.print(div_natural(0, 1))
+    Console.print(div_natural(7, 7))
+    Console.print(div_natural(3, 10))

--- a/solutions/aver/VB_T5_001_counter.av
+++ b/solutions/aver/VB_T5_001_counter.av
@@ -1,0 +1,25 @@
+module Counter
+    intent = "Counts to three by recursively incrementing from zero."
+    exposes [count_three]
+
+fn count(n: Int, target: Int) -> Int
+    ? "Increments n until it reaches target."
+    match n == target
+        true  -> n
+        false -> count(n + 1, target)
+
+fn count_three() -> Int
+    ? "Returns 3 via three increments from 0."
+    count(0, 3)
+
+verify count
+    count(0, 3) => 3
+    count(0, 0) => 0
+    count(2, 5) => 5
+
+verify count_three
+    count_three() => 3
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(count_three())

--- a/solutions/aver/VB_T5_001_counter.av
+++ b/solutions/aver/VB_T5_001_counter.av
@@ -4,7 +4,7 @@ module Counter
 
 fn count(n: Int, target: Int) -> Int
     ? "Increments n until it reaches target."
-    match n == target
+    match n >= target
         true  -> n
         false -> count(n + 1, target)
 

--- a/solutions/aver/VB_T5_002_greeter_io_boundary.av
+++ b/solutions/aver/VB_T5_002_greeter_io_boundary.av
@@ -1,0 +1,13 @@
+module GreeterIoBoundary
+    intent = "Greets a user by name using console output."
+    exposes [greet]
+
+fn greet(name: String) -> Unit
+    ? "Prints Hello, <name>! to the console."
+    ! [Console.print]
+    Console.print("Hello, {name}!")
+
+fn main() -> Unit
+    ! [Console.print]
+    greet("World")
+    greet("Alice")

--- a/solutions/aver/VB_T5_003_safe_division_exceptions.av
+++ b/solutions/aver/VB_T5_003_safe_division_exceptions.av
@@ -1,0 +1,31 @@
+module SafeDivisionExceptions
+    intent = "Performs integer division, returning -1 on division by zero."
+    exposes [safe_div]
+
+fn try_div(a: Int, b: Int) -> Result<Int, String>
+    ? "Returns Ok(a/b) or Err if b is zero."
+    match b == 0
+        true  -> Result.Err("division by zero")
+        false -> Result.Ok(a / b)
+
+fn safe_div(a: Int, b: Int) -> Int
+    ? "Returns a/b, or -1 if b is zero."
+    match try_div(a, b)
+        Result.Ok(v)  -> v
+        Result.Err(_) -> 0 - 1
+
+verify try_div
+    try_div(10, 2) => Result.Ok(5)
+    try_div(7, 0)  => Result.Err("division by zero")
+    try_div(0, 1)  => Result.Ok(0)
+
+verify safe_div
+    safe_div(10, 2) => 5
+    safe_div(7, 0)  => 0 - 1
+    safe_div(0, 1)  => 0
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(safe_div(10, 2))
+    Console.print(safe_div(7, 0))
+    Console.print(safe_div(0, 1))

--- a/solutions/aver/VB_T5_004_accumulator.av
+++ b/solutions/aver/VB_T5_004_accumulator.av
@@ -1,0 +1,31 @@
+module Accumulator
+    intent = "Computes the sum of integers from 1 to n using a recursive accumulator."
+    exposes [sum_with_state]
+
+fn sum_loop(i: Int, n: Int, acc: Int) -> Int
+    ? "Accumulates the sum from i to n."
+    match i > n
+        true  -> acc
+        false -> sum_loop(i + 1, n, acc + i)
+
+fn sum_with_state(n: Int) -> Int
+    ? "Returns the sum 1 + 2 + ... + n. Returns 0 for n <= 0."
+    sum_loop(1, n, 0)
+
+verify sum_loop
+    sum_loop(1, 5, 0)  => 15
+    sum_loop(1, 0, 0)  => 0
+    sum_loop(3, 5, 10) => 22
+
+verify sum_with_state
+    sum_with_state(5)  => 15
+    sum_with_state(0)  => 0
+    sum_with_state(1)  => 1
+    sum_with_state(10) => 55
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(sum_with_state(5))
+    Console.print(sum_with_state(0))
+    Console.print(sum_with_state(1))
+    Console.print(sum_with_state(10))

--- a/solutions/aver/VB_T5_005_checked_index.av
+++ b/solutions/aver/VB_T5_005_checked_index.av
@@ -1,0 +1,38 @@
+module CheckedIndex
+    intent = "Safely indexes into a list, returning -1 on out-of-bounds."
+    exposes [safe_index]
+
+fn get_at(lst: List<Int>, idx: Int) -> Result<Int, String>
+    ? "Walks the list to position idx, returning Ok(element) or Err on OOB."
+    match lst
+        [] -> Result.Err("index out of bounds")
+        [h, ..t] -> match idx == 0
+            true  -> Result.Ok(h)
+            false -> get_at(t, idx - 1)
+
+verify get_at
+    get_at([10, 20, 30], 0) => Result.Ok(10)
+    get_at([10, 20, 30], 2) => Result.Ok(30)
+    get_at([], 0)           => Result.Err("index out of bounds")
+
+fn safe_index(arr: List<Int>, idx: Int) -> Int
+    ? "Returns the element at idx, or -1 if out of bounds."
+    match idx < 0
+        true  -> 0 - 1
+        false -> match get_at(arr, idx)
+            Result.Ok(v)  -> v
+            Result.Err(_) -> 0 - 1
+
+verify safe_index
+    safe_index([10, 20, 30], 0)  => 10
+    safe_index([10, 20, 30], 2)  => 30
+    safe_index([10, 20, 30], 5)  => 0 - 1
+    safe_index([], 0)            => 0 - 1
+    safe_index([42], -1)         => 0 - 1
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(safe_index([10, 20, 30], 0))
+    Console.print(safe_index([10, 20, 30], 2))
+    Console.print(safe_index([10, 20, 30], 5))
+    Console.print(safe_index([], 0))

--- a/solutions/aver/VB_T5_006_state_double.av
+++ b/solutions/aver/VB_T5_006_state_double.av
@@ -1,0 +1,20 @@
+module StateDouble
+    intent = "Doubles an integer, translating a stateful pattern into pure computation."
+    exposes [state_double]
+
+fn state_double(x: Int) -> Int
+    ? "Returns x multiplied by 2."
+    x * 2
+
+verify state_double
+    state_double(21) => 42
+    state_double(0)  => 0
+    state_double(5)  => 10
+    state_double(-3) => 0 - 6
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(state_double(21))
+    Console.print(state_double(0))
+    Console.print(state_double(5))
+    Console.print(state_double(-3))

--- a/solutions/aver/VB_T5_007_exn_negate.av
+++ b/solutions/aver/VB_T5_007_exn_negate.av
@@ -1,0 +1,22 @@
+module ExnNegate
+    intent = "Clamps negative integers to zero, replacing exception-based control flow with pattern matching."
+    exposes [safe_non_negative]
+
+fn safe_non_negative(x: Int) -> Int
+    ? "Returns x if non-negative, otherwise 0."
+    match x < 0
+        true  -> 0
+        false -> x
+
+verify safe_non_negative
+    safe_non_negative(5)   => 5
+    safe_non_negative(-3)  => 0
+    safe_non_negative(0)   => 0
+    safe_non_negative(100) => 100
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(safe_non_negative(5))
+    Console.print(safe_non_negative(-3))
+    Console.print(safe_non_negative(0))
+    Console.print(safe_non_negative(100))

--- a/solutions/aver/VB_T5_008_print_numbers.av
+++ b/solutions/aver/VB_T5_008_print_numbers.av
@@ -1,0 +1,25 @@
+module PrintNumbers
+    intent = "Prints integers from 1 to n, each on a new line."
+    exposes [print_numbers]
+
+fn print_and_continue(i: Int, n: Int) -> Unit
+    ? "Prints i then continues with the next integer."
+    ! [Console.print]
+    Console.print(i)
+    print_loop(i + 1, n)
+
+fn print_loop(i: Int, n: Int) -> Unit
+    ? "Recurses from i to n, printing each integer."
+    ! [Console.print]
+    match i <= n
+        true  -> print_and_continue(i, n)
+        false -> Console.print("")
+
+fn print_numbers(n: Int) -> Unit
+    ? "Prints 1 through n on separate lines."
+    ! [Console.print]
+    print_loop(1, n)
+
+fn main() -> Unit
+    ! [Console.print]
+    print_numbers(5)

--- a/solutions/aver/VB_T5_008_print_numbers.av
+++ b/solutions/aver/VB_T5_008_print_numbers.av
@@ -11,9 +11,9 @@ fn print_and_continue(i: Int, n: Int) -> Unit
 fn print_loop(i: Int, n: Int) -> Unit
     ? "Recurses from i to n, printing each integer."
     ! [Console.print]
-    match i <= n
+    match i < n
         true  -> print_and_continue(i, n)
-        false -> Console.print("")
+        false -> Console.print(n)
 
 fn print_numbers(n: Int) -> Unit
     ? "Prints 1 through n on separate lines."

--- a/solutions/aver/VB_T5_009_state_max.av
+++ b/solutions/aver/VB_T5_009_state_max.av
@@ -1,0 +1,42 @@
+module StateMax
+    intent = "Finds the maximum of integers from 1 to n using a recursive accumulator."
+    exposes [state_max]
+
+fn max_step(i: Int, n: Int, current_max: Int) -> Int
+    ? "Advances one step: updates max and recurses with i+1."
+    next = i + 1
+    match i > current_max
+        true  -> max_loop(next, n, i)
+        false -> max_loop(next, n, current_max)
+
+fn max_loop(i: Int, n: Int, current_max: Int) -> Int
+    ? "Compares i against current_max, recurses until i exceeds n."
+    match i > n
+        true  -> current_max
+        false -> max_step(i, n, current_max)
+
+fn state_max(n: Int) -> Int
+    ? "Returns the maximum of 1..n. For n >= 1, this is always n."
+    match n < 1
+        true  -> 0
+        false -> max_loop(1, n, 0)
+
+verify max_step
+    max_step(3, 5, 2) => 5
+    max_step(1, 1, 0) => 1
+
+verify max_loop
+    max_loop(1, 5, 0) => 5
+    max_loop(3, 3, 2) => 3
+    max_loop(4, 3, 3) => 3
+
+verify state_max
+    state_max(5)  => 5
+    state_max(1)  => 1
+    state_max(10) => 10
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(state_max(5))
+    Console.print(state_max(1))
+    Console.print(state_max(10))

--- a/solutions/aver/VB_T5_009_state_max.av
+++ b/solutions/aver/VB_T5_009_state_max.av
@@ -24,6 +24,7 @@ fn state_max(n: Int) -> Int
 verify max_step
     max_step(3, 5, 2) => 5
     max_step(1, 1, 0) => 1
+    max_step(2, 5, 3) => 5
 
 verify max_loop
     max_loop(1, 5, 0) => 5
@@ -34,6 +35,7 @@ verify state_max
     state_max(5)  => 5
     state_max(1)  => 1
     state_max(10) => 10
+    state_max(0)  => 0
 
 fn main() -> Unit
     ! [Console.print]

--- a/solutions/aver/VB_T5_010_safe_head.av
+++ b/solutions/aver/VB_T5_010_safe_head.av
@@ -1,0 +1,21 @@
+module SafeHead
+    intent = "Returns the first element of a list, or -1 if empty."
+    exposes [safe_head]
+
+fn safe_head(lst: List<Int>) -> Int
+    ? "Returns the head of lst, or -1 for an empty list."
+    match lst
+        [h, ..rest] -> h
+        []      -> 0 - 1
+
+verify safe_head
+    safe_head([10, 20, 30]) => 10
+    safe_head([42])         => 42
+    safe_head([0 - 5, 99])  => 0 - 5
+    safe_head([])           => 0 - 1
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(safe_head([10, 20, 30]))
+    Console.print(safe_head([42]))
+    Console.print(safe_head([]))

--- a/solutions/aver/VB_T5_010_safe_head.av
+++ b/solutions/aver/VB_T5_010_safe_head.av
@@ -12,6 +12,7 @@ verify safe_head
     safe_head([10, 20, 30]) => 10
     safe_head([42])         => 42
     safe_head([0 - 5, 99])  => 0 - 5
+    safe_head([0 - 1, 2])   => 0 - 1
     safe_head([])           => 0 - 1
 
 fn main() -> Unit

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1069,11 +1069,18 @@ class TestAverCLI:
 
         from vera_bench.cli import main
 
-        # Just test that --language aver is accepted (will fail on
-        # missing aver binary, but that's the expected path)
         result = CliRunner().invoke(main, ["baselines", "--language", "aver"])
-        # Should fail with "aver not found" not "invalid choice"
         assert "invalid" not in (result.output or "").lower()
+
+    def test_baselines_aver_not_on_path(self):
+        from click.testing import CliRunner
+
+        from vera_bench.cli import main
+
+        with patch("shutil.which", return_value=None):
+            result = CliRunner().invoke(main, ["baselines", "--language", "aver"])
+        assert result.exit_code != 0
+        assert "aver not found" in (result.output or "")
 
     def test_run_command_accepts_aver(self):
         from click.testing import CliRunner
@@ -1081,10 +1088,102 @@ class TestAverCLI:
         from vera_bench.cli import main
 
         result = CliRunner().invoke(
-            main, ["run", "--model", "claude-haiku-4-5-20251001", "--language", "aver"]
+            main,
+            [
+                "run",
+                "--model",
+                "claude-haiku-4-5-20251001",
+                "--language",
+                "aver",
+            ],
         )
-        # Should not fail with "invalid choice"
         assert "invalid" not in (result.output or "").lower()
+
+    def test_run_aver_version_not_found(self):
+        from click.testing import CliRunner
+
+        from vera_bench.cli import main
+
+        # Mock llms.txt loading to isolate the aver version check
+        with (
+            patch("vera_bench.models.create_client"),
+            patch(
+                "vera_bench.prompts.load_aver_llms_txt",
+                return_value="# mock spec",
+            ),
+            patch(
+                "subprocess.run",
+                side_effect=FileNotFoundError,
+            ),
+        ):
+            result = CliRunner().invoke(
+                main,
+                [
+                    "run",
+                    "--model",
+                    "claude-haiku-4-5-20251001",
+                    "--language",
+                    "aver",
+                ],
+            )
+        assert result.exit_code != 0
+        assert "aver not found" in (result.output or "")
+
+    def test_run_aver_mode_warning(self):
+        from click.testing import CliRunner
+
+        from vera_bench.cli import main
+
+        result = CliRunner().invoke(
+            main,
+            [
+                "run",
+                "--model",
+                "claude-haiku-4-5-20251001",
+                "--language",
+                "aver",
+                "--mode",
+                "spec-from-nl",
+            ],
+        )
+        assert "mode" in (result.output or "").lower()
+
+    def test_run_python_skill_md_warning(self):
+        from click.testing import CliRunner
+
+        from vera_bench.cli import main
+
+        result = CliRunner().invoke(
+            main,
+            [
+                "run",
+                "--model",
+                "claude-haiku-4-5-20251001",
+                "--language",
+                "python",
+                "--mode",
+                "spec-from-nl",
+            ],
+        )
+        assert "ignored" in (result.output or "").lower()
+
+    def test_run_no_matching_problems(self):
+        from click.testing import CliRunner
+
+        from vera_bench.cli import main
+
+        result = CliRunner().invoke(
+            main,
+            [
+                "run",
+                "--model",
+                "claude-haiku-4-5-20251001",
+                "--problem",
+                "VB-T99-999",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "No matching" in (result.output or "")
 
 
 class TestAverOutputMatches:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1071,9 +1071,7 @@ class TestAverCLI:
 
         # Just test that --language aver is accepted (will fail on
         # missing aver binary, but that's the expected path)
-        result = CliRunner().invoke(
-            main, ["baselines", "--language", "aver"]
-        )
+        result = CliRunner().invoke(main, ["baselines", "--language", "aver"])
         # Should fail with "aver not found" not "invalid choice"
         assert "invalid" not in (result.output or "").lower()
 
@@ -1083,8 +1081,7 @@ class TestAverCLI:
         from vera_bench.cli import main
 
         result = CliRunner().invoke(
-            main, ["run", "--model", "claude-haiku-4-5-20251001",
-                   "--language", "aver"]
+            main, ["run", "--model", "claude-haiku-4-5-20251001", "--language", "aver"]
         )
         # Should not fail with "invalid choice"
         assert "invalid" not in (result.output or "").lower()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import json
 import shutil
+import subprocess
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -782,6 +783,343 @@ class TestStripAverMain:
         result = _strip_aver_main(code)
         assert "fn main" not in result
         assert "fn bar" in result
+
+
+class TestEvaluateAverCode:
+    def _sample_problem(self, test_cases=None):
+        return {
+            "id": "VB-T1-001",
+            "entry_point": "absolute_value",
+            "test_cases": test_cases or [],
+        }
+
+    def _mock_subprocess(self, returncode=0, stdout="", stderr=""):
+        result = MagicMock()
+        result.returncode = returncode
+        result.stdout = stdout
+        result.stderr = stderr
+        return result
+
+    @patch("vera_bench.runner.subprocess.run")
+    def test_check_pass(self, mock_run, tmp_path):
+        from vera_bench.runner import _evaluate_aver_code
+
+        # check passes, verify passes, no test cases
+        mock_run.side_effect = [
+            self._mock_subprocess(returncode=0),  # aver check
+            self._mock_subprocess(returncode=0),  # aver verify
+        ]
+        code = 'module Test\n    intent = "test"\n\nfn absolute_value(x: Int) -> Int\n    match x < 0\n        true -> 0 - x\n        false -> x\n'
+        result = _evaluate_aver_code(code, self._sample_problem(), tmp_path, 1)
+        assert result["check_pass"] is True
+        assert result["verify_pass"] is True
+        assert result["run_correct"] is None
+
+    @patch("vera_bench.runner.subprocess.run")
+    def test_check_fail(self, mock_run, tmp_path):
+        from vera_bench.runner import _evaluate_aver_code
+
+        mock_run.return_value = self._mock_subprocess(
+            returncode=1, stderr="error: type mismatch"
+        )
+        result = _evaluate_aver_code(
+            "fn bad() -> Int\n    true\n",
+            self._sample_problem(),
+            tmp_path,
+            1,
+        )
+        assert result["check_pass"] is False
+        assert "type mismatch" in result["error_message"]
+
+    @patch("vera_bench.runner.subprocess.run")
+    def test_aver_not_found(self, mock_run, tmp_path):
+        from vera_bench.runner import _evaluate_aver_code
+
+        mock_run.side_effect = FileNotFoundError
+        result = _evaluate_aver_code(
+            "fn x() -> Int\n    1\n",
+            self._sample_problem(),
+            tmp_path,
+            1,
+        )
+        assert result["check_pass"] is False
+        assert "aver not found" in result["error_message"]
+
+    @patch("vera_bench.runner.subprocess.run")
+    def test_check_timeout(self, mock_run, tmp_path):
+        from vera_bench.runner import _evaluate_aver_code
+
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="aver", timeout=30)
+        result = _evaluate_aver_code(
+            "fn x() -> Int\n    1\n",
+            self._sample_problem(),
+            tmp_path,
+            1,
+        )
+        assert result["check_pass"] is False
+        assert "timed out" in result["error_message"]
+
+    @patch("vera_bench.runner.subprocess.run")
+    def test_with_test_cases(self, mock_run, tmp_path):
+        from vera_bench.runner import _evaluate_aver_code
+
+        mock_run.side_effect = [
+            self._mock_subprocess(returncode=0),  # aver check
+            self._mock_subprocess(returncode=0),  # aver verify
+            self._mock_subprocess(returncode=0, stdout="42\n"),  # aver run tc1
+            self._mock_subprocess(returncode=0, stdout="5\n"),  # aver run tc2
+        ]
+        problem = self._sample_problem(
+            test_cases=[
+                {"args": [42], "expected": 42},
+                {"args": [-5], "expected": 5},
+            ]
+        )
+        result = _evaluate_aver_code(
+            'module T\n    intent = "t"\n\nfn absolute_value(x: Int) -> Int\n    x\n',
+            problem,
+            tmp_path,
+            1,
+        )
+        assert result["check_pass"] is True
+        assert result["tests_total"] == 2
+        assert result["tests_passed"] == 2
+        assert result["run_correct"] is True
+
+    @patch("vera_bench.runner.subprocess.run")
+    def test_verify_timeout_counts_as_failure(self, mock_run, tmp_path):
+        from vera_bench.runner import _evaluate_aver_code
+
+        mock_run.side_effect = [
+            self._mock_subprocess(returncode=0),  # aver check
+            subprocess.TimeoutExpired(cmd="aver", timeout=30),  # aver verify
+        ]
+        result = _evaluate_aver_code(
+            'module T\n    intent = "t"\n\nfn x() -> Int\n    1\n',
+            self._sample_problem(),
+            tmp_path,
+            1,
+        )
+        assert result["check_pass"] is True
+        assert result["verify_pass"] is False
+
+
+class TestRunSingleProblemAver:
+    def _mock_client(self, text):
+        client = MagicMock()
+        client.complete.return_value = LLMResponse(
+            text=text,
+            input_tokens=100,
+            output_tokens=50,
+            wall_time_s=1.0,
+            model="mock",
+        )
+        return client
+
+    @patch("vera_bench.runner.subprocess.run")
+    def test_aver_language(self, mock_run, tmp_path):
+        from vera_bench.runner import run_single_problem
+
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),  # check
+            MagicMock(returncode=0, stdout="", stderr=""),  # verify
+        ]
+        client = self._mock_client(
+            'module T\n    intent = "t"\n\nfn test(x: Int) -> Int\n    x\n'
+        )
+        results = run_single_problem(
+            problem={
+                "id": "VB-T1-001",
+                "description": "Test",
+                "entry_point": "test",
+                "test_cases": [],
+            },
+            client=client,
+            skill_md="spec",
+            vera=None,
+            work_dir=tmp_path,
+            language="aver",
+        )
+        assert len(results) == 1
+        assert results[0].language == "aver"
+        assert results[0].check_pass is True
+
+    @patch("vera_bench.runner.subprocess.run")
+    def test_aver_no_retry_on_tooling_error(self, mock_run, tmp_path):
+        from vera_bench.runner import run_single_problem
+
+        mock_run.side_effect = FileNotFoundError
+        client = self._mock_client("fn bad() -> Int\n    1\n")
+        results = run_single_problem(
+            problem={
+                "id": "VB-T1-001",
+                "description": "Test",
+                "entry_point": "bad",
+                "test_cases": [],
+            },
+            client=client,
+            skill_md="spec",
+            vera=None,
+            work_dir=tmp_path,
+            language="aver",
+        )
+        # Only 1 attempt — no retry on tooling error
+        assert len(results) == 1
+        assert results[0].check_pass is False
+        assert client.complete.call_count == 1
+
+    @patch("vera_bench.runner.subprocess.run")
+    def test_aver_retry_on_check_failure(self, mock_run, tmp_path):
+        from vera_bench.runner import run_single_problem
+
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="error: type mismatch"
+        )
+        client = self._mock_client("fn bad() -> Int\n    true\n")
+        results = run_single_problem(
+            problem={
+                "id": "VB-T1-001",
+                "description": "Test",
+                "entry_point": "bad",
+                "test_cases": [],
+            },
+            client=client,
+            skill_md="spec",
+            vera=None,
+            work_dir=tmp_path,
+            language="aver",
+        )
+        # 2 attempts — retry on actual check failure
+        assert len(results) == 2
+        assert client.complete.call_count == 2
+
+    def test_unknown_language_raises(self, tmp_path):
+        from vera_bench.runner import run_single_problem
+
+        client = MagicMock()
+        client.complete.return_value = LLMResponse(
+            text="code",
+            input_tokens=10,
+            output_tokens=10,
+            wall_time_s=0.1,
+            model="mock",
+        )
+        with pytest.raises(ValueError, match="Unknown language"):
+            run_single_problem(
+                problem={
+                    "id": "VB-T1-001",
+                    "description": "Test",
+                    "entry_point": "test",
+                    "test_cases": [],
+                },
+                client=client,
+                skill_md="",
+                vera=None,
+                work_dir=tmp_path,
+                language="rust",
+            )
+
+
+class TestAverPrompt:
+    def test_build_aver_prompt(self):
+        from vera_bench.prompts import build_aver_prompt
+
+        problem = {
+            "description": "Compute absolute value",
+            "description_neutral": "Return the absolute value of an integer.",
+            "entry_point": "absolute_value",
+        }
+        result = build_aver_prompt(problem, "# Aver spec")
+        assert "absolute_value" in result["user"]
+        assert "Aver" in result["system"]
+        assert "# Aver spec" in result["system"]
+        assert "Return the absolute value" in result["user"]
+
+    def test_aver_prompt_uses_neutral(self):
+        from vera_bench.prompts import build_aver_prompt
+
+        problem = {
+            "description": "Vera-flavoured description with @Int",
+            "description_neutral": "Neutral description",
+            "entry_point": "test",
+        }
+        result = build_aver_prompt(problem, "spec")
+        assert "Neutral description" in result["user"]
+        assert "Vera-flavoured" not in result["user"]
+
+    def test_build_aver_fix_prompt(self):
+        from vera_bench.prompts import build_aver_fix_prompt
+
+        result = build_aver_fix_prompt("bad code", "type error", "spec")
+        assert "bad code" in result["user"]
+        assert "type error" in result["user"]
+        assert "Fix" in result["user"]
+
+
+class TestAverCLI:
+    def test_baselines_command_accepts_aver(self):
+        from click.testing import CliRunner
+
+        from vera_bench.cli import main
+
+        # Just test that --language aver is accepted (will fail on
+        # missing aver binary, but that's the expected path)
+        result = CliRunner().invoke(
+            main, ["baselines", "--language", "aver"]
+        )
+        # Should fail with "aver not found" not "invalid choice"
+        assert "invalid" not in (result.output or "").lower()
+
+    def test_run_command_accepts_aver(self):
+        from click.testing import CliRunner
+
+        from vera_bench.cli import main
+
+        result = CliRunner().invoke(
+            main, ["run", "--model", "claude-haiku-4-5-20251001",
+                   "--language", "aver"]
+        )
+        # Should not fail with "invalid choice"
+        assert "invalid" not in (result.output or "").lower()
+
+
+class TestAverOutputMatches:
+    def test_exact_int_match(self):
+        from vera_bench.baseline_runner import _aver_output_matches
+
+        assert _aver_output_matches("42", 42) is True
+
+    def test_bool_true_from_int(self):
+        from vera_bench.baseline_runner import _aver_output_matches
+
+        assert _aver_output_matches("true", 1) is True
+
+    def test_bool_false_from_int(self):
+        from vera_bench.baseline_runner import _aver_output_matches
+
+        assert _aver_output_matches("false", 0) is True
+
+    def test_int_not_treated_as_bool(self):
+        from vera_bench.baseline_runner import _aver_output_matches
+
+        # 42 should NOT match "true" even though it's truthy
+        assert _aver_output_matches("true", 42) is False
+
+    def test_negative_match(self):
+        from vera_bench.baseline_runner import _aver_output_matches
+
+        assert _aver_output_matches("-5", -5) is True
+
+    def test_string_match(self):
+        from vera_bench.baseline_runner import _aver_output_matches
+
+        assert _aver_output_matches("hello", "hello") is True
+
+    def test_bool_literal_match(self):
+        from vera_bench.baseline_runner import _aver_output_matches
+
+        assert _aver_output_matches("true", True) is True
+        assert _aver_output_matches("false", False) is True
 
 
 class TestRunBenchmarkIntegration:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -12,7 +12,13 @@ import pytest
 
 from vera_bench.metrics import compute_metrics
 from vera_bench.models import LLMResponse, create_client
-from vera_bench.runner import ProblemResult, extract_code, extract_vera_code
+from vera_bench.runner import (
+    ProblemResult,
+    _aver_literal,
+    _strip_aver_main,
+    extract_code,
+    extract_vera_code,
+)
 
 # === extract_vera_code ===
 
@@ -411,6 +417,46 @@ class TestCLICommands:
 # === Python generation ===
 
 
+class TestNeutralDescription:
+    def test_returns_neutral_when_present(self):
+        from vera_bench.prompts import _neutral_description
+
+        problem = {
+            "description": "Vera-flavoured description",
+            "description_neutral": "Neutral description",
+        }
+        assert _neutral_description(problem) == "Neutral description"
+
+    def test_falls_back_to_original(self):
+        from vera_bench.prompts import _neutral_description
+
+        problem = {"description": "Original description"}
+        assert _neutral_description(problem) == "Original description"
+
+    def test_falls_back_on_empty_string(self):
+        from vera_bench.prompts import _neutral_description
+
+        problem = {"description": "Original", "description_neutral": ""}
+        assert _neutral_description(problem) == "Original"
+
+
+class TestLoadAverLlmsTxt:
+    def test_loads_from_file(self, tmp_path):
+        from vera_bench.prompts import load_aver_llms_txt
+
+        txt_file = tmp_path / "llms.txt"
+        txt_file.write_text("# Aver spec\nfn foo() -> Int", encoding="utf-8")
+        content = load_aver_llms_txt(txt_file)
+        assert "Aver spec" in content
+        assert "fn foo" in content
+
+    def test_raises_on_missing_file(self):
+        from vera_bench.prompts import load_aver_llms_txt
+
+        with pytest.raises(FileNotFoundError):
+            load_aver_llms_txt("/nonexistent/llms.txt")
+
+
 class TestPythonPrompt:
     def test_build_python_prompt(self):
         from vera_bench.prompts import build_python_prompt
@@ -664,6 +710,78 @@ class TestEvaluatePythonErrors:
         assert result["check_pass"] is True
         assert result["run_correct"] is False
         assert result["tests_passed"] == 0
+
+
+class TestAverLiteral:
+    def test_positive_int(self):
+        assert _aver_literal(42) == "42"
+
+    def test_zero(self):
+        assert _aver_literal(0) == "0"
+
+    def test_negative_int(self):
+        assert _aver_literal(-5) == "(0 - 5)"
+
+    def test_bool_true(self):
+        assert _aver_literal(True) == "true"
+
+    def test_bool_false(self):
+        assert _aver_literal(False) == "false"
+
+    def test_string(self):
+        assert _aver_literal("hello") == '"hello"'
+
+    def test_string_with_quotes(self):
+        assert _aver_literal('say "hi"') == '"say \\"hi\\""'
+
+    def test_string_with_backslash(self):
+        assert _aver_literal("a\\b") == '"a\\\\b"'
+
+    def test_float(self):
+        assert _aver_literal(3.14) == "3.14"
+
+    def test_list(self):
+        assert _aver_literal([1, 2, 3]) == "[1, 2, 3]"
+
+    def test_nested_list(self):
+        assert _aver_literal([[1], [2]]) == "[[1], [2]]"
+
+    def test_empty_list(self):
+        assert _aver_literal([]) == "[]"
+
+
+class TestStripAverMain:
+    def test_removes_main(self):
+        code = (
+            "fn foo(x: Int) -> Int\n"
+            "    x + 1\n"
+            "\n"
+            "fn main() -> Unit\n"
+            "    ! [Console.print]\n"
+            "    Console.print(foo(5))\n"
+        )
+        result = _strip_aver_main(code)
+        assert "fn foo" in result
+        assert "fn main" not in result
+        assert "Console.print(foo(5))" not in result
+
+    def test_keeps_code_without_main(self):
+        code = "fn foo(x: Int) -> Int\n    x + 1\n"
+        result = _strip_aver_main(code)
+        assert "fn foo" in result
+
+    def test_preserves_code_after_main(self):
+        code = (
+            "fn main() -> Unit\n"
+            "    ! [Console.print]\n"
+            "    Console.print(42)\n"
+            "\n"
+            "fn bar(x: Int) -> Int\n"
+            "    x * 2\n"
+        )
+        result = _strip_aver_main(code)
+        assert "fn main" not in result
+        assert "fn bar" in result
 
 
 class TestRunBenchmarkIntegration:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -809,7 +809,14 @@ class TestEvaluateAverCode:
             self._mock_subprocess(returncode=0),  # aver check
             self._mock_subprocess(returncode=0),  # aver verify
         ]
-        code = 'module Test\n    intent = "test"\n\nfn absolute_value(x: Int) -> Int\n    match x < 0\n        true -> 0 - x\n        false -> x\n'
+        code = (
+            "module Test\n"
+            '    intent = "test"\n\n'
+            "fn absolute_value(x: Int) -> Int\n"
+            "    match x < 0\n"
+            "        true -> 0 - x\n"
+            "        false -> x\n"
+        )
         result = _evaluate_aver_code(code, self._sample_problem(), tmp_path, 1)
         assert result["check_pass"] is True
         assert result["verify_pass"] is True

--- a/vera_bench/baseline_runner.py
+++ b/vera_bench/baseline_runner.py
@@ -481,13 +481,16 @@ def run_aver_baseline(
             check_pass=True,
             run_correct=False,
             tests_total=len(test_cases),
-            error_message=(run_result.stderr[:200] if run_result.stderr else "Non-zero exit"),
+            error_message=(
+                run_result.stderr[:200] if run_result.stderr else "Non-zero exit"
+            ),
             wall_time_s=elapsed,
             timestamp=_now(),
         )
 
     # Parse output: each line corresponds to one test case result
-    output_lines = run_result.stdout.strip().split("\n") if run_result.stdout.strip() else []
+    stdout = run_result.stdout.strip()
+    output_lines = stdout.split("\n") if stdout else []
     tests_passed = 0
 
     for i, tc in enumerate(test_cases):

--- a/vera_bench/baseline_runner.py
+++ b/vera_bench/baseline_runner.py
@@ -579,9 +579,7 @@ def run_all_baselines(
         run_problems = [p for p in problems if p.get("test_cases")]
         skipped = len(problems) - len(run_problems)
         if skipped:
-            console.print(
-                f"[dim]Skipping {skipped} problems with no test cases[/dim]"
-            )
+            console.print(f"[dim]Skipping {skipped} problems with no test cases[/dim]")
 
     with tempfile.TemporaryDirectory(prefix="verabench_baseline_") as tmpdir:
         work_dir = Path(tmpdir)

--- a/vera_bench/baseline_runner.py
+++ b/vera_bench/baseline_runner.py
@@ -19,7 +19,7 @@ from vera_bench.runner import ProblemResult
 
 console = Console()
 
-_EXT = {"python": ".py", "typescript": ".ts"}
+_EXT = {"python": ".py", "typescript": ".ts", "aver": ".av"}
 
 
 def _snake_to_camel(name: str) -> str:
@@ -364,6 +364,190 @@ def _parse_subprocess_result(
     )
 
 
+def run_aver_baseline(
+    problem: dict,
+    solutions_dir: Path,
+    work_dir: Path,
+    timeout: int = 30,
+) -> ProblemResult:
+    """Run an Aver baseline solution against test cases."""
+    problem_id = problem["id"]
+    test_cases = problem.get("test_cases", [])
+
+    baseline_path = _find_baseline_file(problem_id, solutions_dir, "aver")
+    if baseline_path is None:
+        return ProblemResult(
+            problem_id=problem_id,
+            model="baseline",
+            language="aver",
+            attempt=1,
+            check_pass=False,
+            error_message=f"No Aver baseline found for {problem_id}",
+            timestamp=_now(),
+        )
+
+    # aver check
+    run_env = {k: v for k, v in os.environ.items() if not k.endswith("_API_KEY")}
+    start = time.monotonic()
+
+    try:
+        check_result = subprocess.run(  # noqa: S603
+            ["aver", "check", str(baseline_path)],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+            env=run_env,
+        )
+    except FileNotFoundError:
+        return ProblemResult(
+            problem_id=problem_id,
+            model="baseline",
+            language="aver",
+            attempt=1,
+            check_pass=False,
+            error_message="aver not found on PATH",
+            timestamp=_now(),
+        )
+    except subprocess.TimeoutExpired:
+        return ProblemResult(
+            problem_id=problem_id,
+            model="baseline",
+            language="aver",
+            attempt=1,
+            check_pass=False,
+            error_message="aver check timed out",
+            wall_time_s=round(time.monotonic() - start, 2),
+            timestamp=_now(),
+        )
+
+    if check_result.returncode != 0:
+        err = (check_result.stderr or check_result.stdout)[:200]
+        return ProblemResult(
+            problem_id=problem_id,
+            model="baseline",
+            language="aver",
+            attempt=1,
+            check_pass=False,
+            error_message=err,
+            wall_time_s=round(time.monotonic() - start, 2),
+            timestamp=_now(),
+        )
+
+    if not test_cases:
+        return ProblemResult(
+            problem_id=problem_id,
+            model="baseline",
+            language="aver",
+            attempt=1,
+            check_pass=True,
+            run_correct=None,
+            wall_time_s=round(time.monotonic() - start, 2),
+            timestamp=_now(),
+        )
+
+    # aver run — the baseline .av files have main() that prints test outputs
+    try:
+        run_result = subprocess.run(  # noqa: S603
+            ["aver", "run", str(baseline_path)],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+            env=run_env,
+        )
+    except subprocess.TimeoutExpired:
+        return ProblemResult(
+            problem_id=problem_id,
+            model="baseline",
+            language="aver",
+            attempt=1,
+            check_pass=True,
+            run_correct=False,
+            tests_total=len(test_cases),
+            error_message="aver run timed out",
+            wall_time_s=round(time.monotonic() - start, 2),
+            timestamp=_now(),
+        )
+
+    elapsed = round(time.monotonic() - start, 2)
+
+    if run_result.returncode != 0:
+        return ProblemResult(
+            problem_id=problem_id,
+            model="baseline",
+            language="aver",
+            attempt=1,
+            check_pass=True,
+            run_correct=False,
+            tests_total=len(test_cases),
+            error_message=(run_result.stderr[:200] if run_result.stderr else "Non-zero exit"),
+            wall_time_s=elapsed,
+            timestamp=_now(),
+        )
+
+    # Parse output: each line corresponds to one test case result
+    output_lines = run_result.stdout.strip().split("\n") if run_result.stdout.strip() else []
+    tests_passed = 0
+
+    for i, tc in enumerate(test_cases):
+        expected = tc.get("expected")
+        if i < len(output_lines):
+            actual = output_lines[i].strip()
+            if _aver_output_matches(actual, expected):
+                tests_passed += 1
+
+    return ProblemResult(
+        problem_id=problem_id,
+        model="baseline",
+        language="aver",
+        attempt=1,
+        check_pass=True,
+        run_correct=(tests_passed == len(test_cases)),
+        tests_total=len(test_cases),
+        tests_passed=tests_passed,
+        wall_time_s=elapsed,
+        timestamp=_now(),
+    )
+
+
+def _normalize_aver_expected(expected) -> str:
+    """Normalize expected value to match aver run output.
+
+    Vera uses 1/0 for bools in test_cases; Aver prints true/false.
+    """
+    if isinstance(expected, bool):
+        return "true" if expected else "false"
+    if isinstance(expected, int):
+        # Vera-style bool: 1 -> true, 0 -> false for Bool-returning fns
+        # We can't always know, so keep as int — the caller handles matching
+        return str(expected)
+    if isinstance(expected, float):
+        return str(expected)
+    if isinstance(expected, str):
+        return expected
+    if isinstance(expected, list):
+        items = ", ".join(_normalize_aver_expected(v) for v in expected)
+        return f"[{items}]"
+    return str(expected)
+
+
+def _aver_output_matches(actual: str, expected) -> bool:
+    """Check if aver output matches expected, handling bool normalization.
+
+    Vera test cases use 1/0 for bools; Aver prints true/false.
+    """
+    expected_str = _normalize_aver_expected(expected)
+    if actual == expected_str:
+        return True
+    # Handle Vera-style bool: expected=1 matches "true", expected=0 matches "false"
+    if isinstance(expected, int) and expected in (0, 1):
+        bool_str = "true" if expected == 1 else "false"
+        if actual == bool_str:
+            return True
+    return False
+
+
 def run_all_baselines(
     problems: list[dict],
     solutions_dir: Path,
@@ -371,26 +555,36 @@ def run_all_baselines(
     language: str = "python",
 ) -> list[ProblemResult]:
     """Run baselines for all problems. Write JSONL incrementally."""
-    if language not in ("python", "typescript"):
+    if language not in ("python", "typescript", "aver"):
         raise NotImplementedError(
             f"Baseline runner for {language!r} not yet implemented"
         )
 
-    runner = run_python_baseline if language == "python" else run_typescript_baseline
+    if language == "python":
+        runner = run_python_baseline
+    elif language == "typescript":
+        runner = run_typescript_baseline
+    else:
+        runner = run_aver_baseline
 
     all_results: list[ProblemResult] = []
 
-    testable = [p for p in problems if p.get("test_cases")]
-    skipped = len(problems) - len(testable)
-
-    if skipped:
-        console.print(f"[dim]Skipping {skipped} problems with no test cases[/dim]")
+    # Aver validates all problems (check even without test_cases)
+    if language == "aver":
+        run_problems = problems
+    else:
+        run_problems = [p for p in problems if p.get("test_cases")]
+        skipped = len(problems) - len(run_problems)
+        if skipped:
+            console.print(
+                f"[dim]Skipping {skipped} problems with no test cases[/dim]"
+            )
 
     with tempfile.TemporaryDirectory(prefix="verabench_baseline_") as tmpdir:
         work_dir = Path(tmpdir)
         with Progress(console=console) as progress:
-            task = progress.add_task("Running baselines...", total=len(testable))
-            for problem in testable:
+            task = progress.add_task("Running baselines...", total=len(run_problems))
+            for problem in run_problems:
                 result = runner(problem, solutions_dir, work_dir)
                 all_results.append(result)
 

--- a/vera_bench/baseline_runner.py
+++ b/vera_bench/baseline_runner.py
@@ -392,7 +392,7 @@ def run_aver_baseline(
 
     try:
         check_result = subprocess.run(  # noqa: S603
-            ["aver", "check", str(baseline_path)],
+            ["aver", "check", str(baseline_path)],  # noqa: S607
             capture_output=True,
             text=True,
             timeout=timeout,
@@ -449,7 +449,7 @@ def run_aver_baseline(
     # aver run — the baseline .av files have main() that prints test outputs
     try:
         run_result = subprocess.run(  # noqa: S603
-            ["aver", "run", str(baseline_path)],
+            ["aver", "run", str(baseline_path)],  # noqa: S607
             capture_output=True,
             text=True,
             timeout=timeout,

--- a/vera_bench/baseline_runner.py
+++ b/vera_bench/baseline_runner.py
@@ -566,10 +566,6 @@ def run_all_baselines(
         runner = run_typescript_baseline
     elif language == "aver":
         runner = run_aver_baseline
-    else:
-        raise NotImplementedError(
-            f"Baseline runner for {language!r} not yet implemented"
-        )
 
     all_results: list[ProblemResult] = []
 

--- a/vera_bench/baseline_runner.py
+++ b/vera_bench/baseline_runner.py
@@ -564,8 +564,12 @@ def run_all_baselines(
         runner = run_python_baseline
     elif language == "typescript":
         runner = run_typescript_baseline
-    else:
+    elif language == "aver":
         runner = run_aver_baseline
+    else:
+        raise NotImplementedError(
+            f"Baseline runner for {language!r} not yet implemented"
+        )
 
     all_results: list[ProblemResult] = []
 

--- a/vera_bench/cli.py
+++ b/vera_bench/cli.py
@@ -46,7 +46,7 @@ def validate(problems_dir: Path | None, solutions_dir: Path | None):
 @click.option("--problem", default=None, help="Run only this problem ID")
 @click.option(
     "--language",
-    type=click.Choice(["vera", "python", "typescript"]),
+    type=click.Choice(["vera", "python", "typescript", "aver"]),
     default="vera",
     help="Target language for code generation",
 )
@@ -94,8 +94,8 @@ def run(
     from vera_bench.runner import run_benchmark
     from vera_bench.vera_runner import VeraRunner
 
-    # Warn on Vera-specific flags in non-Vera mode
-    if language != "vera":
+    # Warn on flags that are ignored for the selected language
+    if language not in ("vera", "aver"):
         if skill_md is not None:
             console.print(
                 f"[yellow]Warning: --skill-md is ignored "
@@ -106,6 +106,11 @@ def run(
                 f"[yellow]Warning: --mode is ignored "
                 f"with --language {language}[/yellow]"
             )
+    if language == "aver" and mode != "full-spec":
+        console.print(
+            f"[yellow]Warning: --mode {mode} is ignored "
+            f"with --language aver[/yellow]"
+        )
 
     root = _repo_root()
 
@@ -128,7 +133,7 @@ def run(
 
     console.print(f"Found {len(problems)} problems to evaluate.\n")
 
-    # Load SKILL.md (only needed for Vera)
+    # Load language spec (SKILL.md for Vera, llms.txt for Aver)
     skill_content = ""
     if language == "vera":
         import hashlib
@@ -139,6 +144,15 @@ def run(
         skill_content = load_skill_md(skill_md)
         content_hash = hashlib.sha256(skill_content.encode()).hexdigest()[:12]
         console.print(f"SKILL.md: {source} ({content_hash})")
+    elif language == "aver":
+        import hashlib
+
+        from vera_bench.prompts import AVER_LLMS_TXT_URL, load_aver_llms_txt
+
+        source = str(skill_md) if skill_md else AVER_LLMS_TXT_URL
+        skill_content = load_aver_llms_txt(skill_md)
+        content_hash = hashlib.sha256(skill_content.encode()).hexdigest()[:12]
+        console.print(f"llms.txt: {source} ({content_hash})")
 
     # Versions
     import vera_bench
@@ -149,6 +163,27 @@ def run(
     client = create_client(model)
     vera = VeraRunner() if language == "vera" else None
     vera_ver = vera.version() if vera else ""
+
+    # Get Aver version if running Aver
+    aver_ver = ""
+    if language == "aver":
+        import subprocess as _sp
+
+        try:
+            _av_proc = _sp.run(  # noqa: S603
+                ["aver", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+            aver_ver = _av_proc.stdout.strip().replace("aver ", "")
+        except (FileNotFoundError, _sp.TimeoutExpired):
+            console.print(
+                "[red]Error: aver not found on PATH. "
+                "Install with: cargo install aver-lang[/red]"
+            )
+            raise SystemExit(1)
 
     # Set up output — dots to hyphens in versions for clean filenames
     def _ver_slug(v: str) -> str:
@@ -165,6 +200,8 @@ def run(
     parts.append(f"bench-{_ver_slug(bench_ver)}")
     if vera_ver and vera_ver != "unknown":
         parts.append(f"vera-{_ver_slug(vera_ver)}")
+    if aver_ver and aver_ver != "unknown":
+        parts.append(f"aver-{_ver_slug(aver_ver)}")
     output_path = output_dir / f"{'-'.join(parts)}.jsonl"
 
     # Truncate stale results from previous runs
@@ -175,6 +212,8 @@ def run(
     console.print(f"Language: {language}")
     console.print(f"Mode:     {mode}")
     console.print(f"Bench:    v{bench_ver}")
+    if aver_ver:
+        console.print(f"Aver:     v{aver_ver}")
     if vera_ver:
         console.print(f"Vera:     v{vera_ver}")
     console.print(f"Output:   {output_path}\n")
@@ -216,7 +255,7 @@ def _print_metrics(model: str, metrics, language: str = "vera") -> None:
 
     table.add_row("Problems", str(metrics.total_problems))
     table.add_row("check@1", _fmt_rate(metrics.check_rate))
-    if language == "vera":
+    if language in ("vera", "aver"):
         table.add_row("verify@1", _fmt_rate(metrics.verify_rate))
         table.add_row("fix@1", _fmt_rate(metrics.fix_rate))
     table.add_row("run_correct", _fmt_rate(metrics.run_correct_rate))
@@ -249,7 +288,7 @@ def report(results_dir: Path):
 @main.command()
 @click.option(
     "--language",
-    type=click.Choice(["python", "typescript"]),
+    type=click.Choice(["python", "typescript", "aver"]),
     default="python",
     help="Baseline language to run",
 )

--- a/vera_bench/cli.py
+++ b/vera_bench/cli.py
@@ -108,8 +108,7 @@ def run(
             )
     if language == "aver" and mode != "full-spec":
         console.print(
-            f"[yellow]Warning: --mode {mode} is ignored "
-            f"with --language aver[/yellow]"
+            f"[yellow]Warning: --mode {mode} is ignored with --language aver[/yellow]"
         )
 
     root = _repo_root()

--- a/vera_bench/cli.py
+++ b/vera_bench/cli.py
@@ -325,6 +325,17 @@ def baselines(language: str, output_dir: Path | None):
     if output_path.exists():
         output_path.unlink()
 
+    # Fail fast if aver is not on PATH
+    if language == "aver":
+        import shutil as _shutil
+
+        if _shutil.which("aver") is None:
+            console.print(
+                "[red]Error: aver not found on PATH. "
+                "Install with: cargo install aver-lang[/red]"
+            )
+            raise SystemExit(1)
+
     console.print(f"Language: {language}")
     console.print(f"Output:   {output_path}\n")
 

--- a/vera_bench/cli.py
+++ b/vera_bench/cli.py
@@ -170,7 +170,7 @@ def run(
 
         try:
             _av_proc = _sp.run(  # noqa: S603
-                ["aver", "--version"],
+                ["aver", "--version"],  # noqa: S607
                 capture_output=True,
                 text=True,
                 timeout=5,

--- a/vera_bench/cli.py
+++ b/vera_bench/cli.py
@@ -177,6 +177,13 @@ def run(
                 timeout=5,
                 check=False,
             )
+            if _av_proc.returncode != 0:
+                console.print(
+                    "[red]Error: aver --version failed "
+                    f"(exit {_av_proc.returncode}). "
+                    "Check your aver installation.[/red]"
+                )
+                raise SystemExit(1)
             aver_ver = _av_proc.stdout.strip().replace("aver ", "")
         except (FileNotFoundError, _sp.TimeoutExpired):
             console.print(

--- a/vera_bench/prompts.py
+++ b/vera_bench/prompts.py
@@ -16,6 +16,7 @@ _WRITE_INSTRUCTION = (
 )
 
 SKILL_MD_URL = "https://veralang.dev/SKILL.md"
+AVER_LLMS_TXT_URL = "https://averlang.dev/llms.txt"
 
 
 def load_skill_md(source: str | Path | None = None) -> str:
@@ -38,6 +39,32 @@ def load_skill_md(source: str | Path | None = None) -> str:
         except (urllib.error.URLError, OSError) as e:
             raise RuntimeError(
                 f"Failed to fetch SKILL.md from {source_str}: {e}\n"
+                "Use --skill-md to provide a local copy."
+            ) from e
+
+    return Path(source).read_text(encoding="utf-8")
+
+
+def load_aver_llms_txt(source: str | Path | None = None) -> str:
+    """Load Aver llms.txt from a URL or local file.
+
+    If source is None, fetches from averlang.dev.
+    If source starts with http, fetches from that URL.
+    Otherwise reads from the local file path.
+    """
+    if source is None:
+        source = AVER_LLMS_TXT_URL
+
+    source_str = str(source)
+    if source_str.startswith("http"):
+        try:
+            with urllib.request.urlopen(  # noqa: S310
+                source_str, timeout=10
+            ) as resp:
+                return resp.read().decode("utf-8")
+        except (urllib.error.URLError, OSError) as e:
+            raise RuntimeError(
+                f"Failed to fetch llms.txt from {source_str}: {e}\n"
                 "Use --skill-md to provide a local copy."
             ) from e
 
@@ -97,6 +124,11 @@ PYTHON_SYSTEM_PROMPT = (
 )
 
 
+def _neutral_description(problem: dict) -> str:
+    """Return language-neutral description, falling back to original."""
+    return problem.get("description_neutral") or problem["description"]
+
+
 def build_python_prompt(problem: dict) -> dict:
     """Build a prompt asking the model to write Python.
 
@@ -104,7 +136,7 @@ def build_python_prompt(problem: dict) -> dict:
     """
     entry_point = problem["entry_point"]
     user_msg = (
-        f"{problem['description']}\n\n"
+        f"{_neutral_description(problem)}\n\n"
         f"Write a Python function named `{entry_point}`. "
         "Output only the Python code, no explanation."
     )
@@ -128,12 +160,57 @@ def build_typescript_prompt(problem: dict) -> dict:
 
     entry_point = _snake_to_camel(problem["entry_point"])
     user_msg = (
-        f"{problem['description']}\n\n"
+        f"{_neutral_description(problem)}\n\n"
         f"Write a TypeScript function named `{entry_point}`. "
         "Output only the TypeScript code, no explanation."
     )
     return {
         "system": TYPESCRIPT_SYSTEM_PROMPT,
+        "user": user_msg,
+    }
+
+
+AVER_SYSTEM_PROMPT = (
+    "You are an expert Aver programmer. "
+    "Write correct, concise Aver code. "
+    "Aver is not in your training data — use the llms.txt reference below."
+)
+
+
+def build_aver_prompt(problem: dict, llms_txt: str) -> dict:
+    """Build a prompt asking the model to write Aver.
+
+    Same approach as Python/TypeScript: raw description + function name.
+    The llms.txt in the system prompt replaces training data.
+    """
+    entry_point = problem["entry_point"]
+    user_msg = (
+        f"{_neutral_description(problem)}\n\n"
+        f"Write an Aver function named `{entry_point}`. "
+        "Output only the Aver code, no explanation."
+    )
+    return {
+        "system": f"{AVER_SYSTEM_PROMPT}\n\n{llms_txt}",
+        "user": user_msg,
+    }
+
+
+def build_aver_fix_prompt(
+    original_code: str, error_output: str, llms_txt: str
+) -> dict:
+    """Build a retry prompt after a failed Aver check.
+
+    Returns dict with 'system' and 'user' keys.
+    """
+    user_msg = (
+        "The Aver code you wrote:\n\n"
+        f"```aver\n{original_code}\n```\n\n"
+        f"produced this error:\n\n{error_output}\n\n"
+        "Fix the code. Output only the corrected Aver code, "
+        "no explanation."
+    )
+    return {
+        "system": f"{AVER_SYSTEM_PROMPT}\n\n{llms_txt}",
         "user": user_msg,
     }
 

--- a/vera_bench/prompts.py
+++ b/vera_bench/prompts.py
@@ -195,9 +195,7 @@ def build_aver_prompt(problem: dict, llms_txt: str) -> dict:
     }
 
 
-def build_aver_fix_prompt(
-    original_code: str, error_output: str, llms_txt: str
-) -> dict:
+def build_aver_fix_prompt(original_code: str, error_output: str, llms_txt: str) -> dict:
     """Build a retry prompt after a failed Aver check.
 
     Returns dict with 'system' and 'user' keys.

--- a/vera_bench/runner.py
+++ b/vera_bench/runner.py
@@ -18,6 +18,8 @@ from rich.progress import Progress
 
 from vera_bench.models import LLMClient
 from vera_bench.prompts import (
+    build_aver_fix_prompt,
+    build_aver_prompt,
     build_fix_prompt,
     build_full_spec_prompt,
     build_python_prompt,
@@ -30,7 +32,7 @@ from vera_bench.vera_runner import VeraRunner
 console = Console()
 
 _FENCE_RE = re.compile(
-    r"```(?:vera|python|py|typescript|ts)?\s*\n(.*?)\n?```", re.DOTALL
+    r"```(?:vera|aver|python|py|typescript|ts)?\s*\n(.*?)\n?```", re.DOTALL
 )
 
 
@@ -403,6 +405,189 @@ def _evaluate_typescript_code(
     return result
 
 
+def _evaluate_aver_code(
+    code: str,
+    problem: dict,
+    work_dir: Path,
+    attempt: int,
+) -> dict:
+    """Write Aver code to a file and run check + test cases via aver run."""
+    entry_point = problem.get("entry_point", "")
+    test_cases = problem.get("test_cases", [])
+
+    result: dict = {
+        "check_pass": False,
+        "verify_pass": None,
+        "verify_tier1": 0,
+        "verify_tier3": 0,
+        "run_correct": None,
+        "tests_total": 0,
+        "tests_passed": 0,
+        "error_message": None,
+    }
+
+    # Write the generated code
+    safe_id = problem["id"].replace("-", "_")
+    code_path = work_dir / f"{safe_id}_attempt{attempt}.av"
+    code_path.write_text(code, encoding="utf-8")
+
+    # aver check
+    run_env = {k: v for k, v in os.environ.items() if not k.endswith("_API_KEY")}
+    try:
+        check_proc = subprocess.run(  # noqa: S603
+            ["aver", "check", str(code_path)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            env=run_env,
+        )
+    except FileNotFoundError:
+        result["error_message"] = "aver not found on PATH"
+        return result
+    except subprocess.TimeoutExpired:
+        result["error_message"] = "aver check timed out"
+        return result
+
+    if check_proc.returncode != 0:
+        result["check_pass"] = False
+        result["error_message"] = (check_proc.stderr or check_proc.stdout)[:500]
+        return result
+
+    # aver verify (typecheck + verify blocks in one step)
+    try:
+        verify_proc = subprocess.run(  # noqa: S603
+            ["aver", "verify", str(code_path)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            env=run_env,
+        )
+        result["verify_pass"] = verify_proc.returncode == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        result["verify_pass"] = None
+
+    result["check_pass"] = True
+
+    # Test cases — build a single test .av file per test case
+    if not test_cases:
+        result["run_correct"] = None
+        return result
+
+    # Strategy: strip any existing main() from the LLM code and replace
+    # with our own that calls the entry_point with specific test args.
+    code_without_main = _strip_aver_main(code)
+
+    all_pass = True
+    for i, tc in enumerate(test_cases):
+        if not isinstance(tc, dict):
+            continue
+        args = tc.get("args", [])
+        expected = tc.get("expected")
+        result["tests_total"] += 1
+
+        args_str = ", ".join(_aver_literal(a) for a in args)
+
+        # If code has no module declaration, wrap it
+        has_module = any(
+            line.strip().startswith("module ")
+            for line in code_without_main.split("\n")
+        )
+        if has_module:
+            test_file = (
+                f"{code_without_main}\n\n"
+                f"fn main() -> Unit\n"
+                f"    ! [Console.print]\n"
+                f"    Console.print({entry_point}({args_str}))\n"
+            )
+        else:
+            test_file = (
+                f"module Test{safe_id}\n"
+                f"    intent = \"Test wrapper\"\n\n"
+                f"{code_without_main}\n\n"
+                f"fn main() -> Unit\n"
+                f"    ! [Console.print]\n"
+                f"    Console.print({entry_point}({args_str}))\n"
+            )
+
+        test_path = work_dir / f"{safe_id}_test{i}_attempt{attempt}.av"
+        test_path.write_text(test_file, encoding="utf-8")
+
+        try:
+            run_proc = subprocess.run(  # noqa: S603
+                ["aver", "run", str(test_path)],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+                env=run_env,
+            )
+        except subprocess.TimeoutExpired:
+            all_pass = False
+            continue
+
+        if run_proc.returncode != 0:
+            all_pass = False
+            continue
+
+        actual_output = run_proc.stdout.strip()
+
+        if _aver_output_matches(actual_output, expected):
+            result["tests_passed"] += 1
+        else:
+            all_pass = False
+
+    result["run_correct"] = all_pass
+    return result
+
+
+def _strip_aver_main(code: str) -> str:
+    """Remove fn main() and its body from Aver code."""
+    lines = code.split("\n")
+    result_lines = []
+    skip = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("fn main(") or stripped.startswith("fn main ()"):
+            skip = True
+            continue
+        if skip:
+            # main body is indented; stop skipping at next top-level item
+            if stripped and not line[0:1].isspace():
+                skip = False
+            else:
+                continue
+        if not skip:
+            result_lines.append(line)
+    return "\n".join(result_lines)
+
+
+def _aver_literal(value) -> str:
+    """Convert a Python value to an Aver literal."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        if value < 0:
+            return f"(0 - {abs(value)})"
+        return str(value)
+    if isinstance(value, float):
+        return str(value)
+    if isinstance(value, str):
+        return f'"{value}"'
+    if isinstance(value, list):
+        items = ", ".join(_aver_literal(v) for v in value)
+        return f"[{items}]"
+    return str(value)
+
+
+def _aver_output_matches(actual: str, expected) -> bool:
+    """Check if aver output matches expected, handling bool normalization."""
+    from vera_bench.baseline_runner import _aver_output_matches as _match
+
+    return _match(actual, expected)
+
+
 def run_single_problem(
     problem: dict,
     client: LLMClient,
@@ -423,7 +608,9 @@ def run_single_problem(
     results: list[ProblemResult] = []
 
     # Build prompt
-    if language == "python":
+    if language == "aver":
+        prompt = build_aver_prompt(problem, skill_md)
+    elif language == "python":
         prompt = build_python_prompt(problem)
     elif language == "typescript":
         prompt = build_typescript_prompt(problem)
@@ -457,7 +644,9 @@ def run_single_problem(
 
     code = extract_code(llm_response.text)
 
-    if language == "python":
+    if language == "aver":
+        eval_result = _evaluate_aver_code(code, problem, work_dir, attempt=1)
+    elif language == "python":
         eval_result = _evaluate_python_code(code, problem, work_dir, attempt=1)
     elif language == "typescript":
         eval_result = _evaluate_typescript_code(code, problem, work_dir, attempt=1)
@@ -481,6 +670,52 @@ def run_single_problem(
             **eval_result,
         )
     )
+
+    # Attempt 2: fix from error (Aver — has aver check step)
+    if language == "aver" and not eval_result["check_pass"] and max_fix_attempts > 0:
+        fix_prompt = build_aver_fix_prompt(
+            code, eval_result.get("error_message", ""), skill_md
+        )
+        try:
+            fix_response = client.complete(
+                system=fix_prompt["system"],
+                user=fix_prompt["user"],
+                max_tokens=max_tokens,
+            )
+        except Exception as e:
+            results.append(
+                ProblemResult(
+                    problem_id=problem["id"],
+                    model=llm_response.model,
+                    language=language,
+                    attempt=2,
+                    check_pass=False,
+                    error_message=f"Fix API error: {e}",
+                    timestamp=_now(),
+                    bench_version=bench_version,
+                    vera_version=vera_version,
+                )
+            )
+            return results
+
+        fix_code = extract_code(fix_response.text)
+        fix_eval = _evaluate_aver_code(fix_code, problem, work_dir, attempt=2)
+
+        results.append(
+            ProblemResult(
+                problem_id=problem["id"],
+                model=fix_response.model,
+                language=language,
+                attempt=2,
+                input_tokens=fix_response.input_tokens,
+                output_tokens=fix_response.output_tokens,
+                wall_time_s=fix_response.wall_time_s,
+                timestamp=_now(),
+                bench_version=bench_version,
+                vera_version=vera_version,
+                **fix_eval,
+            )
+        )
 
     # Attempt 2: fix from error (Vera only — Python has no check step)
     if language == "vera" and not eval_result["check_pass"] and max_fix_attempts > 0:

--- a/vera_bench/runner.py
+++ b/vera_bench/runner.py
@@ -491,8 +491,7 @@ def _evaluate_aver_code(
 
         # If code has no module declaration, wrap it
         has_module = any(
-            line.strip().startswith("module ")
-            for line in code_without_main.split("\n")
+            line.strip().startswith("module ") for line in code_without_main.split("\n")
         )
         if has_module:
             test_file = (
@@ -504,7 +503,7 @@ def _evaluate_aver_code(
         else:
             test_file = (
                 f"module Test{safe_id}\n"
-                f"    intent = \"Test wrapper\"\n\n"
+                f'    intent = "Test wrapper"\n\n'
                 f"{code_without_main}\n\n"
                 f"fn main() -> Unit\n"
                 f"    ! [Console.print]\n"
@@ -574,7 +573,7 @@ def _aver_literal(value) -> str:
     if isinstance(value, float):
         return str(value)
     if isinstance(value, str):
-        escaped = value.replace('\\', '\\\\').replace('"', '\\"')
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
         return f'"{escaped}"'
     if isinstance(value, list):
         items = ", ".join(_aver_literal(v) for v in value)

--- a/vera_bench/runner.py
+++ b/vera_bench/runner.py
@@ -466,7 +466,7 @@ def _evaluate_aver_code(
         )
         result["verify_pass"] = verify_proc.returncode == 0
     except (subprocess.TimeoutExpired, FileNotFoundError):
-        result["verify_pass"] = None
+        result["verify_pass"] = False
 
     result["check_pass"] = True
 

--- a/vera_bench/runner.py
+++ b/vera_bench/runner.py
@@ -435,7 +435,7 @@ def _evaluate_aver_code(
     run_env = {k: v for k, v in os.environ.items() if not k.endswith("_API_KEY")}
     try:
         check_proc = subprocess.run(  # noqa: S603
-            ["aver", "check", str(code_path)],
+            ["aver", "check", str(code_path)],  # noqa: S607
             capture_output=True,
             text=True,
             timeout=30,
@@ -457,7 +457,7 @@ def _evaluate_aver_code(
     # aver verify (typecheck + verify blocks in one step)
     try:
         verify_proc = subprocess.run(  # noqa: S603
-            ["aver", "verify", str(code_path)],
+            ["aver", "verify", str(code_path)],  # noqa: S607
             capture_output=True,
             text=True,
             timeout=30,
@@ -515,7 +515,7 @@ def _evaluate_aver_code(
 
         try:
             run_proc = subprocess.run(  # noqa: S603
-                ["aver", "run", str(test_path)],
+                ["aver", "run", str(test_path)],  # noqa: S607
                 capture_output=True,
                 text=True,
                 timeout=30,

--- a/vera_bench/runner.py
+++ b/vera_bench/runner.py
@@ -574,7 +574,8 @@ def _aver_literal(value) -> str:
     if isinstance(value, float):
         return str(value)
     if isinstance(value, str):
-        return f'"{value}"'
+        escaped = value.replace('\\', '\\\\').replace('"', '\\"')
+        return f'"{escaped}"'
     if isinstance(value, list):
         items = ", ".join(_aver_literal(v) for v in value)
         return f"[{items}]"
@@ -614,10 +615,12 @@ def run_single_problem(
         prompt = build_python_prompt(problem)
     elif language == "typescript":
         prompt = build_typescript_prompt(problem)
-    elif mode == "spec-from-nl":
+    elif language == "vera" and mode == "spec-from-nl":
         prompt = build_spec_from_nl_prompt(problem, skill_md)
-    else:
+    elif language == "vera":
         prompt = build_full_spec_prompt(problem, skill_md)
+    else:
+        raise ValueError(f"Unknown language: {language!r}")
 
     # Attempt 1: generate
     try:
@@ -650,10 +653,12 @@ def run_single_problem(
         eval_result = _evaluate_python_code(code, problem, work_dir, attempt=1)
     elif language == "typescript":
         eval_result = _evaluate_typescript_code(code, problem, work_dir, attempt=1)
-    else:
+    elif language == "vera":
         if vera is None:
             raise ValueError("VeraRunner required for language='vera'")
         eval_result = _evaluate_code(code, problem, vera, work_dir, attempt=1)
+    else:
+        raise ValueError(f"Unknown language: {language!r}")
 
     results.append(
         ProblemResult(
@@ -671,8 +676,16 @@ def run_single_problem(
         )
     )
 
-    # Attempt 2: fix from error (Aver — has aver check step)
-    if language == "aver" and not eval_result["check_pass"] and max_fix_attempts > 0:
+    # Attempt 2: fix from error (Aver — only on actual check failures,
+    # not tooling errors like "aver not found" or timeouts)
+    _aver_error = eval_result.get("error_message") or ""
+    _is_tooling_error = "aver not found" in _aver_error or "timed out" in _aver_error
+    if (
+        language == "aver"
+        and not eval_result["check_pass"]
+        and max_fix_attempts > 0
+        and not _is_tooling_error
+    ):
         fix_prompt = build_aver_fix_prompt(
             code, eval_result.get("error_message", ""), skill_md
         )


### PR DESCRIPTION
## Summary

- Add Aver as a comparison language (50 canonical solutions, runner, baselines, CLI)
- Add `description_neutral` field to all 50 problem JSONs

## Language-neutral descriptions

The existing `description` references Vera builtins (`string_upper`, `array_fold`), types (`Nat`), and concepts (`handle[State<Int>]`, `Exn<E>`). Models writing Python/TypeScript ignore these from training data, but any zero-training-data language takes them literally.

`description_neutral` has only the functional requirement. Python, TypeScript, and Aver use it. Vera still uses the original `description`. Relevant for Go (#21) too.

## What is Aver

[Aver](https://github.com/jasisz/aver) — statically typed, zero training data, learns from [llms.txt](https://averlang.dev/llms.txt) in the prompt. Named params instead of De Bruijn indices, `verify` blocks instead of contracts, `Result<T,E>` instead of effect handlers.

## Usage

```bash
vera-bench baselines --language aver
vera-bench run --model claude-sonnet-4-20250514 --language aver \
  --skill-md /path/to/llms.txt
```

## Test plan

- [x] 50/50 solutions pass `aver check` + `aver run`
- [x] Baselines: 100% check, 100% run_correct (24 testable)
- [x] Existing tests: 339 passed (2 pre-existing failures — `vera` not on PATH)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end Aver language support: generate, verify, run and attempt fixes from errors; ~50 worked solution examples added across tiers 1–5.

* **Documentation**
  * Added neutral alternative descriptions to many problem statements for more consistent prompts.

* **Chores**
  * CLI and tooling now detect/report Aver version, include Aver in baseline runs, and normalise Aver outputs for evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->