### PR TITLE
Fix Cloudflare 403 on Aver llms.txt fetch

### DIFF
--- a/vera_bench/prompts.py
+++ b/vera_bench/prompts.py
@@ -18,6 +18,15 @@ _WRITE_INSTRUCTION = (
 SKILL_MD_URL = "https://veralang.dev/SKILL.md"
 AVER_LLMS_TXT_URL = "https://averlang.dev/llms.txt"
 
+_USER_AGENT = "vera-bench/0.0.9"
+
+
+def _fetch_url(url: str, *, timeout: int = 10) -> str:
+    """Fetch a URL with a proper User-Agent (avoids Cloudflare 403s)."""
+    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+        return resp.read().decode("utf-8")
+
 
 def load_skill_md(source: str | Path | None = None) -> str:
     """Load SKILL.md from a URL or local file.
@@ -32,10 +41,7 @@ def load_skill_md(source: str | Path | None = None) -> str:
     source_str = str(source)
     if source_str.startswith("http"):
         try:
-            with urllib.request.urlopen(  # noqa: S310
-                source_str, timeout=10
-            ) as resp:
-                return resp.read().decode("utf-8")
+            return _fetch_url(source_str)
         except (urllib.error.URLError, OSError) as e:
             raise RuntimeError(
                 f"Failed to fetch SKILL.md from {source_str}: {e}\n"
@@ -58,10 +64,7 @@ def load_aver_llms_txt(source: str | Path | None = None) -> str:
     source_str = str(source)
     if source_str.startswith("http"):
         try:
-            with urllib.request.urlopen(  # noqa: S310
-                source_str, timeout=10
-            ) as resp:
-                return resp.read().decode("utf-8")
+            return _fetch_url(source_str)
         except (urllib.error.URLError, OSError) as e:
             raise RuntimeError(
                 f"Failed to fetch llms.txt from {source_str}: {e}\n"

--- a/vera_bench/prompts.py
+++ b/vera_bench/prompts.py
@@ -23,7 +23,7 @@ _USER_AGENT = "vera-bench/0.0.9"
 
 def _fetch_url(url: str, *, timeout: int = 10) -> str:
     """Fetch a URL with a proper User-Agent (avoids Cloudflare 403s)."""
-    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})  # noqa: S310
     with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
         return resp.read().decode("utf-8")
 


### PR DESCRIPTION
## Summary
- Python's default urllib User-Agent (`Python-urllib/3.14`) is blocked by Cloudflare on averlang.dev, causing `--language aver` to crash with HTTP 403
- Extracts a shared `_fetch_url()` helper that sends `vera-bench/0.0.9` as User-Agent
- Fixes both SKILL.md and llms.txt fetches (veralang.dev could hit the same issue any time)

## Test plan
- [x] `load_aver_llms_txt()` returns 11702 chars successfully
- [x] `load_skill_md()` returns 72260 chars successfully

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal HTTP fetching now sends a consistent user-agent to improve server compatibility and request tracking. Behaviour for local files and existing error handling is unchanged, so user-visible functionality remains the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->