### PR TITLE
aver: strip module-level effects before injecting test main (planned 0.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.10] - 2026-04-29
+
+### Changed
+
+- Aver evaluation harness strips module-header `effects [...]` declarations
+  before injecting the test main (#62). The injected main needs
+  `! [Console.print]`, which would violate any narrower boundary the LLM
+  declared (including the common `effects []` for "pure" modules) once
+  Aver 0.13 ships and enforces the boundary as a hard type error.
+- The strip is window-scoped (only fires inside the module-header block,
+  not on `effects [...]`-shaped lines elsewhere), tolerates arbitrary
+  whitespace between `effects` and `[`, and tolerates trailing line
+  comments after the closing `]`.
+
+### Compatibility note
+
+This is a methodology change for Aver scoring: the same LLM output now
+goes through an extra strip pass before reaching the compiler. On Aver
+0.12 and earlier the strip is a no-op (LLMs don't emit module-level
+`effects [...]` because the docs don't yet describe it), so today's
+Aver scores are byte-identical to v0.0.9. Once Aver 0.13 ships and the
+boundary becomes part of the doc nudge to models, Aver `run_correct`
+rates from v0.0.10 onwards will diverge from any v0.0.9-tagged Aver
+results run against Aver 0.13+ — the strip will activate on a measurable
+fraction of generations and prevent the underdeclared-effects type
+error. Result files are tagged with `bench_version` so cross-version
+comparisons can detect this boundary.
+
+Vera, Vera spec-from-NL, Python, and TypeScript scoring is unaffected.
+
 ## [0.0.9] - 2026-04-16
 
 ### Added
@@ -161,7 +191,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Claude Sonnet 4: 96% check@1, 96% verify@1, 83% run_correct (50 problems, full-spec mode)
 - Python canonical baselines: 100% run_correct (24 testable problems)
 
-[Unreleased]: https://github.com/aallan/vera-bench/compare/v0.0.9...HEAD
+[Unreleased]: https://github.com/aallan/vera-bench/compare/v0.0.10...HEAD
+[0.0.10]: https://github.com/aallan/vera-bench/compare/v0.0.9...v0.0.10
 [0.0.9]: https://github.com/aallan/vera-bench/compare/v0.0.8...v0.0.9
 [0.0.8]: https://github.com/aallan/vera-bench/compare/v0.0.7...v0.0.8
 [0.0.7]: https://github.com/aallan/vera-bench/compare/v0.0.6...v0.0.7

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 title: "VeraBench: a benchmark suite for LLM code generation in Vera"
 message: "If you use this benchmark, please cite it as below."
 type: software
-version: "0.0.9"
-date-released: "2026-04-16"
+version: "0.0.10"
+date-released: "2026-04-29"
 authors:
   - given-names: Alasdair
     family-names: Allan

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,8 @@
 
 ## Where we are
 
+**v0.0.10** — Aver evaluation harness strips module-header `effects [...]` declarations before injecting the test main, so canonical and LLM-generated solutions continue to compile under Aver 0.13's enforced effects boundary. No-op on Aver 0.12 and earlier; methodology change documented in CHANGELOG.
+
 **v0.0.9** — 60 problems across 5 tiers (10 new T2/T3 problems with testable signatures). T1–T4 `run_correct` pool expanded from 18 to 30 testable problems. New T3 problems use Int-only signatures with internal ADT construction for CLI testability.
 
 **v0.0.8** — 50 problems across 5 tiers with strengthened postconditions and explicit slot ordering descriptions. Working LLM harness (Anthropic, OpenAI, Moonshot), Python, TypeScript, and Aver baseline runners, cross-language generation comparison. Full benchmark runner script. SKILL.md and Aver's llms.txt fetched at runtime. Language-neutral problem descriptions (`description_neutral`) for fair cross-language prompting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vera-bench"
-version = "0.0.9"
+version = "0.0.10"
 description = "HumanEval/MBPP-style benchmark for the Vera programming language"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -936,6 +936,35 @@ class TestStripModuleEffects:
         result = _strip_module_effects(code)
         assert result == code
 
+    def test_no_op_when_no_module_declaration(self):
+        # Without a `module X` header there is no module-effect
+        # boundary to strip; an `effects [...]` token at the top
+        # level is something else, so we must leave the code
+        # untouched. The bench-side wrapper synthesises a `module
+        # Test{safe_id}` for these cases — it never owned the
+        # boundary in the first place.
+        code = 'effects [Console.print]\n\nfn f() -> Unit\n    Console.print("hi")\n'
+        result = _strip_module_effects(code)
+        assert result == code
+
+    def test_only_strips_inside_module_header(self):
+        # An `effects [...]`-shaped line that appears below a
+        # function body must not be removed; only the module-header
+        # occurrence is the bench's concern.
+        code = (
+            "module M\n"
+            '    intent = "t"\n'
+            "    effects [Console.print]\n"
+            "\n"
+            "fn f() -> Unit\n"
+            "    effects [Console.print]\n"
+            '    Console.print("hi")\n'
+        )
+        result = _strip_module_effects(code)
+        lines = result.split("\n")
+        # Header `effects` line gone, fn-body `effects` line kept.
+        assert sum(1 for line in lines if "effects [Console.print]" in line) == 1
+
 
 class TestEvaluateAverCode:
     def _sample_problem(self, test_cases=None):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -986,6 +986,50 @@ class TestStripModuleEffects:
         # Header `effects` line gone, fn-body `effects` line kept.
         assert sum(1 for line in lines if "effects [Console.print]" in line) == 1
 
+    def test_strips_inline_effects_with_trailing_comment(self):
+        # Aver allows `// ...` line comments; an inline `effects
+        # [...] // comment` declaration must be detected as
+        # single-line, not fall into the multi-line skip path that
+        # would chew through the function body.
+        code = (
+            "module M\n"
+            '    intent = "t"\n'
+            "    effects [Console.print] // pure module\n"
+            "\n"
+            "fn f() -> Unit\n"
+            "    ! [Console.print]\n"
+            '    Console.print("hi")\n'
+        )
+        result = _strip_module_effects(code)
+        # Header `effects` line is gone.
+        assert "effects [Console.print]" not in result
+        # And critically: the function body is intact, NOT eaten by
+        # a runaway skip_until_close.
+        assert "fn f() -> Unit" in result
+        assert 'Console.print("hi")' in result
+
+    def test_strips_multiline_effects_with_trailing_comment_on_close(self):
+        # Same hazard on the closing line of a multi-line list:
+        # `]` can be followed by a trailing comment.
+        code = (
+            "module M\n"
+            '    intent = "t"\n'
+            "    effects [\n"
+            "        Console.print,\n"
+            "    ] // pure module\n"
+            "\n"
+            "fn f() -> Unit\n"
+            "    ! [Console.print]\n"
+            '    Console.print("hi")\n'
+        )
+        result = _strip_module_effects(code)
+        # Whole effects block gone (header through close).
+        assert "effects [" not in result
+        assert "Console.print," not in result
+        # Function body intact.
+        assert "fn f() -> Unit" in result
+        assert 'Console.print("hi")' in result
+
 
 class TestEvaluateAverCode:
     def _sample_problem(self, test_cases=None):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -947,6 +947,27 @@ class TestStripModuleEffects:
         result = _strip_module_effects(code)
         assert result == code
 
+    def test_strips_arbitrary_whitespace_between_keyword_and_bracket(self):
+        # LLM-formatted output may emit any whitespace between
+        # `effects` and `[`; the strip must catch every variant the
+        # Aver parser accepts, not just the canonical single space.
+        for opener in ("effects[", "effects [", "effects  [", "effects\t["):
+            code = (
+                "module M\n"
+                '    intent = "t"\n'
+                f"    {opener}Console.print]\n"
+                "\n"
+                "fn f() -> Unit\n"
+                "    ! [Console.print]\n"
+                '    Console.print("hi")\n'
+            )
+            result = _strip_module_effects(code)
+            header_part = result.split("fn f")[0]
+            assert "Console.print]" not in header_part, (
+                f"failed to strip header with opener: {opener!r}"
+            )
+            assert "fn f" in result
+
     def test_only_strips_inside_module_header(self):
         # An `effects [...]`-shaped line that appears below a
         # function body must not be removed; only the module-header

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -17,6 +17,7 @@ from vera_bench.runner import (
     ProblemResult,
     _aver_literal,
     _strip_aver_main,
+    _strip_module_effects,
     extract_code,
     extract_vera_code,
 )
@@ -880,6 +881,60 @@ class TestStripAverMain:
         result = _strip_aver_main(code)
         assert "fn main" not in result
         assert "fn bar" in result
+
+
+class TestStripModuleEffects:
+    def test_removes_inline_empty_effects(self):
+        code = (
+            "module M\n"
+            '    intent = "t"\n'
+            "    effects []\n"
+            "\n"
+            "fn f(x: Int) -> Int\n"
+            "    x + 1\n"
+        )
+        result = _strip_module_effects(code)
+        assert "effects []" not in result
+        assert "fn f" in result
+        assert "module M" in result
+
+    def test_removes_inline_listed_effects(self):
+        code = (
+            "module M\n"
+            '    intent = "t"\n'
+            "    effects [Console.print, Disk.readText]\n"
+            "\n"
+            "fn f() -> Unit\n"
+            "    ! [Console.print]\n"
+            '    Console.print("hi")\n'
+        )
+        result = _strip_module_effects(code)
+        assert "effects [" not in result
+        assert "fn f" in result
+        assert "Console.print" in result  # body still has it
+
+    def test_removes_multiline_effects(self):
+        code = (
+            "module M\n"
+            '    intent = "t"\n'
+            "    effects [\n"
+            "        Console.print,\n"
+            "        Disk.readText,\n"
+            "    ]\n"
+            "\n"
+            "fn f() -> Unit\n"
+            "    ! [Console.print]\n"
+            '    Console.print("hi")\n'
+        )
+        result = _strip_module_effects(code)
+        assert "effects [" not in result
+        assert "Disk.readText" not in result.split("fn f")[0]
+        assert "fn f" in result
+
+    def test_no_op_when_no_effects(self):
+        code = 'module M\n    intent = "t"\n\nfn f(x: Int) -> Int\n    x + 1\n'
+        result = _strip_module_effects(code)
+        assert result == code
 
 
 class TestEvaluateAverCode:

--- a/vera_bench/runner.py
+++ b/vera_bench/runner.py
@@ -576,23 +576,49 @@ def _strip_module_effects(code: str) -> str:
     common `effects []` for "pure" modules). Stripping the line
     returns the module to legacy / no-boundary mode where the
     injected main type-checks.
+
+    Scoped to the module-header window: we start matching after a
+    top-level `module X` line and stop at the next top-level item
+    (a non-indented, non-blank, non-comment line). Outside that
+    window any `effects [...]` we see is left alone — it isn't the
+    boundary declaration this strip was written for.
     """
     lines = code.split("\n")
     out = []
+    in_module_header = False
     skip_until_close = False
     for line in lines:
         stripped = line.strip()
+        indent_len = len(line) - len(line.lstrip(" "))
+
         if skip_until_close:
             # Multi-line `effects [\n  ...\n]` — drop everything up to
             # and including the line that closes the bracket.
             if stripped.endswith("]"):
                 skip_until_close = False
             continue
-        # Module-header `effects [...]` lives at indent > 0 directly
-        # under `module X`. Match by prefix; we don't bother tracking
-        # the header window because effect-list lines never appear
-        # outside a module header in valid Aver.
-        if stripped.startswith("effects [") or stripped.startswith("effects["):
+
+        # Track the module-header window. The header runs from the
+        # `module X` line through the last indented line before the
+        # next top-level item (mirrors how the Aver parser scopes
+        # `intent` / `exposes` / `depends` / `effects`).
+        if indent_len == 0 and stripped.startswith("module "):
+            in_module_header = True
+            out.append(line)
+            continue
+        if (
+            in_module_header
+            and indent_len == 0
+            and stripped
+            and not stripped.startswith("//")
+        ):
+            in_module_header = False
+
+        if (
+            in_module_header
+            and indent_len > 0
+            and (stripped.startswith("effects [") or stripped.startswith("effects["))
+        ):
             if stripped.endswith("]"):
                 continue
             skip_until_close = True

--- a/vera_bench/runner.py
+++ b/vera_bench/runner.py
@@ -596,8 +596,11 @@ def _strip_module_effects(code: str) -> str:
 
         if skip_until_close:
             # Multi-line `effects [\n  ...\n]` — drop everything up to
-            # and including the line that closes the bracket.
-            if stripped.endswith("]"):
+            # and including the line that closes the bracket. Use
+            # presence rather than `endswith("]")` so a trailing line
+            # comment (Aver's `// ...` syntax) doesn't make us miss
+            # the close and chew through the rest of the file.
+            if "]" in stripped:
                 skip_until_close = False
             continue
 
@@ -622,7 +625,11 @@ def _strip_module_effects(code: str) -> str:
             and indent_len > 0
             and _AVER_EFFECTS_OPEN_RE.match(stripped)
         ):
-            if stripped.endswith("]"):
+            # Same `]`-presence rule as the skip_until_close branch —
+            # tolerates `effects [...] // pure module` (single-line
+            # declaration with a trailing comment) without falling into
+            # the multi-line skip path that would eat the function body.
+            if "]" in stripped:
                 continue
             skip_until_close = True
             continue

--- a/vera_bench/runner.py
+++ b/vera_bench/runner.py
@@ -477,7 +477,11 @@ def _evaluate_aver_code(
 
     # Strategy: strip any existing main() from the LLM code and replace
     # with our own that calls the entry_point with specific test args.
-    code_without_main = _strip_aver_main(code)
+    # Also drop any module-level `effects [...]` boundary the LLM
+    # declared — Aver 0.13+ enforces it as a hard type error, but the
+    # injected main needs `! [Console.print]` which the original
+    # boundary may not cover.
+    code_without_main = _strip_module_effects(_strip_aver_main(code))
 
     all_pass = True
     for i, tc in enumerate(test_cases):
@@ -560,6 +564,41 @@ def _strip_aver_main(code: str) -> str:
         if not skip:
             result_lines.append(line)
     return "\n".join(result_lines)
+
+
+def _strip_module_effects(code: str) -> str:
+    """Remove the module header's `effects [...]` declaration if present.
+
+    Aver 0.13+ enforces that every function's `! [Effect]` is covered
+    by the module's declared `effects [...]` boundary. The bench
+    injects its own `fn main()` with `! [Console.print]`, which would
+    violate any narrower boundary the LLM declared (including the
+    common `effects []` for "pure" modules). Stripping the line
+    returns the module to legacy / no-boundary mode where the
+    injected main type-checks.
+    """
+    lines = code.split("\n")
+    out = []
+    skip_until_close = False
+    for line in lines:
+        stripped = line.strip()
+        if skip_until_close:
+            # Multi-line `effects [\n  ...\n]` — drop everything up to
+            # and including the line that closes the bracket.
+            if stripped.endswith("]"):
+                skip_until_close = False
+            continue
+        # Module-header `effects [...]` lives at indent > 0 directly
+        # under `module X`. Match by prefix; we don't bother tracking
+        # the header window because effect-list lines never appear
+        # outside a module header in valid Aver.
+        if stripped.startswith("effects [") or stripped.startswith("effects["):
+            if stripped.endswith("]"):
+                continue
+            skip_until_close = True
+            continue
+        out.append(line)
+    return "\n".join(out)
 
 
 def _aver_literal(value) -> str:

--- a/vera_bench/runner.py
+++ b/vera_bench/runner.py
@@ -566,6 +566,9 @@ def _strip_aver_main(code: str) -> str:
     return "\n".join(result_lines)
 
 
+_AVER_EFFECTS_OPEN_RE = re.compile(r"^effects\s*\[")
+
+
 def _strip_module_effects(code: str) -> str:
     """Remove the module header's `effects [...]` declaration if present.
 
@@ -617,7 +620,7 @@ def _strip_module_effects(code: str) -> str:
         if (
             in_module_header
             and indent_len > 0
-            and (stripped.startswith("effects [") or stripped.startswith("effects["))
+            and _AVER_EFFECTS_OPEN_RE.match(stripped)
         ):
             if stripped.endswith("]"):
                 continue


### PR DESCRIPTION
## Summary

Aver 0.13 (the upcoming release) introduces a module-level `effects [...]` boundary that the type-checker enforces: every function's `! [Effect]` must be covered, or compilation fails.

The bench harness currently asks the LLM for a function only, then strips the LLM's `main()` and injects its own `Console.print(fn(...))` main with `! [Console.print]`. If the LLM declared a narrower module boundary in the original source — including the very common `effects []` for a "pure" module — the injected main violates that boundary and `aver run` fails with an underdeclared-effects type error before any test case runs.

This PR adds `_strip_module_effects(code)` to the runner, called right after `_strip_aver_main(code)`. It removes the module-header `effects [...]` line (inline or multi-line), so the module reverts to legacy / no-boundary mode and the injected main type-checks.

Compatibility:
- **No-op on Aver 0.12 and earlier** — those versions don't recognise `effects [...]` on the module header, so LLMs don't generate it and the strip pass simply doesn't fire.
- **Necessary the moment Aver 0.13 ships** — once the boundary is enforced, any LLM that follows the language docs and declares it will fail bench without this fix. We measured a 50pp regression on tier1 with claude-haiku-4-5 on 0.13-dev when the doc nudge for `effects []` reaches the model.

So merging now is safe: it doesn't change current behaviour, and it lets `aver-bench` continue to work on the day 0.13 lands without a follow-up rush.

## What changed

- `vera_bench/runner.py`: new `_strip_module_effects(code)` helper, wired into the test-main injection path.
- `tests/test_runner.py`: 4 cases on `TestStripModuleEffects` (inline `[]`, inline list, multi-line list, no-op).

## Test plan

- [x] `pytest tests/test_runner.py` — 101 passed locally
- [x] Full suite `pytest tests/` — 489 passed
- [x] `ruff check` + `ruff format --check` clean
- [x] Tier1 sanity with claude-haiku-4-5 on Aver 0.13-dev: 9/10 (matches Aver 0.12 baseline)

## Context

- Linked discussion: this is the bench-side counterpart to a docs change in jasisz/aver where the language now documents `effects [...]` as a first-class module feature
- VB-T1-007 (`safe_modulo`) remains the one tier1 fail on haiku-4.5 in both old and new world — Result-wrap vs raw Int return — unrelated to this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests covering removal of module-level effects declarations across inline, multi-line and edge-case scenarios.

* **Chores**
  * Improved the evaluation/benchmark pipeline to post-process generated code (removing module-level effects and injected mains) for cleaner, consistently type-checked bench outputs, ensuring more reliable and predictable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->