### PR TITLE
scripts/run_full_benchmark.py: include AILANG targets in sweep

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,11 +14,11 @@ the installed package, but kept in-repo for reproducibility.
 
 ## `run_full_benchmark.py` — full matrix benchmark runner
 
-Runs all eight benchmark targets for a single model, writing result JSONLs to
+Runs all ten benchmark targets for a single model, writing result JSONLs to
 `results/` and a timing summary to `results/timing.json`. Running it once per
 model sweeps the full matrix used by `plot_results.py`.
 
-### The eight targets
+### The ten targets
 
 | # | Target | Uses |
 |---|--------|------|
@@ -27,11 +27,13 @@ model sweeps the full matrix used by `plot_results.py`.
 | 3 | Python LLM | model |
 | 4 | TypeScript LLM | model (via `npx tsx`) |
 | 5 | Aver LLM | model + Aver compiler + llms.txt |
-| 6 | Python baselines | canonical `solutions/python/*.py` |
-| 7 | TypeScript baselines | canonical `solutions/typescript/*.ts` |
-| 8 | Aver baselines | canonical `solutions/aver/*.av` |
+| 6 | AILANG LLM | model + AILANG compiler + embedded teaching prompt |
+| 7 | Python baselines | canonical `solutions/python/*.py` |
+| 8 | TypeScript baselines | canonical `solutions/typescript/*.ts` |
+| 9 | Aver baselines | canonical `solutions/aver/*.av` |
+| 10 | AILANG baselines | canonical `solutions/ailang/*.ail` |
 
-Targets 6–8 don't call an LLM — they just run the canonical solutions against
+Targets 7–10 don't call an LLM — they just run the canonical solutions against
 each problem's test cases to confirm the problem JSONs are self-consistent.
 Skip them with `--skip-baselines` when running multiple models back-to-back
 (they produce the same numbers every time).
@@ -146,7 +148,7 @@ problems that already have a passing attempt on file.
 | `1` | One or more targets failed, or missing API key / unknown model |
 
 A failed target does **not** abort the rest — the script always runs all
-eight, writes `timing.json` with each target's status, then exits non-zero
+ten, writes `timing.json` with each target's status, then exits non-zero
 at the end if any failed. This makes partial-run recovery straightforward.
 
 ---

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -95,6 +95,7 @@ done
 vera-bench baselines
 vera-bench baselines --language typescript
 vera-bench baselines --language aver
+vera-bench baselines --language ailang
 
 # Headline chart
 python scripts/plot_results.py
@@ -104,7 +105,7 @@ python scripts/plot_results.py
 
 Rough per-model totals observed on v0.0.9 (60 problems, 2026-04):
 
-| Provider / model | Full suite (8 targets) |
+| Provider / model | Full suite (10 targets) |
 |------------------|-----------------------|
 | Claude Opus 4 | ~17 min |
 | Claude Sonnet 4 | ~15 min |
@@ -119,7 +120,7 @@ once we have data to attribute.
 
 ### Output files
 
-For model `M` at bench version `V` and compiler versions `VV` / `AV`:
+For model `M` at bench version `V` and compiler versions `VV` (Vera) / `AV` (Aver) / `LV` (AILANG):
 
 | File | Contents |
 |------|----------|
@@ -128,7 +129,8 @@ For model `M` at bench version `V` and compiler versions `VV` / `AV`:
 | `results/{M}-python-bench-{V}.jsonl` | Python generation attempts |
 | `results/{M}-typescript-bench-{V}.jsonl` | TypeScript generation attempts |
 | `results/{M}-aver-bench-{V}-aver-{AV}.jsonl` | Aver generation attempts |
