### PR TITLE
ci: work around CVE-2026-3219 in setup-python's bundled pip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,12 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies and pip-audit
-        run: pip install -e . && pip install pip-audit
+        # pip install --upgrade pip is a workaround for CVE-2026-3219:
+        # the pip 26.0.1 bundled in actions/setup-python@v6 is
+        # vulnerable; pip 26.1 (released 2026-04-26) is the fix.
+        # Remove this once the runner image ships pip >= 26.1
+        # natively. See issue #63.
+        run: pip install --upgrade pip && pip install -e . && pip install pip-audit
 
       - name: Audit dependencies for known CVEs
         run: pip-audit --skip-editable

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,0 +1,126 @@
+# Known issues and workarounds
+
+This file collects active workarounds, dev-environment gotchas, and
+analytical caveats that don't have a more natural home in the codebase.
+Entries are deliberately written to include their *exit condition* — the
+specific event that lets us remove the workaround or close the caveat —
+so they don't quietly outlive their reason.
+
+For tracked feature work and roadmap items, see [ROADMAP.md](ROADMAP.md).
+For language gotchas (Vera and Aver syntax rules), see
+[CLAUDE.md](CLAUDE.md).
+
+---
+
+## CI workarounds
+
+### CI: `pip install --upgrade pip` in the dependency-audit job
+
+**File:** `.github/workflows/ci.yml`, `dependency-audit` job
+**Tracking issue:** [#63](https://github.com/aallan/vera-bench/issues/63)
+**Related:** [aallan/vera#537](https://github.com/aallan/vera/issues/537)
+(same workaround, same root cause)
+
+[CVE-2026-3219](https://nvd.nist.gov/vuln/detail/CVE-2026-3219) is a
+vulnerability in pip 26.0.1's archive handling. It was fixed in pip 26.1
+(released 2026-04-26). However, `actions/setup-python@v6` bakes pip
+26.0.1 into its Python 3.12 toolchain image, so `pip-audit` running
+inside the runner reports the runner's own pip as vulnerable until
+GitHub refreshes the toolchain image.
+
+The workaround is a `pip install --upgrade pip` step before `pip-audit`
+runs, pulling pip 26.1 from PyPI to replace the bundled 26.0.1.
+
+**Removal trigger:** when `actions/setup-python@v6` ships a runner
+image with pip ≥ 26.1 natively, drop the `pip install --upgrade pip &&`
+prefix from the `Install dependencies and pip-audit` step. Verification
+guidance is in issue #63.
+
+---
+
+## Documentation pins
+
+### `assets/results-graph.png` shows v0.0.7 data, not the latest
+
+**File:** `assets/results-graph.png`
+**Documented in:** [scripts/README.md](scripts/README.md#plot_resultspy--benchmark-comparison-chart)
+
+The canonical chart committed to the repo is currently pinned to
+**v0.0.7** content to match the v0.0.7 narrative in the top-level
+README. The benchmark itself is at v0.0.9 (60 problems vs 50), and the
+plotting script's default invocation regenerates from the *current*
+pyproject version — so running `python scripts/plot_results.py` with
+no args overwrites the pinned image with v0.0.9 content.
+
+If you accidentally overwrite the pin, restore with:
+
+```bash
+python scripts/plot_results.py --version 0.0.7 --output assets/results-graph.png
+```
+
+**Removal trigger:** when the v0.0.9 narrative is written up in the
+top-level README, the pin can be released — `python scripts/plot_results.py`
+will then regenerate the canonical chart from current data each time.
+
+---
+
+## Analytical caveats
+
+### `input_tokens` semantic shift across PR #60 (Anthropic prompt caching)
+
+**Affected:** `LLMResponse.input_tokens` for Anthropic models in any
+JSONL written after PR [#60](https://github.com/aallan/vera-bench/pull/60)
+landed (2026-04-17).
+
+Pre-merge: `input_tokens` was the raw count of (system + user) tokens
+sent to the API. Post-merge: it's the **total billed input** —
+uncached tokens, plus cache-write tokens, plus cache-read tokens —
+summed into a single field.
+
+The numerical totals are still meaningful and additive for cost
+estimation, but they're not directly comparable to pre-merge values
+because:
+
+- Pre-#60: each call's `input_tokens` repeated the ~18k-token system
+  prompt for full price.
+- Post-#60: subsequent calls report the cached read at 0.1× price
+  rolled into the same field, so the *count* is comparable but the
+  *per-token cost* implicit in that count is not.
+
+For analyses that need the breakdown, see
+[issue #61](https://github.com/aallan/vera-bench/issues/61) — the
+follow-up to expose `cached_tokens` separately is tracked there.
+
+**Removal trigger:** none — this is a permanent provenance note about
+a metric semantic change. Will eventually move to a CHANGELOG note
+once #61 is resolved and the breakdown is exposed structurally.
+
+---
+
+## Dev-environment gotchas
+
+### `/opt/homebrew/bin/vera` is not the Vera programming language
+
+There is an unrelated Homebrew package that installs a `vera` binary at
+`/opt/homebrew/bin/vera` (a static-analysis tool for C++). It has
+**nothing to do with the Vera programming language** that this
+benchmark targets.
+
+If `which vera` returns `/opt/homebrew/bin/vera`, that's the wrong
+binary. The benchmark needs the Python `vera` from
+[aallan/vera](https://github.com/aallan/vera), installed via:
+
+```bash
+pip install git+https://github.com/aallan/vera.git
+# or, for development:
+git clone https://github.com/aallan/vera.git /tmp/vera
+pip install -e /tmp/vera
+```
+
+Verify with `vera version` — should print `vera 0.0.111` or later, not
+the Homebrew tool's banner.
+
+**Removal trigger:** none — this is a permanent dev-env hazard
+caused by a name collision with an unrelated tool. Will stay until
+either Homebrew's package renames or we ship a wrapper that errors out
+helpfully when invoked from the wrong path.


### PR DESCRIPTION
## Summary

Fixes the `dependency-audit` CI job, which started failing on PR #62 due to [CVE-2026-3219](https://nvd.nist.gov/vuln/detail/CVE-2026-3219) in pip 26.0.1 — the version bundled into `actions/setup-python@v6`'s Python 3.12 toolchain image. The CVE was patched in pip 26.1 on 2026-04-26, but the runner image hasn't refreshed yet, so `pip-audit` running inside the runner reports the runner's own pip as vulnerable regardless of what's available on PyPI.

Same workaround as [aallan/vera#537](https://github.com/aallan/vera/issues/537): `pip install --upgrade pip` before `pip-audit` runs, pulling pip 26.1 from PyPI to replace the bundled 26.0.1.

Also opens `KNOWN_ISSUES.md` as the catalogue location for active workarounds, dev-env gotchas, and analytical caveats. Initial entries cover the CI workaround above plus three pre-existing items that didn't have a natural home before:

| Entry | Why it's worth surfacing |
|-------|--------------------------|
| CI: pip CVE workaround | New (this PR) — tracked in #63 with a clear removal trigger |
| `assets/results-graph.png` v0.0.7 pin | Currently only documented in `scripts/README.md`; cross-references it for visibility |
| `input_tokens` semantic shift across #60 | Not previously documented anywhere; analytical caveat for anyone doing pre-vs-post-caching cost trending |
| `/opt/homebrew/bin/vera` is not the Vera language | Dev-env name-collision gotcha; previously only in private memory |

Each entry has an explicit "removal trigger" so cleanup is straightforward when the underlying conditions change.

## Test plan

- [x] CI workflow change is mechanical and matches the vera#537 fix verbatim
- [x] Inline `# CVE-2026-3219 workaround; see #63` comment in `ci.yml` makes the intent legible at the call site
- [x] KNOWN_ISSUES.md links cleanly to all relevant tracking issues and external CVE references
- [x] No code or test changes — pure CI/docs PR
- [ ] CI green once this lands (the failure is the thing being fixed)

## Closes / related

- Doesn't close #63 — that issue tracks the *removal* of this workaround when GitHub's runner image catches up. Stays open.
- Unblocks #62 (Aver module-effects strip) which is currently red in CI on this same dependency-audit failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Published comprehensive known issues documentation detailing active workarounds across deployment pipelines, documentation versioning, analytics metrics, and development environments, including mitigation steps and resolution timelines.

* **Chores**
  * Updated continuous integration workflow for dependency auditing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->