### PR TITLE
aver: replace the removed integer `/` operator with Int.div

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.14] - 2026-06-03
+
+### Changed
+
+- **Aver baselines migrated from the integer `/` operator to
+  `Int.div`** ([#82](https://github.com/aallan/vera-bench/pull/82), by
+  [@jasisz](https://github.com/jasisz), Aver's upstream author).
+  Aver's upcoming release drops the partial integer `/` operator —
+  integer division can divide by zero (and overflow on `i64::MIN /
+  -1`), so it's now the `Result`-returning function `Int.div(a, b) :
+  Result<Int, String>`, matching `Int.mod` and Aver's "partial
+  operations are functions" rule. (Float `/` stays a total
+  operator.) Five Aver baselines used integer `/`:
+  - `VB_T3_011_safe_divide` and `VB_T5_003_safe_division_exceptions`
+    consume `Int.div`'s `Result` idiomatically via `match Ok/Err`.
+    The redundant manual `b == 0` checks are gone — `Int.div`
+    already reports the failure — and `try_div` in T5-003
+    simplifies to `Int.div(a, b)`, since the function was literally
+    re-implementing what `Int.div` now does.
+  - `VB_T1_007_safe_modulo` (`a - (a / b) * b`),
+    `VB_T4_002_greatest_common_divisor` (`a - (a / b) * b`), and
+    `VB_T4_007_count_digits` (`n / 10`) use
+    `Result.withDefault(Int.div(...), 0)` — the divisor is
+    precondition-guaranteed non-zero in each context, so the
+    sentinel never fires in practice.
+
+### Compatibility note
+
+Aver scoring on the upcoming Aver release (post-0.23) requires
+v0.0.14 — without this release, every `aver run` against an
+`Int.div`-aware compiler would fail. For Aver ≤ 0.23, the converse
+applies: these baselines will not compile against `Int.div`-less
+compilers. Result files are tagged with `bench_version` so
+cross-version comparisons can detect this boundary.
+
+Same forward-compat shape as v0.0.11's `Console.print("{x}")`
+migration for Aver 0.16. Vera, Vera spec-from-NL, Python,
+TypeScript, and AILANG scoring are unaffected — `0.0.14` is purely
+an Aver baseline migration for those languages.
+
 ## [0.0.13] - 2026-05-29
 
 ### Changed
@@ -370,7 +410,8 @@ Vera, Vera spec-from-NL, Python, and TypeScript scoring is unaffected.
 - Claude Sonnet 4: 96% check@1, 96% verify@1, 83% run_correct (50 problems, full-spec mode)
 - Python canonical baselines: 100% run_correct (24 testable problems)
 
-[Unreleased]: https://github.com/aallan/vera-bench/compare/v0.0.13...HEAD
+[Unreleased]: https://github.com/aallan/vera-bench/compare/v0.0.14...HEAD
+[0.0.14]: https://github.com/aallan/vera-bench/compare/v0.0.13...v0.0.14
 [0.0.13]: https://github.com/aallan/vera-bench/compare/v0.0.12...v0.0.13
 [0.0.12]: https://github.com/aallan/vera-bench/compare/v0.0.11...v0.0.12
 [0.0.11]: https://github.com/aallan/vera-bench/compare/v0.0.10...v0.0.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vera-bench"
-version = "0.0.13"
+version = "0.0.14"
 description = "HumanEval/MBPP-style benchmark for the Vera programming language"
 readme = "README.md"
 license = "MIT"

--- a/solutions/aver/VB_T1_007_safe_modulo.av
+++ b/solutions/aver/VB_T1_007_safe_modulo.av
@@ -3,7 +3,7 @@ module SafeModulo
 
 fn safe_modulo(a: Int, b: Int) -> Int
     ? "Returns a modulo b. Assumes b != 0."
-    a - (a / b) * b
+    a - Result.withDefault(Int.div(a, b), 0) * b
 
 verify safe_modulo
     safe_modulo(10, 3) => 1

--- a/solutions/aver/VB_T3_011_safe_divide.av
+++ b/solutions/aver/VB_T3_011_safe_divide.av
@@ -8,9 +8,9 @@ type DivResult
 
 fn safe_divide(a: Int, b: Int) -> Int
     ? "Returns a / b, or -1 if b is zero."
-    r: DivResult = match b == 0
-        true  -> DivResult.Failure
-        false -> DivResult.Success(a / b)
+    r: DivResult = match Int.div(a, b)
+        Result.Ok(q)  -> DivResult.Success(q)
+        Result.Err(_) -> DivResult.Failure
     match r
         DivResult.Failure -> -1
         DivResult.Success(v) -> v

--- a/solutions/aver/VB_T4_002_greatest_common_divisor.av
+++ b/solutions/aver/VB_T4_002_greatest_common_divisor.av
@@ -8,7 +8,7 @@ fn gcd(a: Int, b: Int) -> Int
     ? "Returns the greatest common divisor of a and b."
     match b
         0 -> a
-        _ -> gcd(b, a - (a / b) * b)
+        _ -> gcd(b, a - Result.withDefault(Int.div(a, b), 0) * b)
 
 verify gcd
     gcd(12, 8)   => 4

--- a/solutions/aver/VB_T4_007_count_digits.av
+++ b/solutions/aver/VB_T4_007_count_digits.av
@@ -8,7 +8,7 @@ fn count_digits(n: Int) -> Int
     ? "Returns the number of digits in n. Handles 0 as having 1 digit."
     match n < 10
         true  -> 1
-        false -> 1 + count_digits(n / 10)
+        false -> 1 + count_digits(Result.withDefault(Int.div(n, 10), 0))
 
 verify count_digits
     count_digits(0)       => 1

--- a/solutions/aver/VB_T5_003_safe_division_exceptions.av
+++ b/solutions/aver/VB_T5_003_safe_division_exceptions.av
@@ -3,10 +3,8 @@ module SafeDivisionExceptions
     exposes [safe_div]
 
 fn try_div(a: Int, b: Int) -> Result<Int, String>
-    ? "Returns Ok(a/b) or Err if b is zero."
-    match b == 0
-        true  -> Result.Err("division by zero")
-        false -> Result.Ok(a / b)
+    ? "Returns Ok(a/b) or Err if b is zero — Int.div already is exactly this."
+    Int.div(a, b)
 
 fn safe_div(a: Int, b: Int) -> Int
     ? "Returns a/b, or -1 if b is zero."

--- a/vera_bench/__init__.py
+++ b/vera_bench/__init__.py
@@ -8,4 +8,4 @@ except PackageNotFoundError:
     # Fallback for development checkouts without `pip install -e .`.
     # Kept in sync with pyproject.toml `version`; the canonical source
     # is the installed package metadata above.
-    __version__ = "0.0.13"
+    __version__ = "0.0.14"

--- a/vera_bench/prompts.py
+++ b/vera_bench/prompts.py
@@ -23,7 +23,7 @@ AVER_LLMS_TXT_URL = "https://averlang.dev/llms.txt"
 # to retrieve the canonical, version-locked prompt content for the
 # installed AILANG version. No URL fetching required.
 
-_USER_AGENT = "vera-bench/0.0.13"
+_USER_AGENT = "vera-bench/0.0.14"
 
 
 def _fetch_url(url: str, *, timeout: int = 10) -> str:


### PR DESCRIPTION
Aver's upcoming release drops the partial integer `/` operator — integer division can divide by zero (and overflow on `i64::MIN / -1`), so it's now the `Result`-returning function `Int.div(a, b) : Result<Int, String>`, matching `Int.mod` and Aver's "partial operations are functions" rule. (Float `/` stays a total operator.)

Five aver baselines used integer `/`:

- **`VB_T3_011_safe_divide`, `VB_T5_003_safe_division_exceptions`** — these exist to handle div-by-zero, so they consume `Int.div`'s `Result` idiomatically: `match` Ok/Err. The redundant manual `b == 0` check is gone (Int.div already reports it); `try_div` is now simply `Int.div(a, b)`.
- **`VB_T1_007_safe_modulo`, `VB_T4_002_greatest_common_divisor`** (`a - (a / b) * b`), **`VB_T4_007_count_digits`** (`n / 10`) — the divisor is known non-zero in context, so the division unwraps via `Result.withDefault(Int.div(...), 0)`.

Every `verify` block passes and `main` runs against the upcoming aver build (safe_modulo 4/4, gcd 5/5, safe_divide 5/5, count_digits 5/5, safe_division_exceptions 6/6).

**Note:** these require the upcoming aver release (`Int.div`); they will not run on aver ≤ 0.23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added changelog entry for version 0.0.14 documenting baseline migration and compatibility notes for cross-version compilation.

* **Chores**
  * Updated package version to 0.0.14 across project metadata and version tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->