### PR TITLE
Document Aver support and add comparison language guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Vera-flavoured `description`. This improves fairness for non-Vera languages
   but means results are not directly comparable to v0.0.7 runs which used
   Vera-specific descriptions.
+- README: added Aver as a comparison language, updated CLI examples
+- CLAUDE.md: added `description_neutral` documentation, comparison language guide, Aver section, Tier 5 caveat
+- DESIGN.md: added `description_neutral` rationale, zero-training-data comparison languages, Tier 5 methodology note
+- CONTRIBUTING.md: added "Adding a New Comparison Language" guide with step-by-step checklist
+- ROADMAP.md: added Aver milestone, MoonBit (#49), Tier 5 methodology (#50), timing (#51) items
 
 ## [0.0.7] - 2026-04-07
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — VeraBench
 
-VeraBench is a HumanEval/MBPP-style benchmark for [Vera](https://github.com/aallan/vera), a programming language designed for LLMs. It measures whether LLMs write better code in Vera than in Python, TypeScript, or other comparison languages (currently also [Aver](https://github.com/pchj/aver-lang)).
+VeraBench is a HumanEval/MBPP-style benchmark for [Vera](https://github.com/aallan/vera), a programming language designed for LLMs. It measures whether LLMs write better code in Vera than in Python, TypeScript, or other comparison languages (currently also [Aver](https://github.com/jasisz/aver)).
 
 ## Quick orientation
 
@@ -88,7 +88,7 @@ The pattern for adding a new language is established by the Python, TypeScript, 
 
 ### Aver
 
-[Aver](https://github.com/pchj/aver-lang) is a Haskell-inspired language with strong typing, similar zero-training-data properties to Vera. Its reference doc (`llms.txt`) is fetched from `https://averlang.dev/llms.txt`. The `aver` command must be on `$PATH`.
+[Aver](https://github.com/jasisz/aver) is a Haskell-inspired language with strong typing, similar zero-training-data properties to Vera. Its reference doc (`llms.txt`) is fetched from `https://averlang.dev/llms.txt`. The `aver` command must be on `$PATH`.
 
 ### Tier 5 cross-language caveat
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ VeraBench is a HumanEval/MBPP-style benchmark for [Vera](https://github.com/aall
 - **ROADMAP.md** has forward-looking milestones and open issues.
 - **BRIEFING.md** is the original bootstrap document (kept for historical reference).
 - **SKILL.md** is fetched from `https://veralang.dev/SKILL.md` at runtime (no local cache). Override with `--skill-md /path/to/local/SKILL.md`.
-- **Aver's llms.txt** is fetched from `https://averlang.org/llms.txt` at runtime (equivalent of SKILL.md for Aver).
+- **Aver's llms.txt** is fetched from `https://averlang.dev/llms.txt` at runtime (equivalent of SKILL.md for Aver).
 
 ## Vera installation
 
@@ -88,7 +88,7 @@ The pattern for adding a new language is established by the Python, TypeScript, 
 
 ### Aver
 
-[Aver](https://github.com/pchj/aver-lang) is a Haskell-inspired language with strong typing, similar zero-training-data properties to Vera. Its reference doc (`llms.txt`) is fetched from `https://averlang.org/llms.txt`. The `aver` command must be on `$PATH`.
+[Aver](https://github.com/pchj/aver-lang) is a Haskell-inspired language with strong typing, similar zero-training-data properties to Vera. Its reference doc (`llms.txt`) is fetched from `https://averlang.dev/llms.txt`. The `aver` command must be on `$PATH`.
 
 ### Tier 5 cross-language caveat
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — VeraBench
 
-VeraBench is a HumanEval/MBPP-style benchmark for [Vera](https://github.com/aallan/vera), a programming language designed for LLMs. It measures whether LLMs write better code in Vera than in Python or TypeScript.
+VeraBench is a HumanEval/MBPP-style benchmark for [Vera](https://github.com/aallan/vera), a programming language designed for LLMs. It measures whether LLMs write better code in Vera than in Python, TypeScript, or other comparison languages (currently also [Aver](https://github.com/pchj/aver-lang)).
 
 ## Quick orientation
 
@@ -10,6 +10,7 @@ VeraBench is a HumanEval/MBPP-style benchmark for [Vera](https://github.com/aall
 - **ROADMAP.md** has forward-looking milestones and open issues.
 - **BRIEFING.md** is the original bootstrap document (kept for historical reference).
 - **SKILL.md** is fetched from `https://veralang.dev/SKILL.md` at runtime (no local cache). Override with `--skill-md /path/to/local/SKILL.md`.
+- **Aver's llms.txt** is fetched from `https://averlang.org/llms.txt` at runtime (equivalent of SKILL.md for Aver).
 
 ## Vera installation
 
@@ -20,7 +21,12 @@ vera version   # should print vera 0.0.103 or later
 
 ## Problem structure
 
-Problems live in `problems/tier{1-5}/` as JSON files. Canonical Vera solutions live in `solutions/vera/`. Each problem JSON has: `id`, `tier`, `title`, `description`, `signature`, `contracts`, `entry_point`, `tags`, `test_cases`, `vera_check_must_pass`, `vera_verify_tier1`, `notes`.
+Problems live in `problems/tier{1-5}/` as JSON files. Canonical solutions live in `solutions/{vera,python,typescript,aver}/`. Each problem JSON has: `id`, `tier`, `title`, `description`, `description_neutral`, `signature`, `contracts`, `entry_point`, `tags`, `test_cases`, `vera_check_must_pass`, `vera_verify_tier1`, `notes`.
+
+### `description` vs `description_neutral`
+
+- **`description`** — Vera-specific problem description (references Vera types, slot references, contracts). Used for Vera full-spec and spec-from-NL prompts.
+- **`description_neutral`** — Language-agnostic description. Used for Python, TypeScript, Aver, and any future comparison language. Equivalent in purpose to spec-from-NL descriptions — the model must infer its own language-specific constructs from the natural language description.
 
 ### The five tiers
 
@@ -67,6 +73,27 @@ vera run solutions/vera/VB-T1-001_absolute_value.vera --fn absolute_value -- -42
 
 Both issues have caused false baseline failures (VB-T4-003 for Python, VB-T1-006 for TypeScript).
 
+## Comparison languages
+
+### Adding a new comparison language
+
+The pattern for adding a new language is established by the Python, TypeScript, and Aver implementations:
+
+1. **Prompt builder** (`prompts.py`) — `build_{lang}_prompt()` that uses `description_neutral` + the language's reference doc
+2. **Code evaluator** (`runner.py`) — `_evaluate_{lang}_code()` that writes code to a temp file, runs the compiler/interpreter, and checks output
+3. **Baseline runner** (`baseline_runner.py`) — `run_{lang}_baseline()` for canonical solutions
+4. **CLI integration** (`cli.py`) — add to `--language` choices
+5. **Canonical solutions** (`solutions/{lang}/`) — one per problem
+6. **Reference doc** — fetched at runtime (SKILL.md for Vera, llms.txt for Aver)
+
+### Aver
+
+[Aver](https://github.com/pchj/aver-lang) is a Haskell-inspired language with strong typing, similar zero-training-data properties to Vera. Its reference doc (`llms.txt`) is fetched from `https://averlang.org/llms.txt`. The `aver` command must be on `$PATH`.
+
+### Tier 5 cross-language caveat
+
+Tier 5 problems test algebraic effect handlers in Vera (`State`, `Exn`, `IO`). Other languages solve these with native idioms (`try/except` in Python, `try/catch` in TypeScript, etc.). Cross-language T5 comparison is apples-to-oranges. See issue [#50](https://github.com/aallan/vera-bench/issues/50).
+
 ## Coding conventions
 
 - Python 3.11+, type hints everywhere.
@@ -74,7 +101,7 @@ Both issues have caused false baseline failures (VB-T4-003 for Python, VB-T1-006
 - `click` for CLI.
 - `rich` for terminal output.
 - JSONL for results files.
-- Subprocess calls to `vera` with timeouts.
+- Subprocess calls to `vera` (and `aver`, `python`, `npx tsx`) with timeouts.
 
 ## Commands
 
@@ -82,5 +109,11 @@ Both issues have caused false baseline failures (VB-T4-003 for Python, VB-T1-006
 vera-bench validate                    # check all problem JSONs + canonical solutions
 vera-bench run --model MODEL           # run benchmark
 vera-bench run --model MODEL --tier N  # run one tier
+vera-bench run --model MODEL --language python      # Python LLM generation
+vera-bench run --model MODEL --language typescript   # TypeScript LLM generation
+vera-bench run --model MODEL --language aver         # Aver LLM generation
+vera-bench baselines                   # run canonical Python baselines
+vera-bench baselines --language typescript  # TypeScript baselines
+vera-bench baselines --language aver       # Aver baselines
 vera-bench report results/DIR/         # generate report
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,11 +17,34 @@ If you find a bug, incorrect test case, or have a suggestion:
 New benchmark problems are welcome. For each new problem, you must produce:
 
 1. A `.vera` canonical solution in `solutions/vera/` that passes `vera check` and `vera verify`.
-2. A JSON problem definition in `problems/tier{N}/` with all required fields.
+2. A JSON problem definition in `problems/tier{N}/` with all required fields (including `description_neutral`).
 3. A Python baseline in `solutions/python/`.
 4. A TypeScript baseline in `solutions/typescript/`.
+5. An Aver baseline in `solutions/aver/`.
 
 See [CLAUDE.md](CLAUDE.md) for problem structure, tier definitions, and Vera gotchas.
+
+### Adding a New Comparison Language
+
+VeraBench supports cross-language comparison. Currently: Vera, Python, TypeScript, and Aver. To add a new language:
+
+1. **Canonical solutions** — Create `solutions/{lang}/` with one solution per problem (50 files). Each must produce correct output for all test cases.
+
+2. **Prompt builder** — Add `build_{lang}_prompt()` to `vera_bench/prompts.py`. Use `description_neutral` (not `description`, which is Vera-specific). If the language has a reference doc (like SKILL.md or llms.txt), fetch it at runtime.
+
+3. **Code evaluator** — Add `_evaluate_{lang}_code()` to `vera_bench/runner.py`. This writes generated code to a temp file, runs the compiler/interpreter, and compares output to expected values.
+
+4. **Baseline runner** — Add `run_{lang}_baseline()` to `vera_bench/baseline_runner.py`. This runs canonical solutions against test cases.
+
+5. **CLI integration** — Add the language name to the `--language` choice list in `vera_bench/cli.py`.
+
+6. **Problem JSON** — If your language needs special descriptions, add them to the problem JSONs. For most languages, `description_neutral` is sufficient.
+
+7. **Tests** — Add unit tests for the new evaluator, prompt builder, and any helper functions.
+
+8. **CodeRabbit exclusions** — Add `!**/*.{ext}` and `!solutions/{lang}/**` to `.coderabbit.yaml` path_filters (CodeRabbit doesn't understand novel languages).
+
+See PR [#48](https://github.com/aallan/vera-bench/pull/48) (Aver support) as a reference implementation.
 
 ### Code Contributions
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -51,7 +51,7 @@ For each problem × model combination:
 - **fix@1** — Given the error message from a failed first attempt, can the model fix it in one turn?
 - **run_correct** — Does the best passing attempt produce the correct output for all test cases?
 
-Aggregate rates are computed per tier and overall. Cross-language baselines (Python, TypeScript) measure the same problems without Vera's contract system for comparison.
+Aggregate rates are computed per tier and overall. Cross-language baselines (Python, TypeScript, Aver) measure the same problems for comparison. Python and TypeScript are heavily represented in LLM training data; Aver (like Vera) has zero training data, providing a second data point for the zero-training-data thesis.
 
 ---
 
@@ -59,9 +59,13 @@ Aggregate rates are computed per tier and overall. Cross-language baselines (Pyt
 
 **Problem descriptions are natural language, not code stubs.** Unlike HumanEval (which gives a Python function signature + docstring), VeraBench gives a natural language description + the Vera function signature + optionally the contracts.
 
+**Two description fields: `description` and `description_neutral`.** The `description` field contains Vera-specific language (slot references, contract clauses). The `description_neutral` field is language-agnostic and is used for all non-Vera languages (Python, TypeScript, Aver). This is a fairness correction: non-Vera languages should not receive Vera-flavoured prompts. The neutral descriptions are functionally equivalent to spec-from-NL descriptions — the model must infer language-specific constructs from natural language.
+
 **Contracts can be provided or omitted.** For Tiers 1–2, provide the contracts in the prompt (full-spec mode). For Tiers 3–5, a spec-from-NL variant where the agent must also write the contracts.
 
-**The SKILL.md is always provided.** Unlike benchmarks for well-known languages, Vera is not in any model's training data. The SKILL.md is the sole source of language knowledge.
+**The SKILL.md is always provided.** Unlike benchmarks for well-known languages, Vera is not in any model's training data. The SKILL.md is the sole source of language knowledge. Similarly, Aver's `llms.txt` is fetched and provided for Aver benchmarks.
+
+**Comparison languages with zero training data are first-class.** Aver (Haskell-inspired, zero training data) is included alongside Python and TypeScript to test whether the zero-training-data thesis holds for languages beyond Vera. Adding further zero-training-data languages (e.g., MoonBit — see issue [#49](https://github.com/aallan/vera-bench/issues/49)) strengthens the comparison.
 
 **Retry with error feedback is a first-class metric.** Vera's error messages are designed to be agent-friendly (natural language, concrete fix suggestions). This is a competitive advantage worth measuring.
 
@@ -75,6 +79,7 @@ Aggregate rates are computed per tier and overall. Cross-language baselines (Pyt
 - **Don't make Tier 5 problems require network access.** Mock the `Http` and `Inference` effects.
 - **Don't use problems from the vera examples/ or conformance/ directories.** Those are in the repo and therefore in training data. Write fresh problems.
 - **Don't over-engineer.** Ship, get data, iterate.
+- **Don't compare Tier 5 across languages naïvely.** Vera's algebraic effect handlers test fundamentally different constructs than `try/except` in Python. See issue [#50](https://github.com/aallan/vera-bench/issues/50).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ For each problem, we measure:
 - **fix@1** — Given the error message, can the model fix it in one turn?
 - **run_correct** — Does execution produce the correct output?
 
-The same problems are also run in Python, TypeScript, and [Aver](https://github.com/pchj/aver-lang) as baselines. Aver is a Haskell-inspired language with zero LLM training data, providing a second data point alongside Vera for the zero-training-data thesis.
+The same problems are also run in Python, TypeScript, and [Aver](https://github.com/jasisz/aver) as baselines. Aver is a Haskell-inspired language with zero LLM training data, providing a second data point alongside Vera for the zero-training-data thesis.
 
 ## Prerequisites
 
 * Python 3.11+
 * Git
 * Node.js 22+ *(optional, for TypeScript baselines and generation)*
-* [Aver](https://github.com/pchj/aver-lang) *(optional, for Aver baselines and generation)*
+* [Aver](https://github.com/jasisz/aver) *(optional, for Aver baselines and generation)*
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ vera-bench baselines --language aver
 # Generate a combined report
 vera-bench report results/
 
-# Or run the full benchmark suite (all 6 targets) with one command
+# Or run the full benchmark suite (all 8 targets) with one command
 python scripts/run_full_benchmark.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,13 +70,14 @@ For each problem, we measure:
 - **fix@1** — Given the error message, can the model fix it in one turn?
 - **run_correct** — Does execution produce the correct output?
 
-The same problems are also run in Python and TypeScript as baselines.
+The same problems are also run in Python, TypeScript, and [Aver](https://github.com/pchj/aver-lang) as baselines. Aver is a Haskell-inspired language with zero LLM training data, providing a second data point alongside Vera for the zero-training-data thesis.
 
 ## Prerequisites
 
 * Python 3.11+
 * Git
 * Node.js 22+ *(optional, for TypeScript baselines and generation)*
+* [Aver](https://github.com/pchj/aver-lang) *(optional, for Aver baselines and generation)*
 
 ## Installation
 
@@ -132,13 +133,15 @@ vera-bench run --model claude-sonnet-4-20250514 --problem VB-T1-001
 # Spec-from-NL mode (agent writes its own contracts)
 vera-bench run --model claude-sonnet-4-20250514 --mode spec-from-nl
 
-# Ask the same model to write Python or TypeScript for comparison
+# Ask the same model to write Python, TypeScript, or Aver for comparison
 vera-bench run --model claude-sonnet-4-20250514 --language python
 vera-bench run --model claude-sonnet-4-20250514 --language typescript
+vera-bench run --model claude-sonnet-4-20250514 --language aver
 
 # Run canonical baselines as a reference
 vera-bench baselines
 vera-bench baselines --language typescript
+vera-bench baselines --language aver
 
 # Generate a combined report
 vera-bench report results/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Where we are
 
-**v0.0.7** — 50 problems across 5 tiers with strengthened postconditions and explicit slot ordering descriptions. Working LLM harness (Anthropic, OpenAI, Moonshot), Python and TypeScript baseline runners, cross-language generation comparison. Full benchmark runner script. SKILL.md fetched from veralang.dev at runtime.
+**v0.0.8** — 50 problems across 5 tiers with strengthened postconditions and explicit slot ordering descriptions. Working LLM harness (Anthropic, OpenAI, Moonshot), Python, TypeScript, and Aver baseline runners, cross-language generation comparison. Full benchmark runner script. SKILL.md and Aver's llms.txt fetched at runtime. Language-neutral problem descriptions (`description_neutral`) for fair cross-language prompting.
 
 ## Milestone 1: Publication-ready benchmark (current)
 
@@ -11,9 +11,13 @@
 - [ ] Refactor `models.py` to a provider registry before adding more (issue [#45](https://github.com/aallan/vera-bench/issues/45))
 - [x] Run spec-from-NL mode comparison (issue #7)
 - [x] TypeScript baseline runner and LLM generation
+- [x] Aver language support — generation, baselines, `description_neutral` field ([PR #48](https://github.com/aallan/vera-bench/pull/48))
 - [x] Generate paper-quality figures — [`scripts/plot_results.py`](scripts/plot_results.py) produces [`assets/benchmark_v0.0.7.png`](assets/benchmark_v0.0.7.png) with veralang.dev site palette (v0.0.7)
 - [ ] Hugging Face dataset export
 - [x] [`CITATION.cff`](CITATION.cff)
+- [ ] MoonBit support (issue [#49](https://github.com/aallan/vera-bench/issues/49))
+- [ ] Tier 5 cross-language methodology (issue [#50](https://github.com/aallan/vera-bench/issues/50))
+- [ ] Timing instrumentation in benchmark script (issue [#51](https://github.com/aallan/vera-bench/issues/51))
 - [ ] Expand to 75+ problems (15 per tier)
 - [x] Strengthen problem descriptions for slot ordering (issue #13)
 - [x] Strengthen postconditions to catch slot-swap bugs (issue #14)

--- a/scripts/run_full_benchmark.py
+++ b/scripts/run_full_benchmark.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run the full VeraBench benchmark suite (all 6 targets).
+"""Run the full VeraBench benchmark suite (all 8 targets).
 
 Usage:
   # Interactive mode — prompts for model and API key

--- a/scripts/run_full_benchmark.py
+++ b/scripts/run_full_benchmark.py
@@ -13,13 +13,15 @@ Usage:
   ANTHROPIC_API_KEY=sk-ant-... \
     python scripts/run_full_benchmark.py --model claude-sonnet-4-20250514
 
-Runs all 6 targets:
+Runs all 8 targets:
   1. Vera full-spec
   2. Vera spec-from-NL
   3. Python LLM generation
   4. TypeScript LLM generation
-  5. Python baselines
-  6. TypeScript baselines
+  5. Aver LLM generation
+  6. Python baselines
+  7. TypeScript baselines
+  8. Aver baselines
 """
 
 from __future__ import annotations
@@ -206,6 +208,17 @@ def main():
                 "typescript",
             ],
         ),
+        (
+            "Aver LLM",
+            [
+                "vera-bench",
+                "run",
+                "--model",
+                model,
+                "--language",
+                "aver",
+            ],
+        ),
     ]
 
     if not args.skip_baselines:
@@ -219,6 +232,15 @@ def main():
                         "baselines",
                         "--language",
                         "typescript",
+                    ],
+                ),
+                (
+                    "Aver baselines",
+                    [
+                        "vera-bench",
+                        "baselines",
+                        "--language",
+                        "aver",
                     ],
                 ),
             ]

--- a/vera_bench/validate.py
+++ b/vera_bench/validate.py
@@ -15,6 +15,7 @@ REQUIRED_FIELDS = [
     "tier",
     "title",
     "description",
+    "description_neutral",
     "signature",
     "contracts",
     "entry_point",


### PR DESCRIPTION
## Summary

- Update README, CLAUDE.md, DESIGN.md, CONTRIBUTING.md, and ROADMAP.md to document Aver as a comparison language
- Add `description_neutral` field documentation and rationale
- Add step-by-step "Adding a New Comparison Language" guide to CONTRIBUTING.md
- Add Aver LLM generation and baseline targets to `scripts/run_full_benchmark.py` (6 → 8 targets)
- Add Tier 5 cross-language methodology caveat (references #50)
- Add MoonBit (#49), Tier 5 (#50), timing (#51) to ROADMAP.md

**Depends on #48** — CHANGELOG.md will need a rebase after #48 merges (both add to `[Unreleased]`). All other files are non-overlapping.

## Test plan

- [x] `ruff check .` and `ruff format --check .` pass
- [ ] Rebase on main after #48 merges
- [ ] Verify CHANGELOG.md merge is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Aver as a supported comparison language; CLI and benchmark suite accept --language aver and include Aver generation and baseline targets, increasing visible suite targets.

* **Documentation**
  * Introduced a language‑agnostic problem field (description_neutral) and updated contributor checklist for adding comparison languages.
  * Updated README, design notes, contributing guide, CLAUDE guidance, roadmap (v0.0.8) and changelog with Aver setup, CLI examples, zero‑training‑data guidance and Tier 5 cross‑language caveats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->