### PR TITLE
docs(codecov): fix stale --cov-fail-under comment (35 → 80)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 # threshold is a delta (not absolute floor) — "don't drop by more than 1%".
-# The absolute floor is enforced by CI's --cov-fail-under=35.
+# The absolute floor is enforced by CI's --cov-fail-under=80.
 coverage:
   status:
     project:


### PR DESCRIPTION
## Summary

`codecov.yml` line 2 documents the CI absolute floor as `--cov-fail-under=35`, but `.github/workflows/ci.yml:73` has been at `--cov-fail-under=80` for a while. The floor was raised at some point and this explanatory comment did not follow — pure documentation drift, no behavioural impact.

## Diff

```diff
 # threshold is a delta (not absolute floor) — "don't drop by more than 1%".
-# The absolute floor is enforced by CI's --cov-fail-under=35.
+# The absolute floor is enforced by CI's --cov-fail-under=80.
```

## How this was found

Surfaced during a Codecov integration audit prompted by the [Harness/Codecov acquisition announcement](https://www.prnewswire.com/news-releases/harness-acquires-codecov-from-sentry-to-strengthen-software-delivery-governance-in-the-ai-era-302487862.html) (2026-06-02). Cataloguing our integration surface to understand what could be affected, I noticed this comment didn't match reality. Unrelated to the acquisition itself — purely a stale-comment catch.

Same class of finding as the v0.0.12 audit's `_USER_AGENT = "vera-bench/0.0.9"` drift: a config artifact nobody reads day-to-day that quietly diverged from the source of truth.

## Verification

- [x] `grep "cov-fail-under" .github/workflows/ci.yml` confirms the actual value is 80
- [x] `git diff` confirms the one-line change
- [x] codecov.yml YAML schema is unchanged (no thresholds or paths modified) so no behavioural impact
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->