### PR TITLE
Bump version to 0.0.12 + documentation consistency pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,100 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.12] - 2026-05-25
+
+### Added
+
+- **AILANG comparison language**
+  ([#70](https://github.com/aallan/vera-bench/pull/70),
+  [#75](https://github.com/aallan/vera-bench/pull/75)).
+  Fourth comparison language alongside Python, TypeScript, and Aver.
+  AILANG is another zero-training-data language, providing an additional
+  data point for the language-design-vs-training-data thesis. Includes:
+  prompt builder (`build_ailang_prompt` / `build_ailang_fix_prompt`),
+  code evaluator (`_evaluate_ailang_code` with per-test-case main
+  synthesis), baseline runner (`run_ailang_baseline`), CLI plumbing
+  (`--language ailang` for both `run` and `baselines`), and 60
+  canonical reference solutions (`solutions/ailang/*.ail`). The AILANG
+  teaching prompt is loaded via `ailang prompt --source embedded`
+  (matching the AILANG eval-harness pattern) — no URL fetching. The
+  full-benchmark sweep script (`scripts/run_full_benchmark.py`) now
+  includes AILANG LLM + AILANG baseline targets (#75), bringing the
+  matrix from 8 to 10 targets per model.
+- **`--parallel N` flag for concurrent benchmark sweeps**
+  ([#73](https://github.com/aallan/vera-bench/pull/73)). Dispatches
+  problems to a `ThreadPoolExecutor` with `N` workers. Each worker is
+  I/O-bound on its LLM call + subprocess `check`/`run`, so the GIL is
+  not a bottleneck. Default `parallel=1` preserves the existing
+  sequential code path. Validated with `click.IntRange(min=1)` to
+  reject 0/negative at parse time.
+- **OpenRouter client** for accessing AILANG-capable models via the
+  OpenAI-compatible OpenRouter API. Used by the AILANG LLM-eval mode
+  to reach models not directly available from Anthropic/OpenAI/Moonshot.
+  Explicit error handling for `AuthenticationError`, `RateLimitError`,
+  `BadRequestError`, `APIStatusError`, empty `choices`, and empty
+  `content` (with `finish_reason` surfaced).
+- **AILANG retry-on-error** in `run_single_problem`. The existing
+  `build_ailang_fix_prompt` was previously dispatched only as
+  unreachable code; now `--max-fix-attempts > 0` actually retries
+  AILANG failures (was silently no-op, undercounting AILANG vs
+  Aver/Vera by the entire attempt-2 contribution).
+- **Worker crash recording** in `run_benchmark`. Both sequential and
+  parallel paths now synthesise a `ProblemResult` with
+  `traceback.format_exc()` in `error_message` when
+  `run_single_problem` raises. Previously, parallel-path worker
+  crashes vanished silently from the JSONL — a 60-problem sweep with
+  2 crashes wrote 58 rows and downstream `vera-bench report` showed
+  "58/58 (100%)" with no record of the crashes.
+
+### Changed
+
+- **Per-test runtime error capture in AILANG evaluator**. The
+  `_evaluate_ailang_code` loop previously `continue`d on timeout and
+  non-zero exit, so a row where every test failed at runtime was
+  indistinguishable from one that compiled but produced wrong output
+  (both showed `check_pass=True, run_correct=False, tests_passed=0,
+  error_message=None`). Now captures the first non-zero
+  stderr/stdout/exit-N marker into `error_message` (truncated to 400
+  chars). Issue [#72](https://github.com/aallan/vera-bench/issues/72)
+  tracks the broader per-test stderr aggregation shared with the
+  Aver path.
+- **Compile-vs-runtime tag classification** in `baseline_runner.py`
+  is now regex-based (`re.search(r"\bError ([A-Z]+)_", err)`) with an
+  explicit `compile_tags = ("PAR", "TC", "MOD", "ELB", "LINK", "TY")`
+  allow-list. Previously used substring matching, which would have
+  silently misclassified a future AILANG release adding `Error
+  PARSER_` (matches `Error PAR`) or any new tag.
+- **Sequential and parallel run_benchmark paths now share fault
+  semantics**. Pre-#73, `--parallel 1` aborted on any worker
+  exception while `--parallel 2+` logged-and-continued. Now both
+  paths wrap `run_single_problem` in identical `try/except` and route
+  crashes through `_crash_result` + `_record` helpers.
+
+### Fixed
+
+- `_strip_ailang_main` brace-counter bug: the previous heuristic
+  mis-classified canonical AILANG main lines like
+  `export func main() -> () ! {IO} {` because `{IO}` provides
+  balanced braces, leaving the body as orphan code that broke the
+  injected per-test-case `main`. Replaced with indentation +
+  bare-`}` regex sentinel logic.
+- `_USER_AGENT` constant in `prompts.py` was stuck at `0.0.9` since
+  that release. Now matches the package version.
+
+### Compatibility note
+
+Vera, Vera spec-from-NL, Python, TypeScript, and Aver scoring is
+unaffected — `0.0.12` is purely additive for those languages. The
+AILANG baseline + LLM-eval mode is a new fourth comparison target;
+result files from `0.0.12` onwards include AILANG rows that
+`0.0.11`-and-earlier sweeps cannot have produced.
+
+The `--parallel N` flag is opt-in; default `parallel=1` exactly
+replicates the `0.0.11` sequential code path. JSONL line content is
+identical between sequential and parallel modes; only ordering may
+differ (parallel writes by completion order, not problem index).
+
 ## [0.0.11] - 2026-05-04
 
 ### Changed
@@ -248,7 +342,8 @@ Vera, Vera spec-from-NL, Python, and TypeScript scoring is unaffected.
 - Claude Sonnet 4: 96% check@1, 96% verify@1, 83% run_correct (50 problems, full-spec mode)
 - Python canonical baselines: 100% run_correct (24 testable problems)
 
-[Unreleased]: https://github.com/aallan/vera-bench/compare/v0.0.11...HEAD
+[Unreleased]: https://github.com/aallan/vera-bench/compare/v0.0.12...HEAD
+[0.0.12]: https://github.com/aallan/vera-bench/compare/v0.0.11...v0.0.12
 [0.0.11]: https://github.com/aallan/vera-bench/compare/v0.0.10...v0.0.11
 [0.0.10]: https://github.com/aallan/vera-bench/compare/v0.0.9...v0.0.10
 [0.0.9]: https://github.com/aallan/vera-bench/compare/v0.0.8...v0.0.9

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — VeraBench
 
-VeraBench is a HumanEval/MBPP-style benchmark for [Vera](https://github.com/aallan/vera), a programming language designed for LLMs. It measures whether LLMs write better code in Vera than in Python, TypeScript, or other comparison languages (currently also [Aver](https://github.com/jasisz/aver)).
+VeraBench is a HumanEval/MBPP-style benchmark for [Vera](https://github.com/aallan/vera), a programming language designed for LLMs. It measures whether LLMs write better code in Vera than in Python, TypeScript, or other comparison languages (currently also [Aver](https://github.com/jasisz/aver) and [AILANG](https://ailang.sunholo.com/)).
 
 ## Quick orientation
 
@@ -20,7 +20,7 @@ vera version   # should print vera 0.0.103 or later
 
 ## Problem structure
 
-Problems live in `problems/tier{1-5}/` as JSON files. Canonical solutions live in `solutions/{vera,python,typescript,aver}/`. Each problem JSON has: `id`, `tier`, `title`, `description`, `description_neutral`, `signature`, `contracts`, `entry_point`, `tags`, `test_cases`, `vera_check_must_pass`, `vera_verify_tier1`, `notes`.
+Problems live in `problems/tier{1-5}/` as JSON files. Canonical solutions live in `solutions/{vera,python,typescript,aver,ailang}/`. Each problem JSON has: `id`, `tier`, `title`, `description`, `description_neutral`, `signature`, `contracts`, `entry_point`, `tags`, `test_cases`, `vera_check_must_pass`, `vera_verify_tier1`, `notes`.
 
 ### `description` vs `description_neutral`
 
@@ -91,6 +91,22 @@ The pattern for adding a new language is established by the Python, TypeScript, 
 
 [Aver](https://github.com/jasisz/aver) is a Haskell-inspired language with strong typing, similar zero-training-data properties to Vera. Its reference doc (`llms.txt`) is fetched from `https://averlang.dev/llms.txt`. The `aver` command must be on `$PATH`.
 
+### AILANG
+
+[AILANG](https://ailang.sunholo.com/) is another zero-training-data language designed for LLM authorship. The `ailang` command must be on `$PATH`. Unlike SKILL.md (Vera) and llms.txt (Aver), the AILANG teaching prompt is **embedded in the `ailang` CLI binary** — `load_ailang_prompt()` shells out to `ailang prompt --source embedded` to retrieve the canonical, version-locked prompt content. This matches how the AILANG eval-harness loads its own prompt and guarantees alignment with the installed CLI version.
+
+AILANG-specific runtime flags used by the harness:
+- `--quiet` — suppresses standard tracing so stdout contains only `println` output (one line per test case)
+- `--caps IO` — grants the IO capability required for `println` in the harness-synthesised `main`
+- `--entry main` — invokes the harness's wrapper, not the LLM's main (which is stripped)
+- `--relax-modules` — required for the LLM-authored single-file solutions
+
+Plus `AILANG_TRACE=off` in the subprocess env. The `_evaluate_ailang_code` evaluator scrubs `*_API_KEY` env vars before invoking AILANG so credentials don't leak into the subprocess.
+
+### Adding more comparison languages
+
+OpenRouter models can be reached via the `OpenRouterClient` (`vera_bench/models.py`) using the OpenAI-compatible API. `MOONSHOT_API_KEY` and `OPENROUTER_API_KEY` are recognised provider env vars in addition to `ANTHROPIC_API_KEY` and `OPENAI_API_KEY`.
+
 ### Tier 5 cross-language caveat
 
 Tier 5 problems test algebraic effect handlers in Vera (`State`, `Exn`, `IO`). Other languages solve these with native idioms (`try/except` in Python, `try/catch` in TypeScript, etc.). Cross-language T5 comparison is apples-to-oranges. See issue [#50](https://github.com/aallan/vera-bench/issues/50).
@@ -110,11 +126,16 @@ Tier 5 problems test algebraic effect handlers in Vera (`State`, `Exn`, `IO`). O
 vera-bench validate                    # check all problem JSONs + canonical solutions
 vera-bench run --model MODEL           # run benchmark
 vera-bench run --model MODEL --tier N  # run one tier
-vera-bench run --model MODEL --language python      # Python LLM generation
+vera-bench run --model MODEL --parallel 10           # parallel sweep (slow models)
+vera-bench run --model MODEL --language python       # Python LLM generation
 vera-bench run --model MODEL --language typescript   # TypeScript LLM generation
 vera-bench run --model MODEL --language aver         # Aver LLM generation
+vera-bench run --model MODEL --language ailang       # AILANG LLM generation
 vera-bench baselines                   # run canonical Python baselines
 vera-bench baselines --language typescript  # TypeScript baselines
 vera-bench baselines --language aver       # Aver baselines
+vera-bench baselines --language ailang     # AILANG baselines
 vera-bench report results/DIR/         # generate report
 ```
+
+`--parallel N` dispatches problems to a `ThreadPoolExecutor` with N workers. Default `parallel=1` preserves the sequential path. Workers are I/O-bound on LLM calls + subprocess `check`/`run`, so the GIL is not a bottleneck. Use this when sweeping slow models (e.g. Kimi K2.5 at ~50s/problem sequentially drops to ~5s/problem at `--parallel 10`). JSONL output ordering is by completion order in parallel mode; each line is self-contained (carries `problem_id`) so downstream consumers can sort if needed.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -47,10 +47,12 @@ guidance is in issue #63.
 
 The canonical chart committed to the repo is currently pinned to
 **v0.0.7** content to match the v0.0.7 narrative in the top-level
-README. The benchmark itself is at v0.0.9 (60 problems vs 50), and the
+README. The benchmark itself has moved on since then — at the time of
+writing, 60 problems vs the v0.0.7 chart's 50, plus additional
+comparison languages (Aver, AILANG) and methodology changes — and the
 plotting script's default invocation regenerates from the *current*
-pyproject version — so running `python scripts/plot_results.py` with
-no args overwrites the pinned image with v0.0.9 content.
+`pyproject.toml` version. So running `python scripts/plot_results.py`
+with no args overwrites the pinned image with current-version content.
 
 If you accidentally overwrite the pin, restore with:
 
@@ -58,9 +60,11 @@ If you accidentally overwrite the pin, restore with:
 python scripts/plot_results.py --version 0.0.7 --output assets/results-graph.png
 ```
 
-**Removal trigger:** when the v0.0.9 narrative is written up in the
-top-level README, the pin can be released — `python scripts/plot_results.py`
-will then regenerate the canonical chart from current data each time.
+**Removal trigger:** when the top-level README narrative is rewritten
+against a current data release (with re-run results across the
+expanded problem set and comparison languages), the pin can be
+released — `python scripts/plot_results.py` will then regenerate the
+canonical chart from current data each time.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ vera-bench run --model claude-sonnet-4-20250514 --language typescript
 vera-bench run --model claude-sonnet-4-20250514 --language aver
 vera-bench run --model claude-sonnet-4-20250514 --language ailang
 
+# Slow model? Dispatch problems concurrently (default is sequential)
+vera-bench run --model kimi-k2.5 --parallel 10
+
 # Run canonical baselines as a reference
 vera-bench baselines
 vera-bench baselines --language typescript
@@ -155,7 +158,7 @@ vera-bench report results/
 python scripts/run_full_benchmark.py
 ```
 
-Supported providers: [Anthropic](https://anthropic.com) (Claude), [OpenAI](https://openai.com) (GPT), and [Kimi](https://platform.kimi.ai) (Moonshot). Set the appropriate API key environment variable (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `MOONSHOT_API_KEY`).
+Supported providers: [Anthropic](https://anthropic.com) (Claude), [OpenAI](https://openai.com) (GPT), [Kimi](https://platform.kimi.ai) (Moonshot), and [OpenRouter](https://openrouter.ai/) (used for AILANG-capable models). Set the appropriate API key environment variable (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `MOONSHOT_API_KEY`, or `OPENROUTER_API_KEY`).
 
 The Vera language reference ([SKILL.md](https://veralang.dev/SKILL.md)) is fetched automatically from veralang.dev when running Vera benchmarks. To use a local copy instead (e.g., for testing unreleased language features):
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,8 @@
 
 ## Where we are
 
+**v0.0.12** — AILANG added as a fourth comparison language alongside Python, TypeScript, and Aver ([#70](https://github.com/aallan/vera-bench/pull/70)). Includes prompt builder, code evaluator, baseline runner, CLI plumbing, and 60 canonical reference solutions. `--parallel N` flag added for concurrent benchmark sweeps via `ThreadPoolExecutor` ([#73](https://github.com/aallan/vera-bench/pull/73)) — default `parallel=1` preserves sequential behaviour. OpenRouter client for AILANG-capable models. Worker crashes in parallel sweeps now write a crash row to JSONL with traceback (previously vanished silently). Compile-vs-runtime tag classification in the AILANG baseline runner is now regex-based with an explicit allow-list. Sequential and parallel paths share fault semantics.
+
 **v0.0.11** — Aver test-wrapper and 56 canonical baselines migrated to string interpolation (`Console.print("{x}")`) for compatibility with Aver 0.16's typed `Console.print`. Three previously-removed Aver baselines (T2-011/012/013) restored using Aver 0.15+ stdlib. Coverage-gap fix in 9 baselines whose `main()` printed only a subset of test cases. Methodology change documented in CHANGELOG.
 
 **v0.0.10** — Aver evaluation harness strips module-header `effects [...]` declarations before injecting the test main, so canonical and LLM-generated solutions continue to compile under Aver 0.13's enforced effects boundary. No-op on Aver 0.12 and earlier; methodology change documented in CHANGELOG.
@@ -18,6 +20,8 @@
 - [x] Run spec-from-NL mode comparison (issue #7)
 - [x] TypeScript baseline runner and LLM generation
 - [x] Aver language support — generation, baselines, `description_neutral` field ([PR #48](https://github.com/aallan/vera-bench/pull/48))
+- [x] AILANG language support — generation, baselines, OpenRouter client, 60 canonical solutions ([PR #70](https://github.com/aallan/vera-bench/pull/70))
+- [x] Parallel benchmark sweeps — `--parallel N` for `ThreadPoolExecutor`-based concurrent dispatch, useful for slow models ([PR #73](https://github.com/aallan/vera-bench/pull/73))
 - [x] Generate paper-quality figures — [`scripts/plot_results.py`](scripts/plot_results.py) produces [`assets/results-graph.png`](assets/results-graph.png) with veralang.dev site palette ([v0.0.7 snapshot](https://github.com/aallan/vera-bench/releases/download/v0.0.7/benchmark_v0.0.7.png))
 - [ ] Hugging Face dataset export
 - [x] [`CITATION.cff`](CITATION.cff)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vera-bench"
-version = "0.0.11"
+version = "0.0.12"
 description = "HumanEval/MBPP-style benchmark for the Vera programming language"
 readme = "README.md"
 license = "MIT"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -163,10 +163,11 @@ the top-level README.
 > **Heads up:** the committed `assets/results-graph.png` is pinned to the
 > **v0.0.7** data (to match the v0.0.7 narrative in the top-level
 > README). Running `python scripts/plot_results.py` with no args will
-> regenerate it from the *current* pyproject bench version (v0.0.9), so
-> it overwrites the pinned image. Don't commit that overwrite until the
-> v0.0.9 writeup is ready; regenerate the pinned image with
-> `--version 0.0.7 --output assets/results-graph.png` to restore it.
+> regenerate it from the *current* pyproject bench version, overwriting
+> the pinned image. Don't commit that overwrite until the README
+> narrative is rewritten against current-version data; regenerate the
+> pinned image with `--version 0.0.7 --output assets/results-graph.png`
+> to restore it.
 
 ### Usage
 

--- a/vera_bench/__init__.py
+++ b/vera_bench/__init__.py
@@ -5,4 +5,7 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("vera-bench")
 except PackageNotFoundError:
-    __version__ = "0.1.0"
+    # Fallback for development checkouts without `pip install -e .`.
+    # Kept in sync with pyproject.toml `version`; the canonical source
+    # is the installed package metadata above.
+    __version__ = "0.0.12"

--- a/vera_bench/prompts.py
+++ b/vera_bench/prompts.py
@@ -23,7 +23,7 @@ AVER_LLMS_TXT_URL = "https://averlang.dev/llms.txt"
 # to retrieve the canonical, version-locked prompt content for the
 # installed AILANG version. No URL fetching required.
 
-_USER_AGENT = "vera-bench/0.0.9"
+_USER_AGENT = "vera-bench/0.0.12"
 
 
 def _fetch_url(url: str, *, timeout: int = 10) -> str:


### PR DESCRIPTION
## Summary

- Bump package version `0.0.11` → `0.0.12` in `pyproject.toml`, the `__init__.py` fallback, and the `_USER_AGENT` constant in `prompts.py` (this last one had been stuck at `0.0.9` since that release).
- Walk through the documentation and resolve drift introduced by the AILANG addition (#70), the `--parallel N` flag (#73), and pre-existing chart-pin staleness.

Docs-only — no behavioral changes to any code path. The three `0.0.x` literal updates are constants.

## What was inconsistent before this PR

Pre-existing drift surfaced by the audit:

- **`vera_bench/__init__.py:8`** had a fallback `__version__ = "0.1.0"` — never matched any actual release (highest released version is `0.0.11`, no `0.1.0` exists). The fallback only fires when the package isn't installed via metadata, but as a literal value it was misleading.
- **`vera_bench/prompts.py:26`** `_USER_AGENT = "vera-bench/0.0.9"` — pinned to the version when the constant was introduced; never updated through 0.0.10 or 0.0.11. Tied to outbound HTTP requests for `SKILL.md` / `llms.txt` fetches, so external observers saw a stale fingerprint.
- **`CLAUDE.md:3`** still said "currently also Aver" — no mention of AILANG despite the language having shipped in #70.
- **`CLAUDE.md:23`** listed `solutions/{vera,python,typescript,aver}/` — missing `ailang` (60 solution files added in #70 weren't reflected in the docs).
- **`CLAUDE.md` Comparison languages section** had an Aver subsection but no AILANG subsection — no documentation of `--quiet`/`--caps IO`/`--entry main`/`--relax-modules`, `AILANG_TRACE=off`, or the `*_API_KEY` env scrubbing pattern.
- **`CLAUDE.md` Commands list** missing `--language ailang` for both `run` and `baselines`, and missing `--parallel N` entirely.
- **`README.md`** missing `--parallel N` example in Quick start, missing OpenRouter from the supported providers list (despite the new `OpenRouterClient` shipping in #70).
- **`ROADMAP.md` "Where we are"** still anchored at v0.0.11 — no mention of AILANG or `--parallel`. Milestone 1 checklist didn't reflect that AILANG language support and parallel sweeps had landed.
- **`KNOWN_ISSUES.md`** chart-pin section referenced "v0.0.9" content in three places; the package is past that, so the references were dated rather than load-bearing.
- **`scripts/README.md`** same chart-pin staleness as `KNOWN_ISSUES.md`.

## CHANGELOG entry

New `## [0.0.12] - 2026-05-25` section documents:

- **Added**: AILANG language (#70), `--parallel N` flag (#73), OpenRouter client, AILANG fix-retry dispatch in `run_single_problem`, worker crash recording in `run_benchmark` (both paths).
- **Changed**: per-test runtime error capture in AILANG evaluator, regex-based compile-vs-runtime tag classification with allow-list, symmetric fault semantics across sequential and parallel paths.
- **Fixed**: `_strip_ailang_main` brace-counter bug, stale `_USER_AGENT`.
- **Compatibility note**: 0.0.12 is purely additive for Vera, Python, TypeScript, and Aver scoring — `--parallel 1` (default) exactly replicates 0.0.11 sequential behavior.

## What's not in this PR (deliberately)

- **`scripts/run_full_benchmark.py`** does not include AILANG targets — PR #70 added the language support but missed updating the sweep script. That's a code change, not a docs change, so I spawned it as a follow-up: extend the targets list to add "AILANG LLM" + "AILANG baselines", bumping the full suite from 8 targets to 10. ~15 lines of code plus matching `scripts/README.md` updates.
- **Test fixture values** `bench_version="0.0.11"` / `vera_version="0.0.108"` in `tests/test_runner.py:2053-2059` are arbitrary strings used by the I5 propagation test (verifying kwargs forwarding through the parallel-path closure). They're not assertions about the current package version. Left as-is.

## Test plan

- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] 229 mock-based tests pass under `pytest` (one known-flaky Rich console-width test that fails locally on narrow terminals, passes in CI — pre-existing, unrelated to this change)
- [x] `python -c "import vera_bench; print(vera_bench.__version__)"` resolves via `importlib.metadata` (fallback only fires for non-installed checkouts)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AILANG comparison-language support with retry-on-error and per-test runtime error capture
  * Introduced --parallel N for concurrent benchmark sweeps with completion-order JSONL output
  * Integrated OpenRouter client for AILANG-capable models; worker crash recording persisted

* **Bug Fixes**
  * Improved compile-vs-runtime classification (regex-based) and fixed error-tag detection
  * Synchronized User-Agent/package version values

* **Documentation**
  * Updated release notes, CLI examples, README and roadmap for v0.0.12

* **Chores**
  * Bumped package version to 0.0.12 and version fallback updated

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aallan/vera-bench/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->