-| `results/{python,typescript,aver}-baseline.jsonl` | Canonical solution runs |
+| `results/{M}-ailang-bench-{V}-ailang-{LV}.jsonl` | AILANG generation attempts |
+| `results/{python,typescript,aver,ailang}-baseline.jsonl` | Canonical solution runs |
 | `results/timing.json` | Per-target wall-clock + status for the most recent run |
 
 Each JSONL line is **one attempt on one problem** — failed `vera check`/`aver

--- a/scripts/run_full_benchmark.py
+++ b/scripts/run_full_benchmark.py
@@ -247,6 +247,17 @@ def main() -> int:
                 "aver",
             ],
         ),
+        (
+            "AILANG LLM",
+            [
+                "vera-bench",
+                "run",
+                "--model",
+                model,
+                "--language",
+                "ailang",
+            ],
+        ),
     ]
 
     if not args.skip_baselines:
@@ -269,6 +280,15 @@ def main() -> int:
                         "baselines",
                         "--language",
                         "aver",
+                    ],
+                ),
+                (
+                    "AILANG baselines",
+                    [
+                        "vera-bench",
+                        "baselines",
+                        "--language",
+                        "ailang",
                     ],
                 ),
             ]

--- a/scripts/run_full_benchmark.py
+++ b/scripts/run_full_benchmark.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run the full VeraBench benchmark suite (all 8 targets).
+"""Run the full VeraBench benchmark suite (all 10 targets).
 
 Usage:
   # Interactive mode — prompts for model and API key
@@ -13,15 +13,17 @@ Usage:
   ANTHROPIC_API_KEY=sk-ant-... \
     python scripts/run_full_benchmark.py --model claude-sonnet-4-20250514
 
-Runs all 8 targets:
+Runs all 10 targets:
   1. Vera full-spec
   2. Vera spec-from-NL
   3. Python LLM generation
   4. TypeScript LLM generation
   5. Aver LLM generation
-  6. Python baselines
-  7. TypeScript baselines
-  8. Aver baselines
+  6. AILANG LLM generation
+  7. Python baselines
+  8. TypeScript baselines
+  9. Aver baselines
+  10. AILANG baselines
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Closes the gap from [#70](https://github.com/aallan/vera-bench/pull/70): AILANG language support landed (prompt builder, code evaluator, baseline runner, CLI flag, 60 canonical solutions) but `scripts/run_full_benchmark.py` wasn't extended to include AILANG targets in the sweep. Running `python scripts/run_full_benchmark.py --model M` still only swept Vera / Python / TypeScript / Aver — AILANG had to be invoked separately.

## Changes

### `scripts/run_full_benchmark.py` (+20 lines)
- New **`AILANG LLM`** target running `vera-bench run --model {model} --language ailang`
- New **`AILANG baselines`** target running `vera-bench baselines --language ailang` (inside the `if not args.skip_baselines` block)

### `scripts/README.md` (+5/-3 lines)
- Baselines example block now includes `vera-bench baselines --language ailang`
- `Full suite (8 targets)` → `Full suite (10 targets)` in the timing table
- Output-files table: new row `results/{M}-ailang-bench-{V}-ailang-{LV}.jsonl` for AILANG generation attempts; updated the baseline-files line to include `ailang`
- Caption clarified: `VV` (Vera) / `AV` (Aver) / `LV` (AILANG) — three compiler-version placeholders, unambiguously named. (The pre-existing caption only mentioned `VV / AV` and was already ambiguous with AILANG in flight; this nails it down.)

## Why a separate PR

The v0.0.12 docs PR ([#74](https://github.com/aallan/vera-bench/pull/74)) is intentionally docs-only — version bump plus consistency pass through the README/CLAUDE/ROADMAP/CHANGELOG layer. The sweep-script extension is a small but real code change, so it lives here. Both PRs touch `scripts/README.md` but in different sections (chart-pin warning vs targets/output-files), so they'll auto-merge cleanly regardless of merge order.

## Verification

- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `python -c "import ast; ast.parse(...)"` parses `scripts/run_full_benchmark.py`
- [x] `python scripts/run_full_benchmark.py --help` runs and shows the expected argparse output
- [ ] CI green

## Test plan

- [ ] CI lint + tests
- [ ] Optional manual smoke: `python scripts/run_full_benchmark.py --model claude-haiku-4-5 --skip-baselines` should now run 5 LLM targets (Vera full-spec, Vera spec-from-NL, Python, TypeScript, Aver, **AILANG**) instead of the prior 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AILANG support to the full benchmark suite, including LLM and baseline benchmark targets.

* **Documentation**
  * Updated benchmark docs and timings to reflect the expanded 10‑target suite and clarified output files to include AILANG generation results and compiler version information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aallan/vera-bench/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->