### PR TITLE
Add per-target timing to benchmark runner

### DIFF
--- a/scripts/run_full_benchmark.py
+++ b/scripts/run_full_benchmark.py
@@ -153,18 +153,24 @@ def _run(cmd: list[str], env: dict, timeout: int = 3600) -> tuple[int, float]:
     Returns:
         Tuple of (return_code, elapsed_seconds).
     """
+    start_ts = datetime.now(timezone.utc)
     print(f"\n{'=' * 60}")
     print(f"Running: {' '.join(cmd)}")
+    print(f"Started: {start_ts.strftime('%H:%M:%S UTC')}")
     print(f"{'=' * 60}\n")
     t0 = time.monotonic()
     try:
         result = subprocess.run(cmd, env=env, check=False, timeout=timeout)
     except subprocess.TimeoutExpired:
         elapsed = time.monotonic() - t0
-        print(f"\nTIMEOUT after {_format_duration(elapsed)}: {' '.join(cmd)}")
+        finish_ts = datetime.now(timezone.utc)
+        print(f"\nTIMEOUT after {_format_duration(elapsed)}")
+        print(f"Finished: {finish_ts.strftime('%H:%M:%S UTC')}")
         return 1, elapsed
     elapsed = time.monotonic() - t0
+    finish_ts = datetime.now(timezone.utc)
     print(f"\nCompleted in {_format_duration(elapsed)}")
+    print(f"Finished: {finish_ts.strftime('%H:%M:%S UTC')}")
     return result.returncode, elapsed
 
 
@@ -270,6 +276,7 @@ def main():
 
     # Run all targets
     results: dict[str, dict] = {}
+    run_start_ts = datetime.now(timezone.utc)
     run_start = time.monotonic()
     for name, cmd in targets:
         rc, elapsed = _run(cmd, env)
@@ -295,7 +302,7 @@ def main():
     timing_path.parent.mkdir(parents=True, exist_ok=True)
     timing_data = {
         "model": model,
-        "started_at": datetime.now(timezone.utc).isoformat(),
+        "started_at": run_start_ts.isoformat(),
         "total_seconds": round(total_elapsed, 1),
         "targets": {
             name: {

--- a/scripts/run_full_benchmark.py
+++ b/scripts/run_full_benchmark.py
@@ -165,7 +165,7 @@ def _run(cmd: list[str], env: dict, timeout: int = 3600) -> tuple[int, float]:
         elapsed = time.monotonic() - t0
         finish_ts = datetime.now(timezone.utc)
         print(f"\nTIMEOUT after {_format_duration(elapsed)}")
-        print(f"Finished: {finish_ts.strftime('%H:%M:%S UTC')}")
+        print(f"Timed out at: {finish_ts.strftime('%H:%M:%S UTC')}")
         return 1, elapsed
     elapsed = time.monotonic() - t0
     finish_ts = datetime.now(timezone.utc)
@@ -174,7 +174,7 @@ def _run(cmd: list[str], env: dict, timeout: int = 3600) -> tuple[int, float]:
     return result.returncode, elapsed
 
 
-def main():
+def main() -> int:
     parser = argparse.ArgumentParser(
         description="Run the full VeraBench benchmark suite"
     )
@@ -300,9 +300,11 @@ def main():
     # Write timing.json
     timing_path = Path("results") / "timing.json"
     timing_path.parent.mkdir(parents=True, exist_ok=True)
+    run_end_ts = datetime.now(timezone.utc)
     timing_data = {
         "model": model,
         "started_at": run_start_ts.isoformat(),
+        "finished_at": run_end_ts.isoformat(),
         "total_seconds": round(total_elapsed, 1),
         "targets": {
             name: {

--- a/scripts/run_full_benchmark.py
+++ b/scripts/run_full_benchmark.py
@@ -28,9 +28,13 @@ from __future__ import annotations
 
 import argparse
 import getpass
+import json
 import os
 import subprocess
 import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
 
 MODELS = {
     "anthropic": [
@@ -129,21 +133,39 @@ def _ensure_api_key(model: str, api_key: str | None) -> dict:
     return env
 
 
-def _run(cmd: list[str], env: dict, timeout: int = 3600) -> int:
+def _format_duration(seconds: float) -> str:
+    """Format seconds as human-readable duration."""
+    m, s = divmod(int(seconds), 60)
+    h, m = divmod(m, 60)
+    if h:
+        return f"{h}h {m:02d}m {s:02d}s"
+    if m:
+        return f"{m}m {s:02d}s"
+    return f"{s}s"
+
+
+def _run(cmd: list[str], env: dict, timeout: int = 3600) -> tuple[int, float]:
     """Run a vera-bench command, streaming output.
 
     Args:
         timeout: Maximum seconds per target (default 60 minutes).
