### PR TITLE
Migrate kimi-k2-turbo-preview → kimi-k2.6 (closes #68)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -86,7 +86,7 @@ for model in \
   gpt-4.1-2025-04-14 \
   gpt-4o \
   moonshot/kimi-k2.5 \
-  moonshot/kimi-k2-turbo-preview; do
+  moonshot/kimi-k2.6; do
   python scripts/run_full_benchmark.py --model "$model" --skip-baselines
 done
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -109,10 +109,12 @@ Rough per-model totals observed on v0.0.9 (60 problems, 2026-04):
 | Claude Sonnet 4 | ~15 min |
 | GPT-4.1 / GPT-4o | ~10–12 min |
 | Moonshot K2.5 | ~3.5 h (slow provider; Aver especially) |
-| Moonshot K2 Turbo | ~1.5 h |
+| Moonshot K2.6 | TBD (no sweep against this model yet — see #68) |
+| Moonshot K2 Turbo *(historical; SKU deprecated 2026-05-25)* | ~1.5 h |
 
-The full six-model sweep is dominated by the two Moonshot models. Expect
-5–8 hours end-to-end.
+The Moonshot models dominate the sweep wall-clock; expect 5–8 hours
+end-to-end. K2.6 timings will be filled in after the first full sweep
+once we have data to attribute.
 
 ### Output files
 

--- a/scripts/plot_results.py
+++ b/scripts/plot_results.py
@@ -100,7 +100,11 @@ MODELS: list[ModelSpec] = [
     # Sonnet row
     ModelSpec("Claude Sonnet 4", "claude-sonnet-4-20250514", "sonnet"),
     ModelSpec("GPT-4o", "gpt-4o", "sonnet"),
-    ModelSpec("Kimi K2 Turbo", "moonshot-kimi-k2-turbo-preview", "sonnet"),
+    # K2.6 lands in the sonnet slot for now (replacing kimi-k2-turbo-preview,
+    # deprecated 2026-05-25). Semantically K2.6 is the new flagship-line model
+    # rather than a "secondary/cheaper" variant; tier placement to be revisited
+    # in the next re-sweep — see issue #68.
+    ModelSpec("Kimi K2.6", "moonshot-kimi-k2.6", "sonnet"),
 ]
 
 # Mode label -> glob pattern fragment inserted between prefix and bench-VER.

--- a/scripts/plot_results.py
+++ b/scripts/plot_results.py
@@ -93,18 +93,17 @@ class ModelSpec:
 
 
 MODELS: list[ModelSpec] = [
-    # Flagship row
+    # Flagship row — current top-tier model from each provider.
     ModelSpec("Claude Opus 4", "claude-opus-4-20250514", "flagship"),
     ModelSpec("GPT-4.1", "gpt-4.1-2025-04-14", "flagship"),
-    ModelSpec("Kimi K2.5", "moonshot-kimi-k2.5", "flagship"),
-    # Sonnet row
+    ModelSpec("Kimi K2.6", "moonshot-kimi-k2.6", "flagship"),
+    # Sonnet row — previous-generation / secondary slot from each provider.
+    # Kimi K2.5 moves here from flagship after Moonshot promoted K2.6 to
+    # the active flagship-line slot (kimi-k2-turbo-preview deprecated
+    # 2026-05-25, see #68).
     ModelSpec("Claude Sonnet 4", "claude-sonnet-4-20250514", "sonnet"),
     ModelSpec("GPT-4o", "gpt-4o", "sonnet"),
-    # K2.6 lands in the sonnet slot for now (replacing kimi-k2-turbo-preview,
-    # deprecated 2026-05-25). Semantically K2.6 is the new flagship-line model
-    # rather than a "secondary/cheaper" variant; tier placement to be revisited
-    # in the next re-sweep — see issue #68.
-    ModelSpec("Kimi K2.6", "moonshot-kimi-k2.6", "sonnet"),
+    ModelSpec("Kimi K2.5", "moonshot-kimi-k2.5", "sonnet"),
 ]
 
 # Mode label -> glob pattern fragment inserted between prefix and bench-VER.

--- a/scripts/run_full_benchmark.py
+++ b/scripts/run_full_benchmark.py
@@ -47,7 +47,7 @@ MODELS = {
     ],
     "moonshot": [
         ("Kimi K2.5", "moonshot/kimi-k2.5"),
-        ("Kimi K2 Turbo", "moonshot/kimi-k2-turbo-preview"),
+        ("Kimi K2.6", "moonshot/kimi-k2.6"),
     ],
 }
 


### PR DESCRIPTION
## Summary

Closes #68.

Moonshot announced (email 2026-05-04) that the `kimi-k2-*` hyphenated named-feature variants — including `kimi-k2-turbo-preview` — will be **discontinued 2026-05-25** and replaced by `kimi-k2.6`. The dot-versioned line (`k2.5`, `k2.6`) is the continuing one.

## What changed

| File | Change |
|------|--------|
| `scripts/plot_results.py` | Registry: `Kimi K2.6` → **flagship** slot; `Kimi K2.5` demoted to **sonnet** (replacing the previous `Kimi K2 Turbo` row entirely) |
| `scripts/run_full_benchmark.py` | `moonshot/kimi-k2.6` replaces `moonshot/kimi-k2-turbo-preview` |
| `scripts/README.md` | Sweep recipe references `moonshot/kimi-k2.6`; timing table keeps the K2 Turbo row annotated as historical (deprecated 2026-05-25) and adds a `Moonshot K2.6 | TBD` row |

## Tier reassignment

K2.6 is structurally the new flagship-line model from Moonshot, so it goes in the **flagship** tier alongside Claude Opus 4 and GPT-4.1. K2.5 moves to **sonnet**, joining Claude Sonnet 4 and GPT-4o as "previous-generation / secondary slot from each provider" — a tighter semantic grouping than the previous mix (where the sonnet Moonshot slot held the cost-optimized Turbo variant rather than a same-generation sibling).

Layout symmetry preserved: 3 flagship + 3 sonnet. The K2.5 flagship→sonnet move is a real chart-layout discontinuity between v0.0.11 results and future sweeps, but the discontinuity is *information* — Moonshot updated their flagship, and the chart should reflect that the moment the registry does, not several PRs later.

## Out of scope (deliberately untouched)

- **9 historical `results/moonshot-kimi-k2-turbo-preview-*.jsonl` files** — frozen audit records of what was measured at the time
- **`README.md` / `ROADMAP.md` v0.0.7 narrative** — historical text describing past benchmarks; rewriting falsifies history
- **`tests/test_models.py`** uses `moonshot/kimi-k2` (generic, not the deprecated SKU) for routing tests; no change needed

## No version bump

Model-registry update + chart-tier reassignment, not a methodology change. Same scoring contract, no result files affected. Mirrors the precedent of registry/config changes (PR #58 Cloudflare User-Agent, PR #67 baseline `bench_version`).

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [x] `pytest tests/` → 495 passed (unchanged from `main`)
- [x] `scripts/plot_results.py --version 0.0.7` runs against new registry; warns gracefully on missing K2.6 result files; K2.5 in sonnet correctly resolves existing v0.0.7 file (file lookup is by `file_prefix`, not tier)
- [x] Chart generation produces a sensible layout with K2.6 in flagship + K2.5 in sonnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Replaced Kimi K2 Turbo with Kimi K2.6 across benchmark tooling and model lists.
* **Documentation**
  * Updated examples and timing notes to reference Moonshot K2.6, with timings marked TBD until full sweep completes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aallan/vera-bench/pull/69)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->