### PR TITLE
Add --parallel N flag to vera-bench run

### DIFF
--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1634,10 +1634,14 @@ class TestRunBenchmarkParallel:
 
     @patch("vera_bench.runner.run_single_problem")
     def test_parallel_writes_are_serialised(self, mock_run, tmp_path):
-        """The write_lock must serialise JSONL writes: every line is a
-        complete, parseable JSON object (no torn writes from interleaving).
-        Worth testing because the comment in the code mentions this is
-        the lock's whole reason for existing."""
+        """JSONL writes from a parallel run must each be a complete,
+        parseable JSON object (no torn writes from interleaving).
+
+        Serialisation is provided by the `for fut in as_completed(...)`
+        loop running on the main thread — workers only run `_run_one`
+        and never touch `output_path`. This test exercises the property
+        under load (20 problems × 8 workers) so a future refactor that
+        accidentally moved the file write into workers would fail here."""
         from vera_bench.runner import run_benchmark
 
         mock_run.side_effect = lambda problem, **kw: [self._result(problem["id"])]
@@ -1709,7 +1713,47 @@ class TestRunBenchmarkParallel:
             ],
         )
         assert "no such option" not in (result.output or "").lower()
-        assert "invalid" not in (result.output or "").lower()
+        # Click signals usage/parse errors with exit_code == 2; anything
+        # else (API-key missing, downstream errors) is fine.
+        assert result.exit_code != 2
+
+    def test_run_command_rejects_zero_parallel(self):
+        """`click.IntRange(min=1)` rejects 0 and negative values at parse
+        time (exit_code == 2). Catches the silent-fall-through-to-sequential
+        bug that `type=int` would have allowed."""
+        from click.testing import CliRunner
+
+        from vera_bench.cli import main
+
+        result = CliRunner().invoke(
+            main,
+            [
+                "run",
+                "--model",
+                "claude-haiku-4-5-20251001",
+                "--parallel",
+                "0",
+            ],
+        )
+        assert result.exit_code == 2
+        assert "parallel" in (result.output or "").lower()
+
+    def test_run_command_rejects_negative_parallel(self):
+        from click.testing import CliRunner
+
+        from vera_bench.cli import main
+
+        result = CliRunner().invoke(
+            main,
+            [
+                "run",
+                "--model",
+                "claude-haiku-4-5-20251001",
+                "--parallel",
+                "-5",
+            ],
+        )
+        assert result.exit_code == 2
 
     def test_run_command_parallel_default_is_one(self):
         from click.testing import CliRunner

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1541,39 +1541,83 @@ class TestRunBenchmarkParallel:
 
     @patch("vera_bench.runner.run_single_problem")
     def test_parallel_one_uses_sequential_path(self, mock_run, tmp_path):
-        """`parallel=1` (the default) must use the sequential path —
-        ThreadPoolExecutor is not imported or constructed."""
+        """`parallel=1` (the default) must use the sequential path: all
+        calls to `run_single_problem` happen on the main thread, i.e. no
+        worker thread is ever spawned.
+
+        Assertion is on observable behaviour (the calling thread identity)
+        rather than the implementation detail of which class gets imported —
+        a future refactor that hoisted `ThreadPoolExecutor` to module
+        scope (legitimate change) would still pass this test."""
+        import threading
+
         from vera_bench.runner import run_benchmark
 
-        mock_run.side_effect = lambda problem, **kw: [self._result(problem["id"])]
+        calling_threads: list[threading.Thread] = []
+
+        def _record_thread(problem, **kw):
+            calling_threads.append(threading.current_thread())
+            return [self._result(problem["id"])]
+
+        mock_run.side_effect = _record_thread
         problems = [self._problem(f"VB-X-{i}") for i in range(3)]
         output = tmp_path / "seq.jsonl"
 
-        # ThreadPoolExecutor is imported inside the parallel branch of
-        # run_benchmark, so we patch the source module attribute. With
-        # parallel=1 it should never be looked up at all.
-        with patch(
-            "concurrent.futures.ThreadPoolExecutor",
-            side_effect=AssertionError("must not be used in sequential path"),
-        ):
-            results = run_benchmark(
-                problems=problems,
-                client=MagicMock(),
-                skill_md="",
-                vera=None,
-                language="python",
-                output_path=output,
-                parallel=1,
-            )
+        results = run_benchmark(
+            problems=problems,
+            client=MagicMock(_model="mock"),
+            skill_md="",
+            vera=None,
+            language="python",
+            output_path=output,
+            parallel=1,
+        )
 
         assert len(results) == 3
         assert mock_run.call_count == 3
-        assert output.exists()
+        # Behaviour assertion: every call ran on the main thread (no spawn).
+        main = threading.main_thread()
+        assert all(t is main for t in calling_threads), (
+            f"expected all calls on main thread; got {calling_threads}"
+        )
+        # And the JSONL output is correct.
         lines = output.read_text().strip().split("\n")
         assert len(lines) == 3
-        # JSONL lines are valid JSON
         ids = {json.loads(line)["problem_id"] for line in lines}
         assert ids == {"VB-X-0", "VB-X-1", "VB-X-2"}