+
+    Returns:
+        Tuple of (return_code, elapsed_seconds).
     """
     print(f"\n{'=' * 60}")
     print(f"Running: {' '.join(cmd)}")
     print(f"{'=' * 60}\n")
+    t0 = time.monotonic()
     try:
         result = subprocess.run(cmd, env=env, check=False, timeout=timeout)
     except subprocess.TimeoutExpired:
-        print(f"\nTIMEOUT after {timeout}s: {' '.join(cmd)}")
-        return 1
-    return result.returncode
+        elapsed = time.monotonic() - t0
+        print(f"\nTIMEOUT after {_format_duration(elapsed)}: {' '.join(cmd)}")
+        return 1, elapsed
+    elapsed = time.monotonic() - t0
+    print(f"\nCompleted in {_format_duration(elapsed)}")
+    return result.returncode, elapsed
 
 
 def main():
@@ -247,27 +269,54 @@ def main():
         )
 
     # Run all targets
-    results = {}
+    results: dict[str, dict] = {}
+    run_start = time.monotonic()
     for name, cmd in targets:
-        rc = _run(cmd, env)
-        results[name] = "PASS" if rc == 0 else f"FAIL (exit {rc})"
+        rc, elapsed = _run(cmd, env)
+        results[name] = {
+            "status": "PASS" if rc == 0 else f"FAIL (exit {rc})",
+            "elapsed": elapsed,
+        }
+    total_elapsed = time.monotonic() - run_start
 
     # Summary
     print(f"\n{'=' * 60}")
     print("Summary")
     print(f"{'=' * 60}\n")
-    for name, status in results.items():
-        print(f"  {name}: {status}")
+    name_width = max(len(n) for n in results)
+    for name, info in results.items():
+        duration = _format_duration(info["elapsed"])
+        print(f"  {name:<{name_width}}  {info['status']:<16} {duration:>12}")
+    total_dur = _format_duration(total_elapsed)
+    print(f"\n  {'Total':<{name_width}}  {'':<16} {total_dur:>12}")
+
+    # Write timing.json
+    timing_path = Path("results") / "timing.json"
+    timing_path.parent.mkdir(parents=True, exist_ok=True)
+    timing_data = {
+        "model": model,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "total_seconds": round(total_elapsed, 1),
+        "targets": {
+            name: {
+                "status": info["status"],
+                "seconds": round(info["elapsed"], 1),
+            }
+            for name, info in results.items()
+        },
+    }
+    timing_path.write_text(json.dumps(timing_data, indent=2) + "\n", encoding="utf-8")
+    print(f"\nTiming written to {timing_path}")
 
     # Generate report
     print(f"\n{'=' * 60}")
     print("Generating report...")
     print(f"{'=' * 60}\n")
-    report_rc = _run(["vera-bench", "report", "results/"], env)
+    report_rc, _ = _run(["vera-bench", "report", "results/"], env)
     if report_rc != 0:
         print(f"\nWarning: report generation failed (exit {report_rc})")
 
-    failed = sum(1 for s in results.values() if "FAIL" in s)
+    failed = sum(1 for info in results.values() if "FAIL" in info["status"])
     if failed:
         print(f"\n{failed} target(s) failed.")
         return 1


### PR DESCRIPTION
## Summary

- Log start time and elapsed duration for each benchmark target
- Show per-target timing in the summary table (aligned columns with human-readable durations)
- Write `results/timing.json` with model, timestamps, and per-target seconds for programmatic analysis
- Total wall-clock time shown at the bottom of the summary

Closes #51

## Example summary output

```
  Vera full-spec      PASS                  4m 12s
  Vera spec-from-NL   PASS                  3m 58s
  Python LLM          PASS                  1m 22s
  Kimi K2.5           PASS                 48m 03s

  Total                                  57m 35s
```

## Test plan

- [x] `ruff check .` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Benchmark runs now show per-target and total elapsed time in a human‑readable format.
  * Run timing is persistently exported to a results file with run metadata, timestamps and per‑target durations.

* **Improvements**
  * Reporting now includes aligned timing for each benchmark target and overall run.
  * Failure counting and report generation updated to work with the new structured results and explicit status fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->