### PR TITLE
Populate bench_version on baseline JSONL output (closes #66)

### DIFF
--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -237,3 +237,31 @@ class TestBaselinesCLI:
         jsonl_files = list(tmp_path.glob("*.jsonl"))
         assert len(jsonl_files) == 1
         assert jsonl_files[0].name == "python-baseline.jsonl"
+
+    def test_baselines_populates_bench_version(self, tmp_path):
+        # Regression for #66: baseline JSONL lines used to ship with
+        # bench_version="" because the baseline runner didn't plumb
+        # version info. Every row should now carry the installed
+        # bench version.
+        import json
+
+        from click.testing import CliRunner
+
+        import vera_bench
+        from vera_bench.cli import main
+
+        result = CliRunner().invoke(main, ["baselines", "--output-dir", str(tmp_path)])
+        assert result.exit_code == 0
+        jsonl_path = tmp_path / "python-baseline.jsonl"
+        assert jsonl_path.exists()
+
+        lines = [
+            json.loads(ln) for ln in jsonl_path.read_text().splitlines() if ln.strip()
+        ]
+        assert lines, "expected at least one baseline row"
+        for row in lines:
+            assert row.get("bench_version") == vera_bench.__version__, (
+                f"row {row.get('problem_id')!r} has "
+                f"bench_version={row.get('bench_version')!r}, "
+                f"expected {vera_bench.__version__!r}"
+            )

--- a/vera_bench/baseline_runner.py
+++ b/vera_bench/baseline_runner.py
@@ -556,8 +556,17 @@ def run_all_baselines(
     solutions_dir: Path,
     output_path: Path | None = None,
     language: str = "python",
+    bench_version: str = "",
 ) -> list[ProblemResult]:
-    """Run baselines for all problems. Write JSONL incrementally."""
+    """Run baselines for all problems. Write JSONL incrementally.
+
+    Args:
+        bench_version: vera-bench version string (e.g. "0.0.11"). Stamped onto
+            every ProblemResult so baseline JSONL lines self-attribute. The
+            field is part of `ProblemResult` for parity with LLM result files;
+            baselines historically left it empty, which made them hard to
+            attribute across version boundaries (#66).
+    """
     if language not in ("python", "typescript", "aver"):
         raise NotImplementedError(
             f"Baseline runner for {language!r} not yet implemented"
@@ -587,6 +596,11 @@ def run_all_baselines(
             task = progress.add_task("Running baselines...", total=len(run_problems))
             for problem in run_problems:
                 result = runner(problem, solutions_dir, work_dir)
+                # Stamp bench_version centrally rather than threading it
+                # through each per-language runner's ProblemResult call sites
+                # (~18 of them across this file). This keeps the attribution
+                # plumbing in one place.
+                result.bench_version = bench_version
                 all_results.append(result)
 
                 if output_path:

--- a/vera_bench/cli.py
+++ b/vera_bench/cli.py
@@ -305,8 +305,11 @@ def report(results_dir: Path):
 )
 def baselines(language: str, output_dir: Path | None):
     """Run baseline solutions against test cases."""
+    import vera_bench
     from vera_bench.baseline_runner import run_all_baselines
     from vera_bench.metrics import compute_metrics
+
+    bench_ver = vera_bench.__version__
 
     root = _repo_root()
 
@@ -351,6 +354,7 @@ def baselines(language: str, output_dir: Path | None):
         solutions_dir=solutions_dir,
         output_path=output_path,
         language=language,
+        bench_version=bench_ver,
     )
 
     # Print summary


### PR DESCRIPTION
## Summary

Closes #66.

`{python,typescript,aver}-baseline.jsonl` rows shipped with `bench_version=""` because the baseline runner didn't plumb version info, even though the corresponding fields in LLM result files are populated correctly. This PR closes the gap.

## What changed

- **`cli.py:baselines()`** fetches `vera_bench.__version__` and passes it to `run_all_baselines`, mirroring how `cli.py:run()` already handles it for LLM runs.
- **`run_all_baselines()`** accepts a `bench_version` kwarg and stamps it onto every `ProblemResult` between the per-language runner call and the `to_jsonl()` write. Stamping centrally keeps the plumbing in one place rather than threading it through ~18 per-language `ProblemResult` call sites.
- **New regression test** `TestBaselinesCLI::test_baselines_populates_bench_version` loads the produced JSONL via the CliRunner integration path and asserts every row's `bench_version` equals `vera_bench.__version__`.

## No version bump

This is a bugfix — `bench_version` is a field that was always meant to be populated and wasn't. Scoring values are identical (same `run_correct`, same `check_pass`, same problem counts), and pre-fix baselines (`bench_version=""`) vs post-fix baselines (`bench_version="0.0.11"`) carry an unambiguous distinguishing signal with no semantic collision. Mirrors the precedent set by PR #60 (Anthropic prompt caching) which also added attribution-style metadata without a bump.

## Out of scope (deferred to follow-up)

The `vera_version` field is misnamed for non-Vera baselines and isn't populated for any language baseline by this PR. For Aver baselines, the natural attribution would be an `aver_version` field, which doesn't exist on `ProblemResult` today. Adding it would touch the dataclass + LLM runner call sites; that's a separate enhancement noted in the issue.

## Test plan

- [x] `pytest tests/` → 495 passed (494 + 1 new)
- [x] `pytest tests/test_baseline.py -v` → 24 passed (all baseline tests including the new one)
- [x] `ruff check` + `ruff format --check` clean
- [x] End-to-end: regenerated all three baselines locally; every row across 36 + 36 + 60 = 132 rows now has `bench_version: "0.0.11"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Baseline results now include benchmark version information for each run.

* **Tests**
  * Added regression test to verify that version information is correctly captured in baseline output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->