### PR TITLE
Bump version to 0.0.13 for the Claude 4 deprecation migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.13] - 2026-05-29
+
 ### Changed
 
 - **Default Anthropic flagship migrated from Claude Opus 4 to Claude
@@ -368,7 +370,8 @@ Vera, Vera spec-from-NL, Python, and TypeScript scoring is unaffected.
 - Claude Sonnet 4: 96% check@1, 96% verify@1, 83% run_correct (50 problems, full-spec mode)
 - Python canonical baselines: 100% run_correct (24 testable problems)
 
-[Unreleased]: https://github.com/aallan/vera-bench/compare/v0.0.12...HEAD
+[Unreleased]: https://github.com/aallan/vera-bench/compare/v0.0.13...HEAD
+[0.0.13]: https://github.com/aallan/vera-bench/compare/v0.0.12...v0.0.13
 [0.0.12]: https://github.com/aallan/vera-bench/compare/v0.0.11...v0.0.12
 [0.0.11]: https://github.com/aallan/vera-bench/compare/v0.0.10...v0.0.11
 [0.0.10]: https://github.com/aallan/vera-bench/compare/v0.0.9...v0.0.10

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,8 @@
 
 ## Where we are
 
+**v0.0.13** — Default Anthropic flagship migrated from Claude Opus 4 to Claude Opus 4.8 (`claude-opus-4-8`), and Sonnet-tier migrated from Claude Sonnet 4 to Claude Sonnet 4.6 (`claude-sonnet-4-6`) ([#76](https://github.com/aallan/vera-bench/pull/76)). Both predecessors are deprecated and retire 2026-06-15, so this migration is pre-emptive. Per the 4.6-generation naming convention, the new model IDs are dateless and are themselves pinned snapshots (not evergreen aliases). No methodology change — Vera/Python/TypeScript/Aver/AILANG scoring is unaffected.
+
 **v0.0.12** — AILANG added as a fourth comparison language alongside Python, TypeScript, and Aver ([#70](https://github.com/aallan/vera-bench/pull/70)). Includes prompt builder, code evaluator, baseline runner, CLI plumbing, and 60 canonical reference solutions. `--parallel N` flag added for concurrent benchmark sweeps via `ThreadPoolExecutor` ([#73](https://github.com/aallan/vera-bench/pull/73)) — default `parallel=1` preserves sequential behaviour. OpenRouter client for AILANG-capable models. Worker crashes in parallel sweeps now write a crash row to JSONL with traceback (previously vanished silently). Compile-vs-runtime tag classification in the AILANG baseline runner is now regex-based with an explicit allow-list. Sequential and parallel paths share fault semantics.
 
 **v0.0.11** — Aver test-wrapper and 56 canonical baselines migrated to string interpolation (`Console.print("{x}")`) for compatibility with Aver 0.16's typed `Console.print`. Three previously-removed Aver baselines (T2-011/012/013) restored using Aver 0.15+ stdlib. Coverage-gap fix in 9 baselines whose `main()` printed only a subset of test cases. Methodology change documented in CHANGELOG.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,18 +1,6 @@
 # Roadmap
 
-## Where we are
-
-**v0.0.13** — Default Anthropic flagship migrated from Claude Opus 4 to Claude Opus 4.8 (`claude-opus-4-8`), and Sonnet-tier migrated from Claude Sonnet 4 to Claude Sonnet 4.6 (`claude-sonnet-4-6`) ([#76](https://github.com/aallan/vera-bench/pull/76)). Both predecessors are deprecated and retire 2026-06-15, so this migration is pre-emptive. Per the 4.6-generation naming convention, the new model IDs are dateless and are themselves pinned snapshots (not evergreen aliases). No methodology change — Vera/Python/TypeScript/Aver/AILANG scoring is unaffected.
-
-**v0.0.12** — AILANG added as a fourth comparison language alongside Python, TypeScript, and Aver ([#70](https://github.com/aallan/vera-bench/pull/70)). Includes prompt builder, code evaluator, baseline runner, CLI plumbing, and 60 canonical reference solutions. `--parallel N` flag added for concurrent benchmark sweeps via `ThreadPoolExecutor` ([#73](https://github.com/aallan/vera-bench/pull/73)) — default `parallel=1` preserves sequential behaviour. OpenRouter client for AILANG-capable models. Worker crashes in parallel sweeps now write a crash row to JSONL with traceback (previously vanished silently). Compile-vs-runtime tag classification in the AILANG baseline runner is now regex-based with an explicit allow-list. Sequential and parallel paths share fault semantics.
-
-**v0.0.11** — Aver test-wrapper and 56 canonical baselines migrated to string interpolation (`Console.print("{x}")`) for compatibility with Aver 0.16's typed `Console.print`. Three previously-removed Aver baselines (T2-011/012/013) restored using Aver 0.15+ stdlib. Coverage-gap fix in 9 baselines whose `main()` printed only a subset of test cases. Methodology change documented in CHANGELOG.
-
-**v0.0.10** — Aver evaluation harness strips module-header `effects [...]` declarations before injecting the test main, so canonical and LLM-generated solutions continue to compile under Aver 0.13's enforced effects boundary. No-op on Aver 0.12 and earlier; methodology change documented in CHANGELOG.
-
-**v0.0.9** — 60 problems across 5 tiers (10 new T2/T3 problems with testable signatures). T1–T4 `run_correct` pool expanded from 18 to 30 testable problems. New T3 problems use Int-only signatures with internal ADT construction for CLI testability.
-
-**v0.0.8** — 50 problems across 5 tiers with strengthened postconditions and explicit slot ordering descriptions. Working LLM harness (Anthropic, OpenAI, Moonshot), Python, TypeScript, and Aver baseline runners, cross-language generation comparison. Full benchmark runner script. SKILL.md and Aver's llms.txt fetched at runtime. Language-neutral problem descriptions (`description_neutral`) for fair cross-language prompting.
+This file tracks **forward-looking** milestones. For what has shipped in each release, see [CHANGELOG.md](CHANGELOG.md).
 
 ## Milestone 1: Publication-ready benchmark (current)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vera-bench"
-version = "0.0.12"
+version = "0.0.13"
 description = "HumanEval/MBPP-style benchmark for the Vera programming language"
 readme = "README.md"
 license = "MIT"

--- a/vera_bench/__init__.py
+++ b/vera_bench/__init__.py
@@ -8,4 +8,4 @@ except PackageNotFoundError:
     # Fallback for development checkouts without `pip install -e .`.
     # Kept in sync with pyproject.toml `version`; the canonical source
     # is the installed package metadata above.
-    __version__ = "0.0.12"
+    __version__ = "0.0.13"

--- a/vera_bench/prompts.py
+++ b/vera_bench/prompts.py
@@ -23,7 +23,7 @@ AVER_LLMS_TXT_URL = "https://averlang.dev/llms.txt"
 # to retrieve the canonical, version-locked prompt content for the
 # installed AILANG version. No URL fetching required.
 
-_USER_AGENT = "vera-bench/0.0.12"
+_USER_AGENT = "vera-bench/0.0.13"
 
 
 def _fetch_url(url: str, *, timeout: int = 10) -> str:


### PR DESCRIPTION
## Summary

Companion bump PR to cut v0.0.13 — the substantive work landed in [#76](https://github.com/aallan/vera-bench/pull/76) (Anthropic Claude 4 deprecation migration). This PR carries:

1. **Version bump** in the three canonical locations: `pyproject.toml`, `vera_bench/__init__.py` fallback, and `vera_bench/prompts.py` `_USER_AGENT` — all from `0.0.12` → `0.0.13`
2. **CHANGELOG promotion**: existing `[Unreleased]` entry renamed to `[0.0.13] - 2026-05-29`, new compare links
3. **ROADMAP cleanup**: stripped the "Where we are" section entirely. It duplicated CHANGELOG content and was a single-source-of-truth violation; ROADMAP is forward-looking only, release history lives in CHANGELOG

## Why two commits

- `4f785ba` — version bump + CHANGELOG promotion (the v0.0.13 release work)
- `4d13011` — ROADMAP cleanup (structural fix, drops a duplicative "Where we are" history section that had been accumulating since v0.0.8)

Both are release-scoped changes but they answer different questions, so they're kept separate for review readability.

## What's in v0.0.13

One substantive change from #76:

- **Default Anthropic flagship**: `claude-opus-4-20250514` → **`claude-opus-4-8`** (Claude Opus 4.8)
- **Default Anthropic Sonnet-tier**: `claude-sonnet-4-20250514` → **`claude-sonnet-4-6`** (Claude Sonnet 4.6)

Both predecessors are deprecated and retire **2026-06-15**, so this migration is pre-emptive — without it, the default Anthropic sweep slots would start returning 404 from the API in ~3 weeks. Per the 4.6-generation naming convention, the new IDs are dateless and are themselves pinned snapshots (not evergreen aliases).

No methodology change: Vera, Vera spec-from-NL, Python, TypeScript, Aver, and AILANG scoring are unaffected.

## Verification

- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `grep "0\.0\.12"` returns only legitimate historical references (prior CHANGELOG entries)
- [ ] CI green

## Test plan

- [ ] CI lint + tests
- [ ] After merge: create `v0.0.13` tag at the merge commit and the GitHub release with notes derived from this CHANGELOG entry

## Acknowledgment

The "release PR" pattern this PR represents is a workflow error I made — the version bump and CHANGELOG promotion should have been in #76 itself, atomically with the substantive change. Recovery path: merge this PR, going forward all release-scoped changes go in the feature PR. Memory file updated to enforce the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Changelog and roadmap updated to reflect the v0.0.13 release.

* **Chores**
  * Project and package version bumped to 0.0.13.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aallan/vera-bench/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->