### PR TITLE
ci: SHA-pin codecov/codecov-action (v6 → e79a6962)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.12'
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml


### PR DESCRIPTION
## Summary

Defense-in-depth SHA-pin for the `codecov/codecov-action` GitHub Action following the [Harness/Codecov acquisition](https://www.prnewswire.com/news-releases/harness-acquires-codecov-from-sentry-to-strengthen-software-delivery-governance-in-the-ai-era-302487862.html) announced 2026-06-02. Replaces the moving `@v6` tag with the immutable SHA it currently resolves to (same commit as the `v6.0.1` release).

## Diff

```diff
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
```

## Why

Under new ownership, a moving major-version tag like `@v6` could be re-pointed — intentionally during a rebrand, or accidentally during a transition. SHA-pinning means:

- Our CI behaviour is frozen to the code at this specific commit
- Any upstream change has to come through a reviewed PR rather than silently flowing in via a tag move
- If an attacker (or a misclick) re-points `@v6` to inject telemetry / mining / anything else, our workflow won't pick it up

## Upgrade path preserved

The trailing `# v6.0.1` comment follows the Dependabot `github-actions` ecosystem convention. Dependabot reads the comment and opens upgrade PRs with both the SHA and the version comment updated atomically. We don't lose mechanical patch-release tracking — we just gain a beat to review each upgrade.

## Surface audit

`grep -rn "codecov/codecov-action" .github/` returned **one** match, at `.github/workflows/ci.yml:77`. If you remembered "two" references, you may have been thinking of the Codecov badge URL in `README.md` (which is `codecov.io/gh/...` HTML, not a GitHub Action and not SHA-pinnable). Let me know if there's a second reference I'm missing — happy to extend this PR.

## Verification

- [x] SHA `e79a6962e0d4c0c17b229090214935d2e33f8354` confirmed via `gh api repos/codecov/codecov-action/tags` — this is the commit `v6` currently dereferences to AND is the same commit `v6.0.1` is annotated against
- [x] [Browseable at codecov/codecov-action](https://github.com/codecov/codecov-action/tree/e79a6962e0d4c0c17b229090214935d2e33f8354)
- [ ] CI green (the test-with-coverage job needs to upload to Codecov; this PR verifies the SHA-pinned action still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI infrastructure dependencies to pinned versions for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->