+
+    @patch("vera_bench.runner.run_single_problem")
+    def test_parallel_two_actually_spawns_worker_threads(self, mock_run, tmp_path):
+        """Counterpoint to the sequential-path test: `parallel>1` does
+        spawn worker threads (not all calls run on the main thread)."""
+        import threading
+
+        from vera_bench.runner import run_benchmark
+
+        calling_threads: list[threading.Thread] = []
+
+        def _record_thread(problem, **kw):
+            calling_threads.append(threading.current_thread())
+            return [self._result(problem["id"])]
+
+        mock_run.side_effect = _record_thread
+        problems = [self._problem(f"VB-X-{i}") for i in range(5)]
+
+        run_benchmark(
+            problems=problems,
+            client=MagicMock(_model="mock"),
+            skill_md="",
+            vera=None,
+            language="python",
+            output_path=None,
+            parallel=3,
+        )
+
+        main = threading.main_thread()
+        worker_calls = [t for t in calling_threads if t is not main]
+        assert worker_calls, (
+            "parallel>1 should spawn worker threads — got all main-thread calls"
+        )
 
     @patch("vera_bench.runner.run_single_problem")
     def test_parallel_two_runs_all_problems(self, mock_run, tmp_path):
@@ -1586,7 +1630,7 @@ class TestRunBenchmarkParallel:
 
         results = run_benchmark(
             problems=problems,
-            client=MagicMock(),
+            client=MagicMock(_model="mock"),
             skill_md="",
             vera=None,
             language="python",
@@ -1603,7 +1647,14 @@ class TestRunBenchmarkParallel:
     @patch("vera_bench.runner.run_single_problem")
     def test_parallel_worker_exception_continues(self, mock_run, tmp_path):
         """One worker raising must not kill the whole sweep — other
-        problems still complete, and a red error line is logged."""
+        problems still complete, AND the crashed problem appears as a
+        visible row in the JSONL output (with traceback in `error_message`).
+
+        Regression guard for the silent-denominator-change bug: prior
+        behaviour was that crashes vanished from JSONL, so a 60-problem
+        sweep with 2 crashes reported 58/58 (100%). Now every problem
+        produces a row — successes carry the normal fields, crashes
+        carry `check_pass=False, run_correct=False, error_message=<tb>`."""
         from vera_bench.runner import run_benchmark
 
         def _side_effect(problem, **kw):
@@ -1617,7 +1668,7 @@ class TestRunBenchmarkParallel:
 
         results = run_benchmark(
             problems=problems,
-            client=MagicMock(),
+            client=MagicMock(_model="mock"),
             skill_md="",
             vera=None,
             language="python",
@@ -1625,12 +1676,63 @@ class TestRunBenchmarkParallel:
             parallel=2,
         )
 
-        # 3 successful + 1 swallowed exception = 3 results
+        # ALL 4 problems produce a result row — 3 successes + 1 crash.
+        assert len(results) == 4
+        ids = {r.problem_id for r in results}
+        assert ids == {"VB-X-0", "VB-X-1", "VB-X-2", "VB-X-3"}
+        # JSONL has 4 lines (the crash row IS written so report doesn't
+        # silently shrink the denominator).
+        lines = output.read_text().strip().split("\n")
+        assert len(lines) == 4
+        # The crash row carries diagnostic detail in `error_message`.
+        crash_row = next(json.loads(ln) for ln in lines if "Worker crash" in ln)
+        assert crash_row["problem_id"] == "VB-X-2"
+        assert crash_row["check_pass"] is False
+        assert "simulated worker crash" in crash_row["error_message"]
+        assert "RuntimeError" in crash_row["error_message"]
+        # And a traceback is included for post-hoc debugging.
+        assert "Traceback" in crash_row["error_message"]
+
+    @patch("vera_bench.runner.run_single_problem")
+    def test_sequential_worker_exception_also_continues(self, mock_run, tmp_path):
+        """Sequential (parallel=1) path has the SAME fault semantics as
+        the parallel path: a single crashed problem doesn't abort the
+        whole sweep, and the crash is recorded in JSONL.
+
+        Closes the prior asymmetry where `--parallel 1` and `--parallel 2`
+        had different fault behaviour on the same input (sequential aborted
+        on a transient model-response error, parallel logged-and-continued).
+        Four-hour sweeps now survive problem 47 of 60 regardless of N."""
+        from vera_bench.runner import run_benchmark
+
+        def _side_effect(problem, **kw):
+            if problem["id"] == "VB-X-1":
+                raise ValueError("LLM returned None mid-sweep")
+            return [self._result(problem["id"])]
+
+        mock_run.side_effect = _side_effect
+        problems = [self._problem(f"VB-X-{i}") for i in range(3)]
+        output = tmp_path / "seq-crash.jsonl"
+
+        results = run_benchmark(
+            problems=problems,
+            client=MagicMock(_model="mock"),
+            skill_md="",
+            vera=None,
+            language="python",
+            output_path=output,
+            parallel=1,
+        )
+
         assert len(results) == 3
         ids = {r.problem_id for r in results}
-        assert ids == {"VB-X-0", "VB-X-1", "VB-X-3"}
-        # JSONL has exactly 3 lines (no entry for the crashed problem)
-        assert len(output.read_text().strip().split("\n")) == 3
+        assert ids == {"VB-X-0", "VB-X-1", "VB-X-2"}
+        lines = output.read_text().strip().split("\n")
+        assert len(lines) == 3
+        crash_row = next(json.loads(ln) for ln in lines if "Worker crash" in ln)
+        assert crash_row["problem_id"] == "VB-X-1"
+        assert "LLM returned None" in crash_row["error_message"]
+        assert "ValueError" in crash_row["error_message"]
 
     @patch("vera_bench.runner.run_single_problem")
     def test_parallel_writes_are_serialised(self, mock_run, tmp_path):
@@ -1645,15 +1747,18 @@ class TestRunBenchmarkParallel:
         from vera_bench.runner import run_benchmark
 
         mock_run.side_effect = lambda problem, **kw: [self._result(problem["id"])]
-        # Use enough problems + parallel workers that interleaving WOULD
-        # happen without a lock (Python's GIL doesn't make file writes
-        # atomic across threads — partial writes are observable).
+        # 20 problems × 8 workers gives many completion-order opportunities
+        # for interleaved writes if a future refactor moved the file write
+        # into workers. Note: this test does NOT prove anything about POSIX
+        # O_APPEND atomicity (short writes < PIPE_BUF on POSIX would be
+        # atomic anyway) — it proves the main-thread `as_completed` loop
+        # is the actual serialisation source.
         problems = [self._problem(f"VB-X-{i:03d}") for i in range(20)]
         output = tmp_path / "concurrent.jsonl"
 
         run_benchmark(
             problems=problems,
-            client=MagicMock(),
+            client=MagicMock(_model="mock"),
             skill_md="",
             vera=None,
             language="python",
@@ -1683,7 +1788,7 @@ class TestRunBenchmarkParallel:
 
         results = run_benchmark(
             problems=problems,
-            client=MagicMock(),
+            client=MagicMock(_model="mock"),
             skill_md="",
             vera=None,
             language="python",
@@ -1692,6 +1797,101 @@ class TestRunBenchmarkParallel:
         )
 
         assert len(results) == 3
+
+    @patch("vera_bench.runner.Progress")
+    @patch("vera_bench.runner.run_single_problem")
+    def test_progress_advances_on_crash_path(self, mock_run, mock_progress, tmp_path):
+        """`progress.advance` must fire even when a worker raises — both
+        sequential and parallel paths. Otherwise the bar hangs at N-1/N
+        if any problem crashes, misleading anyone watching the run.
+
+        Catches a refactor that accidentally moved `advance` into an
+        `else:` branch only reached on the success path."""
+        from vera_bench.runner import run_benchmark
+
+        def _side_effect(problem, **kw):
+            if problem["id"] == "VB-X-1":
+                raise RuntimeError("boom")
+            return [self._result(problem["id"])]
+
+        mock_run.side_effect = _side_effect
+
+        progress_inst = MagicMock()
+        mock_progress.return_value.__enter__.return_value = progress_inst
+        progress_inst.add_task.return_value = "task-token"
+
+        problems = [self._problem(f"VB-X-{i}") for i in range(4)]
+        # Parallel path
+        run_benchmark(
+            problems=problems,
+            client=MagicMock(_model="mock"),
+            skill_md="",
+            vera=None,
+            language="python",
+            output_path=tmp_path / "par.jsonl",
+            parallel=2,
+        )
+        assert progress_inst.advance.call_count == 4, (
+            f"parallel: advance should fire for every problem (3 successes "
+            f"+ 1 crash = 4); got {progress_inst.advance.call_count}"
+        )
+
+        # Sequential path (reset and re-run)
+        progress_inst.advance.reset_mock()
+        run_benchmark(
+            problems=problems,
+            client=MagicMock(_model="mock"),
+            skill_md="",
+            vera=None,
+            language="python",
+            output_path=tmp_path / "seq.jsonl",
+            parallel=1,
+        )
+        assert progress_inst.advance.call_count == 4, (
+            f"sequential: advance should fire for every problem; "
+            f"got {progress_inst.advance.call_count}"
+        )
+
+    @patch("vera_bench.runner.run_single_problem")
+    def test_bench_and_vera_version_propagate_to_workers(self, mock_run, tmp_path):
+        """`bench_version` / `vera_version` are captured by closure into
+        `_run_one` in the parallel path; if a future refactor dropped
+        them from the kwargs forwarded to `run_single_problem`, JSONL
+        rows would silently get empty version strings.
+
+        This test forwards observed kwargs so a regression where the
+        closure stops propagating them surfaces immediately."""
+        from vera_bench.runner import run_benchmark
+
+        captured: list[dict] = []
+
+        def _capture(problem, **kw):
+            captured.append({"id": problem["id"], **kw})
+            return [self._result(problem["id"])]
+
+        mock_run.side_effect = _capture
+        problems = [self._problem(f"VB-X-{i}") for i in range(3)]
+
+        run_benchmark(
+            problems=problems,
+            client=MagicMock(_model="mock"),
+            skill_md="",
+            vera=None,
+            language="python",
+            output_path=None,
+            parallel=3,
+            bench_version="0.0.11",
+            vera_version="0.0.108",
+        )
+
+        assert len(captured) == 3
+        for kw in captured:
+            assert kw["bench_version"] == "0.0.11", (
+                f"bench_version not forwarded: got {kw.get('bench_version')!r}"
+            )
+            assert kw["vera_version"] == "0.0.108", (
+                f"vera_version not forwarded: got {kw.get('vera_version')!r}"
+            )
 
     def test_run_command_accepts_parallel_flag(self):
         from click.testing import CliRunner

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1555,7 +1555,9 @@ class TestRunBenchmarkParallel:
 
         calling_threads: list[threading.Thread] = []
 
-        def _record_thread(problem, **kw):
+        def _record_thread(
+            problem: dict[str, object], **kw: object
+        ) -> list[ProblemResult]:
             calling_threads.append(threading.current_thread())
             return [self._result(problem["id"])]
 
@@ -1596,7 +1598,9 @@ class TestRunBenchmarkParallel:
 
         calling_threads: list[threading.Thread] = []
 
-        def _record_thread(problem, **kw):
+        def _record_thread(
+            problem: dict[str, object], **kw: object
+        ) -> list[ProblemResult]:
             calling_threads.append(threading.current_thread())
             return [self._result(problem["id"])]
 
@@ -1657,7 +1661,9 @@ class TestRunBenchmarkParallel:
         carry `check_pass=False, run_correct=False, error_message=<tb>`."""
         from vera_bench.runner import run_benchmark
 
-        def _side_effect(problem, **kw):
+        def _side_effect(
+            problem: dict[str, object], **kw: object
+        ) -> list[ProblemResult]:
             if problem["id"] == "VB-X-2":
                 raise RuntimeError("simulated worker crash")
             return [self._result(problem["id"])]
@@ -1685,8 +1691,11 @@ class TestRunBenchmarkParallel:
         lines = output.read_text().strip().split("\n")
         assert len(lines) == 4
         # The crash row carries diagnostic detail in `error_message`.
-        crash_row = next(json.loads(ln) for ln in lines if "Worker crash" in ln)
-        assert crash_row["problem_id"] == "VB-X-2"
+        # Select by problem_id (the structural identifier), not by message
+        # substring — message wording shouldn't be load-bearing in a row
+        # selector.
+        rows = [json.loads(ln) for ln in lines]
+        crash_row = next(row for row in rows if row["problem_id"] == "VB-X-2")
         assert crash_row["check_pass"] is False
         assert "simulated worker crash" in crash_row["error_message"]
         assert "RuntimeError" in crash_row["error_message"]
@@ -1705,7 +1714,9 @@ class TestRunBenchmarkParallel:
         Four-hour sweeps now survive problem 47 of 60 regardless of N."""
         from vera_bench.runner import run_benchmark
 
-        def _side_effect(problem, **kw):
+        def _side_effect(
+            problem: dict[str, object], **kw: object
+        ) -> list[ProblemResult]:
             if problem["id"] == "VB-X-1":
                 raise ValueError("LLM returned None mid-sweep")
             return [self._result(problem["id"])]
@@ -1729,8 +1740,8 @@ class TestRunBenchmarkParallel:
         assert ids == {"VB-X-0", "VB-X-1", "VB-X-2"}
         lines = output.read_text().strip().split("\n")
         assert len(lines) == 3
-        crash_row = next(json.loads(ln) for ln in lines if "Worker crash" in ln)
-        assert crash_row["problem_id"] == "VB-X-1"
+        rows = [json.loads(ln) for ln in lines]
+        crash_row = next(row for row in rows if row["problem_id"] == "VB-X-1")
         assert "LLM returned None" in crash_row["error_message"]
         assert "ValueError" in crash_row["error_message"]
 
@@ -1809,7 +1820,9 @@ class TestRunBenchmarkParallel:
         `else:` branch only reached on the success path."""
         from vera_bench.runner import run_benchmark
 
-        def _side_effect(problem, **kw):
+        def _side_effect(
+            problem: dict[str, object], **kw: object
+        ) -> list[ProblemResult]:
             if problem["id"] == "VB-X-1":
                 raise RuntimeError("boom")
             return [self._result(problem["id"])]
@@ -1865,7 +1878,7 @@ class TestRunBenchmarkParallel:
 
         captured: list[dict] = []
 
-        def _capture(problem, **kw):
+        def _capture(problem: dict[str, object], **kw: object) -> list[ProblemResult]:
             captured.append({"id": problem["id"], **kw})
             return [self._result(problem["id"])]
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1508,3 +1508,217 @@ class TestRunBenchmarkIntegration:
         assert output.exists()
         lines = output.read_text().strip().split("\n")
         assert len(lines) >= 1
+
+
+# === --parallel N ===
+
+
+class TestRunBenchmarkParallel:
+    """Tests for the ThreadPoolExecutor path in run_benchmark.
+
+    All tests stub out `run_single_problem` so we exercise the dispatch
+    layer (sequential vs threaded, exception handling, write-lock) without
+    touching the LLM / subprocess machinery underneath.
+    """
+
+    def _problem(self, pid: str) -> dict:
+        # Minimal problem shape — run_benchmark only reads `.get("id", ...)`
+        # in the parallel-path exception handler, so this is enough.
+        return {"id": pid, "entry_point": "fn", "test_cases": []}
+
+    def _result(self, pid: str) -> ProblemResult:
+        return ProblemResult(
+            problem_id=pid,
+            model="mock",
+            language="python",
+            attempt=1,
+            check_pass=True,
+            run_correct=True,
+            tests_total=0,
+            tests_passed=0,
+            timestamp="2026-05-22T00:00:00Z",
+        )
+
+    @patch("vera_bench.runner.run_single_problem")
+    def test_parallel_one_uses_sequential_path(self, mock_run, tmp_path):
+        """`parallel=1` (the default) must use the sequential path —
+        ThreadPoolExecutor is not imported or constructed."""
+        from vera_bench.runner import run_benchmark
+
+        mock_run.side_effect = lambda problem, **kw: [self._result(problem["id"])]
+        problems = [self._problem(f"VB-X-{i}") for i in range(3)]
+        output = tmp_path / "seq.jsonl"
+
+        # ThreadPoolExecutor is imported inside the parallel branch of
+        # run_benchmark, so we patch the source module attribute. With
+        # parallel=1 it should never be looked up at all.
+        with patch(
+            "concurrent.futures.ThreadPoolExecutor",
+            side_effect=AssertionError("must not be used in sequential path"),
+        ):
+            results = run_benchmark(
+                problems=problems,
+                client=MagicMock(),
+                skill_md="",
+                vera=None,
+                language="python",
+                output_path=output,
+                parallel=1,
+            )
+
+        assert len(results) == 3
+        assert mock_run.call_count == 3
+        assert output.exists()
+        lines = output.read_text().strip().split("\n")
+        assert len(lines) == 3
+        # JSONL lines are valid JSON
+        ids = {json.loads(line)["problem_id"] for line in lines}
+        assert ids == {"VB-X-0", "VB-X-1", "VB-X-2"}
+
+    @patch("vera_bench.runner.run_single_problem")
+    def test_parallel_two_runs_all_problems(self, mock_run, tmp_path):
+        """`parallel>1` runs every problem and collects every result."""
+        from vera_bench.runner import run_benchmark
+
+        mock_run.side_effect = lambda problem, **kw: [self._result(problem["id"])]
+        problems = [self._problem(f"VB-X-{i}") for i in range(5)]
+        output = tmp_path / "par.jsonl"
+
+        results = run_benchmark(
+            problems=problems,
+            client=MagicMock(),
+            skill_md="",
+            vera=None,
+            language="python",
+            output_path=output,
+            parallel=2,
+        )
+
+        assert len(results) == 5
+        assert mock_run.call_count == 5
+        # All 5 problem_ids appear (order may differ — completion order)
+        ids_in_results = {r.problem_id for r in results}
+        assert ids_in_results == {f"VB-X-{i}" for i in range(5)}
+
+    @patch("vera_bench.runner.run_single_problem")
+    def test_parallel_worker_exception_continues(self, mock_run, tmp_path):
+        """One worker raising must not kill the whole sweep — other
+        problems still complete, and a red error line is logged."""
+        from vera_bench.runner import run_benchmark
+
+        def _side_effect(problem, **kw):
+            if problem["id"] == "VB-X-2":
+                raise RuntimeError("simulated worker crash")
+            return [self._result(problem["id"])]
+
+        mock_run.side_effect = _side_effect
+        problems = [self._problem(f"VB-X-{i}") for i in range(4)]
+        output = tmp_path / "crash.jsonl"
+
+        results = run_benchmark(
+            problems=problems,
+            client=MagicMock(),
+            skill_md="",
+            vera=None,
+            language="python",
+            output_path=output,
+            parallel=2,
+        )
+
+        # 3 successful + 1 swallowed exception = 3 results
+        assert len(results) == 3
+        ids = {r.problem_id for r in results}
+        assert ids == {"VB-X-0", "VB-X-1", "VB-X-3"}
+        # JSONL has exactly 3 lines (no entry for the crashed problem)
+        assert len(output.read_text().strip().split("\n")) == 3
+
+    @patch("vera_bench.runner.run_single_problem")
+    def test_parallel_writes_are_serialised(self, mock_run, tmp_path):
+        """The write_lock must serialise JSONL writes: every line is a
+        complete, parseable JSON object (no torn writes from interleaving).
+        Worth testing because the comment in the code mentions this is
+        the lock's whole reason for existing."""
+        from vera_bench.runner import run_benchmark
+
+        mock_run.side_effect = lambda problem, **kw: [self._result(problem["id"])]
+        # Use enough problems + parallel workers that interleaving WOULD
+        # happen without a lock (Python's GIL doesn't make file writes
+        # atomic across threads — partial writes are observable).
+        problems = [self._problem(f"VB-X-{i:03d}") for i in range(20)]
+        output = tmp_path / "concurrent.jsonl"
+
+        run_benchmark(
+            problems=problems,
+            client=MagicMock(),
+            skill_md="",
+            vera=None,
+            language="python",
+            output_path=output,
+            parallel=8,
+        )
+
+        # Every line must be parseable JSON; we lose data on torn writes.
+        lines = output.read_text().strip().split("\n")
+        assert len(lines) == 20, f"expected 20 lines, got {len(lines)}"
+        for ln in lines:
+            obj = json.loads(ln)  # would raise if a line is torn
+            assert obj["problem_id"].startswith("VB-X-")
+        # Every expected ID is present exactly once
+        ids = [json.loads(ln)["problem_id"] for ln in lines]
+        assert sorted(ids) == sorted([f"VB-X-{i:03d}" for i in range(20)])
+
+    @patch("vera_bench.runner.run_single_problem")
+    def test_parallel_no_output_path_still_collects_results(self, mock_run, tmp_path):
+        """`output_path=None` is a valid call shape — used by callers that
+        only care about the in-memory list. Parallel path must skip the
+        write block cleanly."""
+        from vera_bench.runner import run_benchmark
+
+        mock_run.side_effect = lambda problem, **kw: [self._result(problem["id"])]
+        problems = [self._problem(f"VB-X-{i}") for i in range(3)]
+
+        results = run_benchmark(
+            problems=problems,
+            client=MagicMock(),
+            skill_md="",
+            vera=None,
+            language="python",
+            output_path=None,
+            parallel=4,  # more workers than problems is fine
+        )
+
+        assert len(results) == 3
+
+    def test_run_command_accepts_parallel_flag(self):
+        from click.testing import CliRunner
+
+        from vera_bench.cli import main
+
+        # Verify the flag parses; downstream failures (API key, etc.) are
+        # expected and not what this test is about.
+        result = CliRunner().invoke(
+            main,
+            [
+                "run",
+                "--model",
+                "claude-haiku-4-5-20251001",
+                "--parallel",
+                "4",
+                "--problem",
+                "VB-T1-001",
+            ],
+        )
+        assert "no such option" not in (result.output or "").lower()
+        assert "invalid" not in (result.output or "").lower()
+
+    def test_run_command_parallel_default_is_one(self):
+        from click.testing import CliRunner
+
+        from vera_bench.cli import main
+
+        # The --parallel help text should mention default=1
+        result = CliRunner().invoke(main, ["run", "--help"])
+        assert result.exit_code == 0
+        assert "--parallel" in result.output
+        # `show_default=True` makes Click print `[default: 1]`
+        assert "1" in result.output

--- a/vera_bench/cli.py
+++ b/vera_bench/cli.py
@@ -76,6 +76,17 @@ def validate(problems_dir: Path | None, solutions_dir: Path | None):
     is_flag=True,
     help="Keep temporary generated files",
 )
