### PR TITLE
ci: fix Dependabot github-actions label mismatch

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -20,5 +20,5 @@ updates:
     commit-message:
       prefix: "ci"
     labels:
-      - "ci"
+      - "infrastructure"
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

Fixes Dependabot's "label not found" comments by aligning `.github/dependabot.yaml` with the actual repo label inventory. Surfaced by [#81](https://github.com/aallan/vera-bench/pull/81) (gitleaks-action bump), which posted:

> The following labels could not be found: `ci`. Please create it before this PR is merged.

## Two broken label references — both fixed

| Line | Ecosystem | Specified | Resolution |
|---|---|---|---|
| 12 | pip | `dependencies` | Created the `dependencies` label out-of-band (see below); config unchanged |
| 23 | github-actions | `ci` | Changed to `infrastructure` (existing label covering "Build, CI, tooling, storage") |

The pip ecosystem issue was a silent finding — pip Dependabot PRs have been landing unlabeled too, but the failure didn't surface as visibly as the github-actions one did. Audit pattern matches the v0.0.12 `_USER_AGENT` drift: config nobody read end-to-end accumulated multiple stale references, only one of them visible.

## Diff

```diff
       commit-message:
         prefix: "ci"
       labels:
-        - "ci"
+        - "infrastructure"
       open-pull-requests-limit: 5
```

## Out-of-band: `dependencies` label created

```bash
gh label create dependencies \
  --description "Pull requests that update a dependency file" \
  --color "0366d6"
```

That's GitHub's default `dependencies` label color and description, so the label looks like the convention from GitHub itself. No code change needed — the existing pip ecosystem config (line 12: `labels: ["dependencies"]`) now works as-is.

## Why `infrastructure` for github-actions and not `dependencies`

Two reasonable choices: tag github-actions Dependabot PRs as `infrastructure` (CI-focused) or `dependencies` (dependency-upgrade-focused). github-actions PRs are technically both — but they touch CI workflows specifically, and `infrastructure` is the more informative tag at a glance (you instantly see "this PR changes CI" rather than just "this PR updates a dependency"). The pip ecosystem keeps `dependencies` because runtime Python deps don't have an existing CI/infrastructure dimension to tag against.

If you'd prefer `[infrastructure, dependencies]` on github-actions PRs to capture both axes, that's a one-character edit (change line 23 from `- "infrastructure"` to two array entries). Happy to do that as a follow-up.

## Verification

- [x] `gh label list` confirms both `dependencies` and `infrastructure` exist
- [x] Single-line config diff verified via `git diff`
- [x] No Dependabot rerun needed — next pip / github-actions PR picks up the right label automatically
- [ ] CI green

## Scope note

No vera-bench behavior change — pure CI metadata fix, no version bump or CHANGELOG entry (per the release-atomicity rule, only release-worthy behavior changes get version bumps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the labelling of automated GitHub Actions dependency update pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->