### PR TITLE
Report T1-T4 aggregate separately for cross-language comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Report shows separate "All Tiers (T1–T5)" and "Comparable (T1–T4)" summary
+  sections for cross-language comparison (#50)
+- `exclude_tiers` parameter on `compute_metrics()` for tier-filtered aggregation
+- Methodology note explaining why T5 is reported separately
+
+### Changed
+
+- Comparable section is suppressed when no T1–T4 problems are present
+
 ## [0.0.8] - 2026-04-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ For each problem, we measure:
 
 The same problems are also run in Python, TypeScript, and [Aver](https://github.com/jasisz/aver) as baselines. Aver is a Haskell-inspired language with zero LLM training data, providing a second data point alongside Vera for the zero-training-data thesis.
 
+> **Cross-language comparison:** For cross-language headline rates, use the T1–T4 aggregate. Tier 5 tests Vera's algebraic effect handlers, which other languages solve with fundamentally different native idioms. See [#50](https://github.com/aallan/vera-bench/issues/50).
+
 ## Prerequisites
 
 * Python 3.11+

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -227,6 +227,43 @@ class TestMetrics:
         assert m.total_problems == 0
         assert m.check_rate is None
 
+    def test_exclude_tiers(self):
+        results = self._make_results() + [
+            {
+                "problem_id": "VB-T5-001",
+                "attempt": 1,
+                "check_pass": True,
+                "verify_pass": True,
+                "run_correct": True,
+            },
+        ]
+        m_all = compute_metrics(results)
+        m_no_t5 = compute_metrics(results, exclude_tiers={5})
+
+        assert m_all.total_problems == 5
+        assert 5 in m_all.by_tier
+        assert m_no_t5.total_problems == 4
+        assert 5 not in m_no_t5.by_tier
+        assert m_no_t5.check_rate == 0.5
+
+    def test_exclude_tiers_none_is_default(self):
+        results = self._make_results()
+        m1 = compute_metrics(results)
+        m2 = compute_metrics(results, exclude_tiers=None)
+        assert m1.total_problems == m2.total_problems
+        assert m1.check_rate == m2.check_rate
+
+    def test_exclude_tiers_empty_set(self):
+        results = self._make_results() + [
+            {
+                "problem_id": "VB-T5-001",
+                "attempt": 1,
+                "check_pass": True,
+            },
+        ]
+        m = compute_metrics(results, exclude_tiers=set())
+        assert m.total_problems == 5
+
     def test_jsonl_round_trip(self, tmp_path):
         results = self._make_results()
         path = tmp_path / "test.jsonl"
@@ -276,7 +313,44 @@ class TestReport:
             assert "VeraBench Results" in report
             assert "test-model" in report
             assert "VB-T1-001" in report
+            assert "All Tiers" in report
+            assert "Comparable" in report
             assert (Path(d) / "summary.md").exists()
+
+    def test_report_t1t4_shows_different_counts(self):
+        from vera_bench.report import generate_report
+
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "test-model.jsonl"
+            lines = [
+                json.dumps(
+                    {
+                        "problem_id": "VB-T1-001",
+                        "attempt": 1,
+                        "check_pass": True,
+                        "run_correct": True,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "problem_id": "VB-T5-001",
+                        "attempt": 1,
+                        "check_pass": True,
+                        "run_correct": True,
+                    }
+                ),
+            ]
+            p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+            report = generate_report(Path(d))
+            all_section, comparable_section = report.split(
+                "### Comparable",
+                1,
+            )
+            # All tiers: 2 problems
+            assert "| test-model | 100% | - | - | 100% | 2 |" in all_section
+            # T1-T4 comparable: 1 problem
+            assert "| test-model | 100% | - | - | 100% | 1 |" in comparable_section
+            assert "Tier 5 tests algebraic effect handlers" in report
 
 
 # === run_single_problem with mocks ===

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -347,10 +347,33 @@ class TestReport:
                 1,
             )
             # All tiers: 2 problems
-            assert "| test-model | 100% | - | - | 100% | 2 |" in all_section
+            assert "test-model" in all_section
+            assert "| 2 |" in all_section
             # T1-T4 comparable: 1 problem
-            assert "| test-model | 100% | - | - | 100% | 1 |" in comparable_section
+            assert "test-model" in comparable_section
+            assert "| 1 |" in comparable_section
             assert "Tier 5 tests algebraic effect handlers" in report
+
+    def test_report_comparable_hidden_when_only_t5(self):
+        from vera_bench.report import generate_report
+
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "test-model.jsonl"
+            p.write_text(
+                json.dumps(
+                    {
+                        "problem_id": "VB-T5-001",
+                        "attempt": 1,
+                        "check_pass": True,
+                        "run_correct": True,
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            report = generate_report(Path(d))
+            assert "All Tiers" in report
+            assert "### Comparable" not in report
 
 
 # === run_single_problem with mocks ===

--- a/vera_bench/metrics.py
+++ b/vera_bench/metrics.py
@@ -38,13 +38,30 @@ def load_results(path: Path) -> list[dict]:
     return results
 
 
-def compute_metrics(results: list[dict]) -> BenchmarkMetrics:
-    """Compute aggregate metrics from result records."""
+def compute_metrics(
+    results: list[dict],
+    *,
+    exclude_tiers: set[int] | None = None,
+) -> BenchmarkMetrics:
+    """Compute aggregate metrics from result records.
+
+    If exclude_tiers is provided, problems in those tiers are filtered out
+    before computing aggregates. Useful for T1-T4 cross-language comparison
+    where T5 tests fundamentally different capabilities per language.
+    """
     # Group by problem_id
     by_problem: dict[str, list[dict]] = {}
     for r in results:
         pid = r.get("problem_id", "")
         by_problem.setdefault(pid, []).append(r)
+
+    # Filter out excluded tiers
+    if exclude_tiers:
+        by_problem = {
+            pid: attempts
+            for pid, attempts in by_problem.items()
+            if _tier_from_id(pid) not in exclude_tiers
+        }
 
     total = len(by_problem)
     if total == 0:

--- a/vera_bench/report.py
+++ b/vera_bench/report.py
@@ -88,26 +88,31 @@ def _summary_table(
         lines.append(_summary_row(model, m))
 
     if comparable_metrics:
-        lines.extend(
-            [
-                "",
-                "### Comparable (T1\u2013T4)\n",
-                _SUMMARY_HEADER,
-                _SUMMARY_SEP,
-            ]
-        )
-        for model, m in sorted(comparable_metrics.items()):
-            lines.append(_summary_row(model, m))
-        lines.extend(
-            [
-                "",
-                "> **Note:** Tier 5 tests algebraic effect handlers "
-                "(State, Exn, IO) unique to Vera. Other languages solve "
-                "these with native idioms (try/except, Result types). "
-                "T1\u2013T4 is the primary cross-language comparison; "
-                "T5 is reported separately.",
-            ]
-        )
+        comparable_rows = [
+            _summary_row(model, m)
+            for model, m in sorted(comparable_metrics.items())
+            if m.total_problems > 0
+        ]
+        if comparable_rows:
+            lines.extend(
+                [
+                    "",
+                    "### Comparable (T1\u2013T4)\n",
+                    _SUMMARY_HEADER,
+                    _SUMMARY_SEP,
+                ]
+            )
+            lines.extend(comparable_rows)
+            lines.extend(
+                [
+                    "",
+                    "> **Note:** Tier 5 tests algebraic effect handlers "
+                    "(State, Exn, IO) unique to Vera. Other languages solve "
+                    "these with native idioms (try/except, Result types). "
+                    "T1\u2013T4 is the primary cross-language comparison; "
+                    "T5 is reported separately.",
+                ]
+            )
 
     return "\n".join(lines) + "\n"
 

--- a/vera_bench/report.py
+++ b/vera_bench/report.py
@@ -23,6 +23,7 @@ def generate_report(results_dir: Path) -> str:
 
     all_model_results: dict[str, list[dict]] = {}
     all_model_metrics: dict[str, BenchmarkMetrics] = {}
+    all_model_metrics_t1t4: dict[str, BenchmarkMetrics] = {}
 
     for jf in jsonl_files:
         model_name = jf.stem
@@ -30,13 +31,16 @@ def generate_report(results_dir: Path) -> str:
         if results:
             all_model_results[model_name] = results
             all_model_metrics[model_name] = compute_metrics(results)
+            all_model_metrics_t1t4[model_name] = compute_metrics(
+                results, exclude_tiers={5}
+            )
 
     if not all_model_metrics:
         return "No results to report.\n"
 
     sections = [
         "# VeraBench Results\n",
-        _summary_table(all_model_metrics),
+        _summary_table(all_model_metrics, all_model_metrics_t1t4),
         _tier_breakdown(all_model_metrics),
         _per_problem_detail(all_model_results),
     ]
@@ -55,23 +59,56 @@ def _pct(rate: float | None) -> str:
     return f"{rate * 100:.0f}%"
 
 
+_SUMMARY_HEADER = "| Model | check@1 | verify@1 | fix@1 | run_correct | Problems |"
+_SUMMARY_SEP = "|-------|---------|----------|-------|-------------|----------|"
+
+
+def _summary_row(model: str, m: BenchmarkMetrics) -> str:
+    return (
+        f"| {model} "
+        f"| {_pct(m.check_rate)} "
+        f"| {_pct(m.verify_rate)} "
+        f"| {_pct(m.fix_rate)} "
+        f"| {_pct(m.run_correct_rate)} "
+        f"| {m.total_problems} |"
+    )
+
+
 def _summary_table(
     all_metrics: dict[str, BenchmarkMetrics],
+    comparable_metrics: dict[str, BenchmarkMetrics] | None = None,
 ) -> str:
     lines = [
         "## Summary\n",
-        "| Model | check@1 | verify@1 | fix@1 | run_correct | Problems |",
-        "|-------|---------|----------|-------|-------------|----------|",
+        "### All Tiers (T1\u2013T5)\n",
+        _SUMMARY_HEADER,
+        _SUMMARY_SEP,
     ]
     for model, m in sorted(all_metrics.items()):
-        lines.append(
-            f"| {model} "
-            f"| {_pct(m.check_rate)} "
-            f"| {_pct(m.verify_rate)} "
-            f"| {_pct(m.fix_rate)} "
-            f"| {_pct(m.run_correct_rate)} "
-            f"| {m.total_problems} |"
+        lines.append(_summary_row(model, m))
+
+    if comparable_metrics:
+        lines.extend(
+            [
+                "",
+                "### Comparable (T1\u2013T4)\n",
+                _SUMMARY_HEADER,
+                _SUMMARY_SEP,
+            ]
         )
+        for model, m in sorted(comparable_metrics.items()):
+            lines.append(_summary_row(model, m))
+        lines.extend(
+            [
+                "",
+                "> **Note:** Tier 5 tests algebraic effect handlers "
+                "(State, Exn, IO) unique to Vera. Other languages solve "
+                "these with native idioms (try/except, Result types). "
+                "T1\u2013T4 is the primary cross-language comparison; "
+                "T5 is reported separately.",
+            ]
+        )
+
     return "\n".join(lines) + "\n"
 
 


### PR DESCRIPTION
## Summary

- Add `exclude_tiers` parameter to `compute_metrics()` for tier-filtered aggregation
- Report shows "All Tiers (T1–T5)" and "Comparable (T1–T4)" sections in summary table
- Methodology note explains why T5 is reported separately
- README note directs readers to T1–T4 for cross-language headline rates

## Context

Tier 5 tests algebraic effect handlers (`State`, `Exn`, `IO`) unique to Vera. Python uses `try/except`, TypeScript uses `try/catch`, Aver uses `Result<T,E>` and recursion. Cross-language T5 comparison is apples-to-oranges.

Discussed in PR #48, formalized in #50.

## Changes

- `vera_bench/metrics.py` — `compute_metrics(results, *, exclude_tiers={5})` filters problems before aggregation
- `vera_bench/report.py` — two summary sections + methodology note; extracted `_SUMMARY_HEADER`, `_SUMMARY_SEP`, `_summary_row()` to avoid duplication
- `README.md` — cross-language comparison note
- `tests/test_runner.py` — tests for tier filtering, backward compatibility, report rendering

## Test plan

- [x] `exclude_tiers={5}` correctly removes T5 from aggregates
- [x] `exclude_tiers=None` and `exclude_tiers=set()` preserve existing behavior
- [x] Report renders both sections with correct problem counts
- [x] 434 tests pass, 85.5% coverage, triple ruff clean

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how to compute cross-language headline rates and explained why Tier 5 is reported separately; changelog notes Comparable section suppression when no T1–T4 problems exist.

* **New Features**
  * Reports show separate metric tables for All Tiers (T1–T5) and Comparable (T1–T4).
  * Added option to exclude specific tiers from metric aggregation.

* **Tests**
  * Expanded tests for tier-exclusion behaviour and report rendering scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->