### PR TITLE
fix: VB-T5-002 latent verification gap (bumps to v0.0.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.15] - 2026-06-22
+
+### Fixed
+
+- **`VB-T5-002 greeter_io_boundary` canonical Vera solution** removed
+  unused `greet_all` and `greet_loop` helper functions that were not
+  required by the problem spec. The helpers contained a latent
+  verification gap: `greet_loop` called `greet(...)` in *statement
+  position* (discarded result) without propagating `greet`'s
+  precondition `requires(string_length(@String.0) > 0)`. Pre-Vera
+  v0.0.176 the verifier silently skipped statement-position calls
+  during call-site precondition checking ([aallan/vera#730](https://github.com/aallan/vera/issues/730)),
+  hiding the gap. v0.0.176 closed that hole, and `vera verify` on the
+  pre-fix solution failed with `E501` and a counterexample showing an
+  empty-string array element would violate `greet`'s contract. The
+  fix simplifies the canonical solution to exactly what the problem
+  asks for: the `effect IO` declaration, `build_greeting` (pure
+  helper), and `greet` (IO entry point). No `greet_all` / `greet_loop`.
+
+### Compatibility note
+
+This is a **forward-compat methodology release** for Vera v0.0.176
+and later. Same shape as v0.0.11 (Aver 0.16 `Console.print` typing)
+and v0.0.14 (upcoming Aver `Int.div` migration): an upstream
+compiler tightened its semantics, vera-bench had a latent gap, and
+this release updates the canonical solution to be strictly correct.
+
+For Vera ≤ v0.0.175 (when statement-position calls were silently
+skipped by the call-site precondition checker), the previous canonical
+solution worked but was technically writing incorrect Vera. For Vera
+≥ v0.0.176, v0.0.14 and earlier vera-bench releases fail `vera
+verify` on VB-T5-002 — this is the unblock.
+
+Bisection trail: v0.0.175 passed verification (9 Tier 1 + 1 Tier 3),
+v0.0.176 introduced the call-site check and failed with `E501`,
+v0.0.177 carried the same failure forward. Confirmed locally in a
+fresh venv across all three releases.
+
+Vera, Aver, Python, TypeScript, and AILANG scoring for other
+problems are unaffected — the change is scoped to the single
+VB-T5-002 canonical solution. All other 59 canonical Vera solutions
+still verify cleanly against v0.0.177.
+
 ## [0.0.14] - 2026-06-03
 
 ### Changed
@@ -410,7 +453,8 @@ Vera, Vera spec-from-NL, Python, and TypeScript scoring is unaffected.
 - Claude Sonnet 4: 96% check@1, 96% verify@1, 83% run_correct (50 problems, full-spec mode)
 - Python canonical baselines: 100% run_correct (24 testable problems)
 
-[Unreleased]: https://github.com/aallan/vera-bench/compare/v0.0.14...HEAD
+[Unreleased]: https://github.com/aallan/vera-bench/compare/v0.0.15...HEAD
+[0.0.15]: https://github.com/aallan/vera-bench/compare/v0.0.14...v0.0.15
 [0.0.14]: https://github.com/aallan/vera-bench/compare/v0.0.13...v0.0.14
 [0.0.13]: https://github.com/aallan/vera-bench/compare/v0.0.12...v0.0.13
 [0.0.12]: https://github.com/aallan/vera-bench/compare/v0.0.11...v0.0.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vera-bench"
-version = "0.0.14"
+version = "0.0.15"
 description = "HumanEval/MBPP-style benchmark for the Vera programming language"
 readme = "README.md"
 license = "MIT"

--- a/solutions/vera/VB-T5-002_greeter.vera
+++ b/solutions/vera/VB-T5-002_greeter.vera
@@ -22,27 +22,3 @@ public fn greet(@String -> @Unit)
 {
   IO.print(build_greeting(@String.0))
 }
-
--- IO: greet multiple names
-private fn greet_all(@Array<String> -> @Unit)
-  requires(true)
-  ensures(true)
-  effects(<IO>)
-{
-  let @Nat = array_length(@Array<String>.0);
-  greet_loop(@Array<String>.0, 0, @Nat.0)
-}
-
-private fn greet_loop(@Array<String>, @Nat, @Nat -> @Unit)
-  requires(@Nat.1 <= @Nat.0)
-  ensures(true)
-  decreases(@Nat.0 - @Nat.1)
-  effects(<IO>)
-{
-  if @Nat.1 >= @Nat.0 then {
-    ()
-  } else {
-    greet(@Array<String>.0[@Nat.1]);
-    greet_loop(@Array<String>.0, @Nat.1 + 1, @Nat.0)
-  }
-}

--- a/vera_bench/__init__.py
+++ b/vera_bench/__init__.py
@@ -8,4 +8,4 @@ except PackageNotFoundError:
     # Fallback for development checkouts without `pip install -e .`.
     # Kept in sync with pyproject.toml `version`; the canonical source
     # is the installed package metadata above.
-    __version__ = "0.0.14"
+    __version__ = "0.0.15"

--- a/vera_bench/prompts.py
+++ b/vera_bench/prompts.py
@@ -23,7 +23,7 @@ AVER_LLMS_TXT_URL = "https://averlang.dev/llms.txt"
 # to retrieve the canonical, version-locked prompt content for the
 # installed AILANG version. No URL fetching required.
 
-_USER_AGENT = "vera-bench/0.0.14"
+_USER_AGENT = "vera-bench/0.0.15"
 
 
 def _fetch_url(url: str, *, timeout: int = 10) -> str:


### PR DESCRIPTION
## Summary

Fixes the VB-T5-002 verification regression that's blocking main CI (visible on [#85](https://github.com/aallan/vera-bench/pull/85)) and ships it as v0.0.15. PR #85 itself is innocent — vera-bench's CI pins Vera to HEAD via `pip install git+https://github.com/aallan/vera.git`, and Vera HEAD moved through 9 releases between vera-bench's last green main (2026-06-08) and PR #85's run (2026-06-22). One of them changed verify semantics in a way that surfaced a latent bug in VB-T5-002's canonical solution.

## Diagnosis (bisection)

Fresh venv, sequential install + `vera verify solutions/vera/VB-T5-002_greeter.vera`:

| Vera | Result | Verifications |
|---|---|---|
| v0.0.167 (last known good) | ✅ OK | 8 Tier 1 + 1 Tier 3 |
| v0.0.175 | ✅ OK | 9 Tier 1 + 1 Tier 3 |
| **v0.0.176** | ❌ **FAIL with E501** | (regression) |
| v0.0.177 | ❌ FAIL with same E501 | (carried forward) |

Breaking change: Vera v0.0.176 closed [aallan/vera#730](https://github.com/aallan/vera/issues/730) — "Call-site precondition checking now covers calls in **statement position**." A call whose result is discarded (`greet(...);` followed by `;`) was previously skipped by the verifier; v0.0.176 fixed that hole.

VB-T5-002's `greet_loop` called `greet(@Array<String>.0[@Nat.1]);` in statement position without propagating `greet`'s precondition `requires(string_length(@String.0) > 0)`. SMT counterexample showed an empty-string array element would violate the contract. **Vera's finding is legitimate — vera-bench was technically writing incorrect Vera; v0.0.176 just stopped silently hiding it.**

## The fix

The problem JSON for VB-T5-002 only requires `build_greeting` and `greet`. The `greet_all` and `greet_loop` helpers were gratuitous over-engineering not in the spec. Removing them eliminates the latent gap entirely — no runtime guards, no contract gymnastics, just the code the problem actually asks for.

```diff
-- IO: print the greeting
public fn greet(@String -> @Unit)
  requires(string_length(@String.0) > 0)
  ensures(true)
  effects(<IO>)
{
  IO.print(build_greeting(@String.0))
}

- -- IO: greet multiple names
- private fn greet_all(@Array<String> -> @Unit) ...
- private fn greet_loop(@Array<String>, @Nat, @Nat -> @Unit) ...
```

After fix: 3 Tier 1 + 1 Tier 3 verifications on v0.0.177, status **OK**. Swept all 60 canonical Vera solutions against v0.0.177 — no other latent gaps surfaced.

## Release artifacts (per the release-atomicity rule)

All in this single PR — no separate "release PR":

- `solutions/vera/VB-T5-002_greeter.vera` — the actual fix (-24 lines)
- `pyproject.toml`: 0.0.14 → 0.0.15
- `vera_bench/__init__.py` fallback: 0.0.14 → 0.0.15
- `vera_bench/prompts.py` `_USER_AGENT`: `vera-bench/0.0.14` → `vera-bench/0.0.15`
- `CHANGELOG.md`: new `[0.0.15] - 2026-06-22` section with `Fixed` entry and `Compatibility note` documenting the v0.0.176 boundary (mirrors v0.0.11 / v0.0.14 forward-compat shape). Compare links updated.

ROADMAP intentionally untouched — maintenance release, no milestone delivered.

## Why this version is a forward-compat release

Same shape as v0.0.11 (Aver 0.16 `Console.print` typing) and v0.0.14 (upcoming Aver `Int.div` migration): upstream compiler tightened semantics, vera-bench had a latent gap, this release updates the canonical solution to be strictly correct.

- Vera ≤ v0.0.175: previous canonical solution worked but was technically writing incorrect Vera (silently skipped statement-position check)
- Vera ≥ v0.0.176: v0.0.14-and-earlier vera-bench releases fail `vera verify` on VB-T5-002 — this PR unblocks

## Verification

- [x] `vera verify VB-T5-002_greeter.vera` passes on v0.0.176 + v0.0.177
- [x] All 60 canonical Vera solutions pass on v0.0.177 (full sweep)
- [x] `ruff check .` / `ruff format --check .` clean
- [ ] CI green — this PR is the unblock for the failure first visible on [#85](https://github.com/aallan/vera-bench/pull/85), so green CI here implies #85 will also pass once rebased

## Follow-up after merge

- Tag `v0.0.15` at the merge commit + create GitHub release with CHANGELOG `[0.0.15]` as notes
- PR #85 (checkout v7) becomes mergeable once rebased onto post-this main

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a specific issue affecting one canonical solution, improving compatibility with newer Vera versions.
  * Clarified behaviour for older Vera releases in the changelog.

* **Chores**
  * Bumped the package version to `0.0.15`.
  * Updated release tracking and generated metadata for the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->