+@click.option(
+    "--parallel",
+    type=int,
+    default=1,
+    show_default=True,
+    help=(
+        "Run N problems concurrently via ThreadPoolExecutor. "
+        "Use >1 for slow models (e.g. Kimi K2.5). "
+        "Each worker is I/O-bound on its LLM call + subprocess runs."
+    ),
+)
 def run(
     model: str,
     tier: int | None,
@@ -86,6 +97,7 @@ def run(
     output_dir: Path | None,
     max_tokens: int,
     keep_temps: bool,
+    parallel: int,
 ):
     """Run benchmark against an LLM model."""
     from vera_bench.metrics import compute_metrics
@@ -237,6 +249,7 @@ def run(
         keep_temps=keep_temps,
         bench_version=bench_ver,
         vera_version=vera_ver,
+        parallel=parallel,
     )
 
     # Print summary

--- a/vera_bench/cli.py
+++ b/vera_bench/cli.py
@@ -78,7 +78,7 @@ def validate(problems_dir: Path | None, solutions_dir: Path | None):
 )
 @click.option(
     "--parallel",
-    type=int,
+    type=click.IntRange(min=1),
     default=1,
     show_default=True,
     help=(

--- a/vera_bench/runner.py
+++ b/vera_bench/runner.py
@@ -944,16 +944,15 @@ def run_benchmark(
                             problem_results = fut.result()
                         except Exception as exc:  # noqa: BLE001
                             pid = futures[fut].get("id", "?")
-                            console.print(
-                                f"[red]Worker failed on {pid}: {exc}[/red]"
-                            )
+                            console.print(f"[red]Worker failed on {pid}: {exc}[/red]")
                             progress.advance(task)
                             continue
                         all_results.extend(problem_results)
                         if output_path:
-                            with write_lock, open(
-                                output_path, "a", encoding="utf-8"
-                            ) as f:
+                            with (
+                                write_lock,
+                                open(output_path, "a", encoding="utf-8") as f,
+                            ):
                                 for r in problem_results:
                                     f.write(r.to_jsonl() + "\n")
                         progress.advance(task)

--- a/vera_bench/runner.py
+++ b/vera_bench/runner.py
@@ -9,6 +9,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import traceback
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -881,35 +882,77 @@ def run_benchmark(
     JSONL output ordering is by completion order, not by problem index,
     when running in parallel. Each line is self-contained (carries
     ``problem_id``) so downstream consumers can sort if needed.
+
+    Worker exceptions are caught (in both sequential and parallel paths)
+    and converted into a visible ``ProblemResult`` row written to JSONL,
+    so downstream ``vera-bench report`` sees an honest denominator
+    rather than a silent under-report when a problem crashes.
     """
     work_dir = Path(tempfile.mkdtemp(prefix="verabench_"))
     all_results: list[ProblemResult] = []
+
+    def _record(problem_results: list[ProblemResult]) -> None:
+        """Append results to the in-memory list AND to output_path (if set)."""
+        all_results.extend(problem_results)
+        if output_path:
+            with open(output_path, "a", encoding="utf-8") as f:
+                for r in problem_results:
+                    f.write(r.to_jsonl() + "\n")
+
+    def _crash_result(problem: dict, exc: BaseException, tb: str) -> ProblemResult:
+        """Synthesise a ProblemResult representing a worker crash.
+
+        Before this existed, worker exceptions vanished silently from the
+        parallel path: a 60-problem sweep with 2 crashes wrote 58 JSONL
+        rows and downstream ``vera-bench report`` showed "58/58 (100%)" —
+        the operator wouldn't know problems had crashed. The crash row
+        keeps the denominator honest and embeds the full traceback in
+        ``error_message`` for post-hoc debugging.
+        """
+        return ProblemResult(
+            problem_id=problem.get("id", "?"),
+            model=getattr(client, "_model", "unknown"),
+            language=language,
+            attempt=0,
+            check_pass=False,
+            run_correct=False,
+            error_message=f"Worker crash: {exc!r}\n{tb}",
+            timestamp=_now(),
+            bench_version=bench_version,
+            vera_version=vera_version,
+        )
 
     try:
         if parallel <= 1:
             with Progress(console=console) as progress:
                 task = progress.add_task("Running benchmark...", total=len(problems))
                 for problem in problems:
-                    problem_results = run_single_problem(
-                        problem=problem,
-                        client=client,
-                        skill_md=skill_md,
-                        vera=vera,
-                        work_dir=work_dir,
-                        mode=mode,
-                        language=language,
-                        max_fix_attempts=max_fix_attempts,
-                        max_tokens=max_tokens,
-                        bench_version=bench_version,
-                        vera_version=vera_version,
-                    )
-                    all_results.extend(problem_results)
-
-                    if output_path:
-                        with open(output_path, "a", encoding="utf-8") as f:
-                            for r in problem_results:
-                                f.write(r.to_jsonl() + "\n")
-
+                    # Symmetry with the parallel path: a single problem's
+                    # crash is logged + recorded + sweep continues, rather
+                    # than aborting the whole run on problem N of M.
+                    try:
+                        problem_results = run_single_problem(
+                            problem=problem,
+                            client=client,
+                            skill_md=skill_md,
+                            vera=vera,
+                            work_dir=work_dir,
+                            mode=mode,
+                            language=language,
+                            max_fix_attempts=max_fix_attempts,
+                            max_tokens=max_tokens,
+                            bench_version=bench_version,
+                            vera_version=vera_version,
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        tb = traceback.format_exc()
+                        pid = problem.get("id", "?")
+                        console.print(f"[red]Worker failed on {pid}: {exc!r}[/red]")
+                        console.print(f"[dim]{tb}[/dim]")
+                        _record([_crash_result(problem, exc, tb)])
+                        progress.advance(task)
+                        continue
+                    _record(problem_results)
                     progress.advance(task)
         else:
             from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -942,18 +985,18 @@ def run_benchmark(
                 with ThreadPoolExecutor(max_workers=parallel) as executor:
                     futures = {executor.submit(_run_one, p): p for p in problems}
                     for fut in as_completed(futures):
+                        problem = futures[fut]
                         try:
                             problem_results = fut.result()
                         except Exception as exc:  # noqa: BLE001
-                            pid = futures[fut].get("id", "?")
-                            console.print(f"[red]Worker failed on {pid}: {exc}[/red]")
+                            tb = traceback.format_exc()
+                            pid = problem.get("id", "?")
+                            console.print(f"[red]Worker failed on {pid}: {exc!r}[/red]")
+                            console.print(f"[dim]{tb}[/dim]")
+                            _record([_crash_result(problem, exc, tb)])
                             progress.advance(task)
                             continue
-                        all_results.extend(problem_results)
-                        if output_path:
-                            with open(output_path, "a", encoding="utf-8") as f:
-                                for r in problem_results:
-                                    f.write(r.to_jsonl() + "\n")
+                        _record(problem_results)
                         progress.advance(task)
     finally:
         if not keep_temps:

--- a/vera_bench/runner.py
+++ b/vera_bench/runner.py
@@ -864,20 +864,62 @@ def run_benchmark(
     keep_temps: bool = False,
     bench_version: str = "",
     vera_version: str = "",
+    parallel: int = 1,
 ) -> list[ProblemResult]:
     """Run the full benchmark across all problems.
 
     Results are written to JSONL incrementally (survives crashes).
+
+    When ``parallel > 1``, problems are dispatched to a ThreadPoolExecutor
+    with ``parallel`` workers. Each problem runs independently (its own
+    LLM call, its own subprocess-based check/run), so threads only block
+    on I/O (HTTP to the LLM provider, subprocess spawns to the toolchain).
+    The GIL is not a bottleneck. Use this when sweeping slow models —
+    e.g. Kimi K2.5 at ~50s/problem sequential becomes ~5s/problem with
+    parallel=10.
+
+    JSONL output ordering is by completion order, not by problem index,
+    when running in parallel. Each line is self-contained (carries
+    ``problem_id``) so downstream consumers can sort if needed.
     """
     work_dir = Path(tempfile.mkdtemp(prefix="verabench_"))
     all_results: list[ProblemResult] = []
 
     try:
-        with Progress(console=console) as progress:
-            task = progress.add_task("Running benchmark...", total=len(problems))
-            for problem in problems:
-                problem_results = run_single_problem(
-                    problem=problem,
+        if parallel <= 1:
+            with Progress(console=console) as progress:
+                task = progress.add_task("Running benchmark...", total=len(problems))
+                for problem in problems:
+                    problem_results = run_single_problem(
+                        problem=problem,
+                        client=client,
+                        skill_md=skill_md,
+                        vera=vera,
+                        work_dir=work_dir,
+                        mode=mode,
+                        language=language,
+                        max_fix_attempts=max_fix_attempts,
+                        max_tokens=max_tokens,
+                        bench_version=bench_version,
+                        vera_version=vera_version,
+                    )
+                    all_results.extend(problem_results)
+
+                    if output_path:
+                        with open(output_path, "a", encoding="utf-8") as f:
+                            for r in problem_results:
+                                f.write(r.to_jsonl() + "\n")
+
+                    progress.advance(task)
+        else:
+            import threading
+            from concurrent.futures import ThreadPoolExecutor, as_completed
+
+            write_lock = threading.Lock()
+
+            def _run_one(p: dict) -> list[ProblemResult]:
+                return run_single_problem(
+                    problem=p,
                     client=client,
                     skill_md=skill_md,
                     vera=vera,
@@ -889,15 +931,32 @@ def run_benchmark(
                     bench_version=bench_version,
                     vera_version=vera_version,
                 )
-                all_results.extend(problem_results)
 
-                # Write JSONL incrementally
-                if output_path:
-                    with open(output_path, "a", encoding="utf-8") as f:
-                        for r in problem_results:
-                            f.write(r.to_jsonl() + "\n")
-
-                progress.advance(task)
+            with Progress(console=console) as progress:
+                task = progress.add_task(
+                    f"Running benchmark (parallel={parallel})...",
+                    total=len(problems),
+                )
+                with ThreadPoolExecutor(max_workers=parallel) as executor:
+                    futures = {executor.submit(_run_one, p): p for p in problems}
+                    for fut in as_completed(futures):
+                        try:
+                            problem_results = fut.result()
+                        except Exception as exc:  # noqa: BLE001
+                            pid = futures[fut].get("id", "?")
+                            console.print(
+                                f"[red]Worker failed on {pid}: {exc}[/red]"
+                            )
+                            progress.advance(task)
+                            continue
+                        all_results.extend(problem_results)
+                        if output_path:
+                            with write_lock, open(
+                                output_path, "a", encoding="utf-8"
+                            ) as f:
+                                for r in problem_results:
+                                    f.write(r.to_jsonl() + "\n")
+                        progress.advance(task)
     finally:
         if not keep_temps:
             shutil.rmtree(work_dir, ignore_errors=True)

--- a/vera_bench/runner.py
+++ b/vera_bench/runner.py
@@ -912,10 +912,12 @@ def run_benchmark(
 
                     progress.advance(task)
         else:
-            import threading
             from concurrent.futures import ThreadPoolExecutor, as_completed
 
-            write_lock = threading.Lock()
+            # No write lock needed: the `for fut in as_completed(...)` loop
+            # below runs on the main thread, so the JSONL appends are
+            # already serialised by the loop structure. Workers only run
+            # `_run_one` (the LLM/subprocess work), never touch output_path.
 
             def _run_one(p: dict) -> list[ProblemResult]:
                 return run_single_problem(
@@ -949,10 +951,7 @@ def run_benchmark(
                             continue
                         all_results.extend(problem_results)
                         if output_path:
-                            with (
-                                write_lock,
-                                open(output_path, "a", encoding="utf-8") as f,
-                            ):
+                            with open(output_path, "a", encoding="utf-8") as f:
                                 for r in problem_results:
                                     f.write(r.to_jsonl() + "\n")
                         progress.advance(task)


### PR DESCRIPTION
## Summary

Adds a `--parallel N` flag to `vera-bench run` that dispatches problems to a `ThreadPoolExecutor` with `N` workers. Each worker is I/O-bound on its LLM call + subprocess `check`/`run`, so the GIL is not a bottleneck.

**Use case:** slow models like Kimi K2.5 averaged ~50s/problem sequentially across the 60-problem sweep (~50 min total). With `--parallel 10` that should drop to ~5 min, which makes release-time re-evals practical.

**Default `parallel=1` preserves the existing sequential path with no behavior change.**

## Scope note

This was originally bundled into [PR #70](https://github.com/aallan/vera-bench/pull/70) (the AILANG baseline). It snuck in during release-time benchmarking and was always intended to be a separate PR — concurrent sweep is independent of AILANG support and deserves its own review. Reverted out of #70 ([revert commit](https://github.com/aallan/vera-bench/pull/70/commits)) and surfacing here.

## Implementation

- `ThreadPoolExecutor` with `max_workers=parallel`, futures collected via `as_completed`
- `threading.Lock` around the JSONL append so concurrent writes don't interleave. Lines are still self-contained (carry `problem_id`) so completion-order writes are fine for downstream consumers
- Workers share `work_dir`; per-problem temp files are uniquified by `problem_id` (existing behaviour, unchanged)
- Exception in any worker is caught, logged red, and the sweep continues — one crashed problem doesn't kill the rest

Smoke-tested with `claude-haiku-4-5 --tier 1 --parallel 4`: 10/10 problems, no duplicates, 100%/100% run_correct.

## Tests

`TestRunBenchmarkParallel` in `tests/test_runner.py` adds 7 cases covering:

- `parallel=1` does NOT use `ThreadPoolExecutor` (patched to raise on use)
- `parallel>1` runs every problem and collects every result
- One worker raising doesn't abort the sweep
- `write_lock` serialises JSONL writes (20 problems × 8 workers, every line parseable JSON)
- `output_path=None` is a valid code path
- Click accepts `--parallel N` and defaults to 1

All 7 pass locally; `ruff check .` / `ruff format --check .` / `ruff check --select S vera_bench/` all clean. Local coverage on `vera_bench/runner.py`: 83% (CI lifts further when vera-binary-dependent paths run).

## Test plan

- [ ] CI green
- [ ] Code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `run` gains a `--parallel` option (default 1) to run problems concurrently; progress shows chosen parallelism, worker errors are recorded per problem without aborting the run, and metadata versions are propagated. `output_path=None` returns in-memory results without writing files.

* **Tests**
  * Added tests covering sequential and parallel execution, concurrency-safe output integrity, error isolation and reporting, CLI validation for `--parallel`, and progress updates for every problem.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aallan/vera-bench/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->