### PR TITLE
Vera 0.1.x compat: clamp rename, State handler semantics, tier flips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Vera 0.1.x compatibility for the problem set and canonical
+  solutions.** Vera moved from v0.0.177 to v0.1.6+ (the v0.1.0 bug
+  burndown plus the 0.1.x line) and three compiler changes broke
+  `vera-bench validate` (22/60 failures). All three are now resolved;
+  the benchmark validates 60/60 against Vera HEAD (v0.1.6,
+  `f6f586b0`):
+  - **VB-T1-002 renamed `clamp` → `clamp_to_range`** across the
+    problem JSON (signature, entry_point, prose) and all five
+    canonical solutions (TypeScript as `clampToRange`). Vera 0.1.x
+    makes `clamp` a built-in (spec §9.6) and rejects redefinition
+    with `E151` — the problem was unwritable as specified. Problem
+    `id` is unchanged (`VB-T1-002`).
+  - **State-handler solutions updated for intrinsic-hybrid clause
+    semantics** ([vera#1003](https://github.com/aallan/vera/issues/1003),
+    shipped in Vera 0.1.x; see also vera#976/#973/#988). Handler
+    clause bodies used to be type-checked but never executed — the
+    runtime always used builtin state-cell semantics. Now clause
+    bodies execute, and the old `put(@Int) -> { resume(()) } with
+    @Int = @Int.0` idiom resolves `@Int.0` to the handler state, so
+    the "update" is state = old-state — a silent no-op that made
+    VB-T5-001 return 0 instead of 3 and broke 3 of 4 VB-T5-006 test
+    cases. All four State solutions (T5-001, T5-004, T5-006,
+    T5-009) drop the `with` clause; the intrinsic store threads
+    state natively (the canonical form in SKILL.md's `run_counter`
+    example). T5-004/T5-009 passed tests only incidentally and
+    carried the same latent no-op.
+  - **`vera_verify_tier1` flipped to `false` on 19 problems**
+    (T1-008, T1-010, T2-001, T2-010, T2-014, T3-001..005, T3-008,
+    T3-012, T4-001, T4-004, T4-005, T4-007, T4-008, T4-010,
+    T5-004). Vera 0.1.x auto-synthesises `int_overflow` /
+    `nat_to_int_coerce` proof obligations on all integer
+    arithmetic; on unbounded `Int`/`Nat` inputs these are
+    legitimately unprovable at Tier 1 (proving them would require
+    adding range preconditions — changing the published contracts
+    of 19 problems). The obligations are checked at Tier 3
+    (runtime) instead, which is the correct classification. This
+    flag gates only canonical validation; LLM `verify@1` scoring
+    is computed from `verify_pass` and is unaffected.
+
+### Compatibility note
+
+Requires Vera ≥ 0.1.x (the intrinsic-hybrid handler semantics and
+`clamp` built-in). Canonical Vera solutions no longer compile/run
+correctly on Vera ≤ 0.0.x: the renamed `clamp_to_range` does not
+collide there (fine), but the State solutions rely on the new
+clause-execution semantics. Aver baselines verified unchanged on
+Aver 0.27.1 (the v0.0.14 `Int.div` migration was forward-compatible
+throughout); AILANG baselines verified on AILANG v0.30.0.
+
 ## [0.0.15] - 2026-06-22
 
 ### Fixed

--- a/problems/tier1/VB_T1_002_clamp.json
+++ b/problems/tier1/VB_T1_002_clamp.json
@@ -1,10 +1,10 @@
 {
   "id": "VB-T1-002",
   "tier": 1,
-  "title": "Clamp",
-  "description": "Write a Vera function that clamps an integer to a range [lo, hi]. Takes three Int parameters: value, lo, hi. Precondition: lo <= hi. Postconditions: result is within [lo, hi].",
+  "title": "Clamp to Range",
+  "description": "Write a Vera function that clamps an integer to a range [lo, hi]. Takes three Int parameters: value, lo, hi. Precondition: lo <= hi. Postconditions: result is within [lo, hi]. Note: name the function clamp_to_range \u2014 'clamp' itself is a Vera built-in (spec \u00a79.6) and cannot be redefined.",
   "description_neutral": "Clamp an integer to a range [lo, hi]. Takes three parameters: value, lo, hi (where lo <= hi). Returns lo if value < lo, hi if value > hi, otherwise value.",
-  "signature": "public fn clamp(@Int, @Int, @Int -> @Int)",
+  "signature": "public fn clamp_to_range(@Int, @Int, @Int -> @Int)",
   "contracts": {
     "requires": [
       "@Int.1 <= @Int.0"
@@ -15,7 +15,7 @@
     ],
     "effects": "pure"
   },
-  "entry_point": "clamp",
+  "entry_point": "clamp_to_range",
   "tags": [
     "arithmetic",
     "conditional",
@@ -59,5 +59,5 @@
   ],
   "vera_check_must_pass": true,
   "vera_verify_tier1": true,
-  "notes": "Three same-typed params make slot ordering tricky: clamp(value, lo, hi) gives @Int.0=hi, @Int.1=lo, @Int.2=value. Key test of De Bruijn understanding."
+  "notes": "Three same-typed params make slot ordering tricky: clamp_to_range(value, lo, hi) gives @Int.0=hi, @Int.1=lo, @Int.2=value. Key test of De Bruijn understanding. Renamed from 'clamp' when Vera 0.1.x made clamp a built-in (E151 redefinition error)."
 }

--- a/problems/tier1/VB_T1_008_distance.json
+++ b/problems/tier1/VB_T1_008_distance.json
@@ -6,19 +6,52 @@
   "description_neutral": "Compute the absolute difference between two integers. Returns a non-negative integer.",
   "signature": "public fn distance(@Int, @Int -> @Nat)",
   "contracts": {
-    "requires": ["true"],
-    "ensures": ["@Nat.result >= 0"],
+    "requires": [
+      "true"
+    ],
+    "ensures": [
+      "@Nat.result >= 0"
+    ],
     "effects": "pure"
   },
   "entry_point": "distance",
-  "tags": ["arithmetic", "conditional", "Nat-return", "absolute-difference"],
+  "tags": [
+    "arithmetic",
+    "conditional",
+    "Nat-return",
+    "absolute-difference"
+  ],
   "test_cases": [
-    {"args": [3, 7], "expected": 4},
-    {"args": [7, 3], "expected": 4},
-    {"args": [5, 5], "expected": 0},
-    {"args": [-3, 3], "expected": 6}
+    {
+      "args": [
+        3,
+        7
+      ],
+      "expected": 4
+    },
+    {
+      "args": [
+        7,
+        3
+      ],
+      "expected": 4
+    },
+    {
+      "args": [
+        5,
+        5
+      ],
+      "expected": 0
+    },
+    {
+      "args": [
+        -3,
+        3
+      ],
+      "expected": 6
+    }
   ],
   "vera_check_must_pass": true,
-  "vera_verify_tier1": true,
+  "vera_verify_tier1": false,
   "notes": "distance(a, b): @Int.0=b, @Int.1=a. Tests Nat return type (non-negative refinement) and conditional logic for absolute difference."
 }

--- a/problems/tier1/VB_T1_010_double_or_nothing.json
+++ b/problems/tier1/VB_T1_010_double_or_nothing.json
@@ -6,19 +6,47 @@
   "description_neutral": "Double a positive integer. Return 0 for non-positive inputs.",
   "signature": "public fn double_or_nothing(@Int -> @Int)",
   "contracts": {
-    "requires": ["true"],
-    "ensures": ["@Int.result >= 0"],
+    "requires": [
+      "true"
+    ],
+    "ensures": [
+      "@Int.result >= 0"
+    ],
     "effects": "pure"
   },
   "entry_point": "double_or_nothing",
-  "tags": ["arithmetic", "conditional", "multiplication"],
+  "tags": [
+    "arithmetic",
+    "conditional",
+    "multiplication"
+  ],
   "test_cases": [
-    {"args": [5], "expected": 10},
-    {"args": [0], "expected": 0},
-    {"args": [-3], "expected": 0},
-    {"args": [1], "expected": 2}
+    {
+      "args": [
+        5
+      ],
+      "expected": 10
+    },
+    {
+      "args": [
+        0
+      ],
+      "expected": 0
+    },
+    {
+      "args": [
+        -3
+      ],
+      "expected": 0
+    },
+    {
+      "args": [
+        1
+      ],
+      "expected": 2
+    }
   ],
   "vera_check_must_pass": true,
-  "vera_verify_tier1": true,
+  "vera_verify_tier1": false,
   "notes": "Simple conditional with multiplication. Tests basic arithmetic and the conditional pattern."
 }

--- a/problems/tier2/VB_T2_001_sum_array.json
+++ b/problems/tier2/VB_T2_001_sum_array.json
@@ -23,6 +23,6 @@
   ],
   "test_cases": [],
   "vera_check_must_pass": true,
-  "vera_verify_tier1": true,
+  "vera_verify_tier1": false,
   "notes": "Tests whether the agent discovers array_fold and writes the correct closure syntax. The closure inside array_fold needs its own effects(pure) annotation."
 }

--- a/problems/tier2/VB_T2_010_sum_positives.json
+++ b/problems/tier2/VB_T2_010_sum_positives.json
@@ -6,14 +6,25 @@
   "description_neutral": "Sum only the positive elements in an integer list.",
   "signature": "public fn sum_positives(@Array<Int> -> @Int)",
   "contracts": {
-    "requires": ["true"],
-    "ensures": ["true"],
+    "requires": [
+      "true"
+    ],
+    "ensures": [
+      "true"
+    ],
     "effects": "pure"
   },
   "entry_point": "sum_positives",
-  "tags": ["array", "builtin-discovery", "array-filter", "array-fold", "composition", "higher-order"],
+  "tags": [
+    "array",
+    "builtin-discovery",
+    "array-filter",
+    "array-fold",
+    "composition",
+    "higher-order"
+  ],
   "test_cases": [],
   "vera_check_must_pass": true,
-  "vera_verify_tier1": true,
+  "vera_verify_tier1": false,
   "notes": "Tests composing array_filter + array_fold. Both closures need effects(pure). The fold accumulator starts at 0."
 }

--- a/problems/tier2/VB_T2_014_combined_length.json
+++ b/problems/tier2/VB_T2_014_combined_length.json
@@ -6,20 +6,60 @@
   "description_neutral": "Return the combined length of two strings.",
   "signature": "public fn combined_length(@String, @String -> @Nat)",
   "contracts": {
-    "requires": ["true"],
-    "ensures": ["true"],
+    "requires": [
+      "true"
+    ],
+    "ensures": [
+      "true"
+    ],
     "effects": "pure"
   },
   "entry_point": "combined_length",
-  "tags": ["string", "builtin-discovery", "string-length", "composition", "two-string-params"],
+  "tags": [
+    "string",
+    "builtin-discovery",
+    "string-length",
+    "composition",
+    "two-string-params"
+  ],
   "test_cases": [
-    {"args": ["hello", "world"], "expected": 10},
-    {"args": ["", ""], "expected": 0},
-    {"args": ["a", "bc"], "expected": 3},
-    {"args": ["test", ""], "expected": 4},
-    {"args": ["", "xyz"], "expected": 3}
+    {
+      "args": [
+        "hello",
+        "world"
+      ],
+      "expected": 10
+    },
+    {
+      "args": [
+        "",
+        ""
+      ],
+      "expected": 0
+    },
+    {
+      "args": [
+        "a",
+        "bc"
+      ],
+      "expected": 3
+    },
+    {
+      "args": [
+        "test",
+        ""
+      ],
+      "expected": 4
+    },
+    {
+      "args": [
+        "",
+        "xyz"
+      ],
+      "expected": 3
+    }
   ],
   "vera_check_must_pass": true,
-  "vera_verify_tier1": true,
+  "vera_verify_tier1": false,
   "notes": "Tests composing string_length with addition. Contracts are trivial (ensures(true)) so Z3-verifiable at Tier 1. String operations are in the body only, not in contracts."
 }

--- a/problems/tier3/VB_T3_001_list_length.json
+++ b/problems/tier3/VB_T3_001_list_length.json
@@ -24,6 +24,6 @@
   ],
   "test_cases": [],
   "vera_check_must_pass": true,
-  "vera_verify_tier1": true,
+  "vera_verify_tier1": false,
   "notes": "The agent must define data List { Nil, Cons(Int, List) } AND write the function. Inside match Cons(@Int, @List), @List.0 refers to the tail (matched binding), not the parameter. This is THE core De Bruijn test."
 }

--- a/problems/tier3/VB_T3_002_tree_depth.json
+++ b/problems/tier3/VB_T3_002_tree_depth.json
@@ -25,6 +25,6 @@
   ],
   "test_cases": [],
   "vera_check_must_pass": true,
-  "vera_verify_tier1": true,
+  "vera_verify_tier1": false,
   "notes": "Requires let bindings for intermediate results inside Branch arm. Tests that the agent discovers max() is a prefix-less builtin. Inside Branch(@Tree, @Tree), @Tree.0 is right child, @Tree.1 is left."
 }

--- a/problems/tier3/VB_T3_003_expression_evaluator.json
+++ b/problems/tier3/VB_T3_003_expression_evaluator.json
@@ -25,6 +25,6 @@
   ],
   "test_cases": [],
   "vera_check_must_pass": true,
-  "vera_verify_tier1": true,
+  "vera_verify_tier1": false,
   "notes": "Three-variant ADT with recursion. Inside Add(@Expr, @Expr), @Expr.0 is the right sub-expr, @Expr.1 is the left. Agent must use 0 - eval_expr(@Expr.0) for negation (no unary minus on function calls)."
 }

--- a/problems/tier3/VB_T3_004_list_sum.json
+++ b/problems/tier3/VB_T3_004_list_sum.json
@@ -6,14 +6,25 @@
   "description_neutral": "Define a linked list type with nil and cons constructors, then write a function that sums all elements.",
   "signature": "public fn list_sum(@List -> @Int)",
   "contracts": {
-    "requires": ["true"],
-    "ensures": ["true"],
+    "requires": [
+      "true"
+    ],
+    "ensures": [
+      "true"
+    ],
     "effects": "pure"
   },
   "entry_point": "list_sum",
-  "tags": ["adt", "pattern-matching", "recursion", "decreases", "data-definition", "arithmetic"],
+  "tags": [
+    "adt",
+    "pattern-matching",
+    "recursion",
+    "decreases",
+    "data-definition",
+    "arithmetic"
+  ],
   "test_cases": [],
   "vera_check_must_pass": true,
-  "vera_verify_tier1": true,
+  "vera_verify_tier1": false,
   "notes": "Inside Cons(@Int, @List), @Int.0 is the matched head, @List.0 is the matched tail. The agent must define the List ADT and use decreases(@List.0)."
 }

--- a/problems/tier3/VB_T3_005_tree_sum.json
+++ b/problems/tier3/VB_T3_005_tree_sum.json
@@ -6,14 +6,25 @@
   "description_neutral": "Define a binary tree type with leaf and branch constructors, then write a function that sums all leaf values.",
   "signature": "public fn tree_sum(@Tree -> @Int)",
   "contracts": {
-    "requires": ["true"],
-    "ensures": ["true"],
+    "requires": [
+      "true"
+    ],
+    "ensures": [
+      "true"
+    ],
     "effects": "pure"
   },
   "entry_point": "tree_sum",
-  "tags": ["adt", "pattern-matching", "recursion", "decreases", "data-definition", "tree"],
+  "tags": [
+    "adt",
+    "pattern-matching",
+    "recursion",
+    "decreases",
+    "data-definition",
+    "tree"
+  ],
   "test_cases": [],
   "vera_check_must_pass": true,
-  "vera_verify_tier1": true,
+  "vera_verify_tier1": false,
   "notes": "Inside Branch(@Tree, @Tree), @Tree.0 is the right subtree, @Tree.1 is the left. Both must be summed recursively."
 }

--- a/problems/tier3/VB_T3_008_tree_count_leaves.json
+++ b/problems/tier3/VB_T3_008_tree_count_leaves.json
@@ -27,5 +27,5 @@
   "test_cases": [],
   "vera_check_must_pass": true,
   "vera_verify_tier1": false,
-  "notes": "The ensures clause @Nat.result >= 1 is verifiable at Tier 1 because the base case returns 1 and the recursive case sums two values each >= 1."
+  "notes": "The ensures clause @Nat.result >= 1 itself still proves at Tier 1 (base case returns 1; recursive case sums two values each >= 1). vera_verify_tier1 is false because Vera 0.1.x auto-synthesises an int_overflow obligation on the recursive sum (tree_count_leaves(l) + tree_count_leaves(r)) which is unprovable at Tier 1 for unbounded trees and is checked at Tier 3 (runtime) instead."
 }

--- a/problems/tier3/VB_T3_008_tree_count_leaves.json
+++ b/problems/tier3/VB_T3_008_tree_count_leaves.json
@@ -6,14 +6,26 @@
   "description_neutral": "Define a binary tree type with leaf and branch constructors. Write a function that counts the number of leaf nodes. The result is always at least 1 (every tree has at least one leaf).",
   "signature": "public fn tree_count_leaves(@Tree -> @Nat)",
   "contracts": {
-    "requires": ["true"],
-    "ensures": ["@Nat.result >= 1"],
+    "requires": [
+      "true"
+    ],
+    "ensures": [
+      "@Nat.result >= 1"
+    ],
     "effects": "pure"
   },
   "entry_point": "tree_count_leaves",
-  "tags": ["adt", "pattern-matching", "recursion", "decreases", "data-definition", "tree", "counting"],
+  "tags": [
+    "adt",
+    "pattern-matching",
+    "recursion",
+    "decreases",
+    "data-definition",
+    "tree",
+    "counting"
+  ],
   "test_cases": [],
   "vera_check_must_pass": true,
-  "vera_verify_tier1": true,
+  "vera_verify_tier1": false,
   "notes": "The ensures clause @Nat.result >= 1 is verifiable at Tier 1 because the base case returns 1 and the recursive case sums two values each >= 1."
 }

--- a/problems/tier3/VB_T3_012_pair_sum.json
+++ b/problems/tier3/VB_T3_012_pair_sum.json
@@ -6,20 +6,61 @@
   "description_neutral": "Construct a pair from two integers, then use pattern matching to extract both components and return their sum.",
   "signature": "public fn pair_sum(@Int, @Int -> @Int)",
   "contracts": {
-    "requires": ["true"],
-    "ensures": ["true"],
+    "requires": [
+      "true"
+    ],
+    "ensures": [
+      "true"
+    ],
     "effects": "pure"
   },
   "entry_point": "pair_sum",
-  "tags": ["adt", "pattern-matching", "data-definition", "two-params", "pair", "de-bruijn"],
+  "tags": [
+    "adt",
+    "pattern-matching",
+    "data-definition",
+    "two-params",
+    "pair",
+    "de-bruijn"
+  ],
   "test_cases": [
-    {"args": [3, 4], "expected": 7},
-    {"args": [0, 0], "expected": 0},
-    {"args": [-5, 5], "expected": 0},
-    {"args": [10, -3], "expected": 7},
-    {"args": [100, 200], "expected": 300}
+    {
+      "args": [
+        3,
+        4
+      ],
+      "expected": 7
+    },
+    {
+      "args": [
+        0,
+        0
+      ],
+      "expected": 0
+    },
+    {
+      "args": [
+        -5,
+        5
+      ],
+      "expected": 0
+    },
+    {
+      "args": [
+        10,
+        -3
+      ],
+      "expected": 7
+    },
+    {
+      "args": [
+        100,
+        200
+      ],
+      "expected": 300
+    }
   ],
   "vera_check_must_pass": true,
-  "vera_verify_tier1": true,
+  "vera_verify_tier1": false,
   "notes": "Parameters: pair_sum(a, b). @Int.0=b, @Int.1=a. The function constructs MkPair(@Int.1, @Int.0) then matches. Inside MkPair(@Int, @Int), @Int.0 is the second field (b) and @Int.1 is the first field (a). Tests De Bruijn indexing inside multi-field constructors."
 }

--- a/problems/tier4/VB_T4_001_fibonacci.json
+++ b/problems/tier4/VB_T4_001_fibonacci.json
@@ -48,6 +48,6 @@
     }
   ],
   "vera_check_must_pass": true,
-  "vera_verify_tier1": true,
+  "vera_verify_tier1": false,
   "notes": "Classic recursion with two base cases. decreases(@Nat.0) is straightforward. Tests whether the agent remembers to include it."
 }

--- a/problems/tier4/VB_T4_004_power.json
+++ b/problems/tier4/VB_T4_004_power.json
@@ -6,20 +6,60 @@
   "description_neutral": "Compute base raised to the power of exponent using repeated multiplication. power(base, 0) = 1, power(base, exp) = base * power(base, exp-1).",
   "signature": "public fn power(@Nat, @Nat -> @Nat)",
   "contracts": {
-    "requires": ["true"],
-    "ensures": ["@Nat.result >= 0"],
+    "requires": [
+      "true"
+    ],
+    "ensures": [
+      "@Nat.result >= 0"
+    ],
     "effects": "pure"
   },
   "entry_point": "power",
-  "tags": ["recursion", "decreases", "termination", "multiplication", "two-params"],
+  "tags": [
+    "recursion",
+    "decreases",
+    "termination",
+    "multiplication",
+    "two-params"
+  ],
   "test_cases": [
-    {"args": [2, 10], "expected": 1024},
-    {"args": [3, 0], "expected": 1},
-    {"args": [5, 1], "expected": 5},
-    {"args": [2, 0], "expected": 1},
-    {"args": [1, 100], "expected": 1}
+    {
+      "args": [
+        2,
+        10
+      ],
+      "expected": 1024
+    },
+    {
+      "args": [
+        3,
+        0
+      ],
+      "expected": 1
+    },
+    {
+      "args": [
+        5,
+        1
+      ],
+      "expected": 5
+    },
+    {
+      "args": [
+        2,
+        0
+      ],
+      "expected": 1
+    },
+    {
+      "args": [
+        1,
+        100
+      ],
+      "expected": 1
+    }
   ],
   "vera_check_must_pass": true,
-  "vera_verify_tier1": true,
+  "vera_verify_tier1": false,
   "notes": "power(base, exp): @Nat.0=exp, @Nat.1=base. decreases(@Nat.0) because the exponent decreases. The agent must identify that the exponent (rightmost Nat) is the decreasing parameter."
 }

--- a/problems/tier4/VB_T4_005_sum_to_n.json
+++ b/problems/tier4/VB_T4_005_sum_to_n.json
@@ -6,19 +6,49 @@
   "description_neutral": "Compute the sum 0 + 1 + 2 + ... + n using recursion.",
   "signature": "public fn sum_to_n(@Nat -> @Nat)",
   "contracts": {
-    "requires": ["true"],
-    "ensures": ["@Nat.result >= 0", "@Nat.result == @Nat.0 * (@Nat.0 + 1) / 2"],
+    "requires": [
+      "true"
+    ],
+    "ensures": [
+      "@Nat.result >= 0",
+      "@Nat.result == @Nat.0 * (@Nat.0 + 1) / 2"
+    ],
     "effects": "pure"
   },
   "entry_point": "sum_to_n",
-  "tags": ["recursion", "decreases", "termination", "arithmetic"],
+  "tags": [
+    "recursion",
+    "decreases",
+    "termination",
+    "arithmetic"
+  ],
   "test_cases": [
-    {"args": [0], "expected": 0},
-    {"args": [1], "expected": 1},
-    {"args": [5], "expected": 15},
-    {"args": [10], "expected": 55}
+    {
+      "args": [
+        0
+      ],
+      "expected": 0
+    },
+    {
+      "args": [
+        1
+      ],
+      "expected": 1
+    },
+    {
+      "args": [
+        5
+      ],
+      "expected": 15
+    },
+    {
+      "args": [
+        10
+      ],
+      "expected": 55
+    }
   ],
   "vera_check_must_pass": true,
-  "vera_verify_tier1": true,
+  "vera_verify_tier1": false,
   "notes": "Simple recursion with decreases(@Nat.0). sum_to_n(0)=0, sum_to_n(n)=n+sum_to_n(n-1)."
 }

--- a/problems/tier4/VB_T4_007_count_digits.json
+++ b/problems/tier4/VB_T4_007_count_digits.json
@@ -6,20 +6,55 @@
   "description_neutral": "Count the number of decimal digits in a non-negative integer. The number 0 has 1 digit.",
   "signature": "public fn count_digits(@Nat -> @Nat)",
   "contracts": {
-    "requires": ["true"],
-    "ensures": ["@Nat.result >= 1"],
+    "requires": [
+      "true"
+    ],
+    "ensures": [
+      "@Nat.result >= 1"
+    ],
     "effects": "pure"
   },
   "entry_point": "count_digits",
-  "tags": ["recursion", "decreases", "termination", "division", "counting"],
+  "tags": [
+    "recursion",
+    "decreases",
+    "termination",
+    "division",
+    "counting"
+  ],
   "test_cases": [
-    {"args": [0], "expected": 1},
-    {"args": [9], "expected": 1},
-    {"args": [42], "expected": 2},
-    {"args": [12345], "expected": 5},
-    {"args": [1000000], "expected": 7}
+    {
+      "args": [
+        0
+      ],
+      "expected": 1
+    },
+    {
+      "args": [
+        9
+      ],
+      "expected": 1
+    },
+    {
+      "args": [
+        42
+      ],
+      "expected": 2
+    },
+    {
+      "args": [
+        12345
+      ],
+      "expected": 5
+    },
+    {
+      "args": [
+        1000000
+      ],
+      "expected": 7
+    }
   ],
   "vera_check_must_pass": true,
-  "vera_verify_tier1": true,
+  "vera_verify_tier1": false,
   "notes": "decreases(@Nat.0) works because n / 10 < n for n >= 10. The base case is n < 10."
 }

--- a/problems/tier4/VB_T4_008_multiply.json
+++ b/problems/tier4/VB_T4_008_multiply.json
@@ -54,6 +54,6 @@
     }
   ],
   "vera_check_must_pass": true,
-  "vera_verify_tier1": true,
+  "vera_verify_tier1": false,
   "notes": "multiply(a, b): @Nat.0=b, @Nat.1=a. decreases(@Nat.0) because b decreases."
 }

--- a/problems/tier4/VB_T4_010_div_natural.json
+++ b/problems/tier4/VB_T4_010_div_natural.json
@@ -63,6 +63,6 @@
     }
   ],
   "vera_check_must_pass": true,
-  "vera_verify_tier1": true,
+  "vera_verify_tier1": false,
   "notes": "div_natural(a, b): @Nat.0=b (divisor), @Nat.1=a (dividend). decreases(@Nat.1) because a decreases by b each step. Common mistake: writing decreases(@Nat.0) which would be wrong since b stays constant. This tests whether the agent reasons about which parameter actually decreases."
 }

--- a/problems/tier5/VB_T5_001_counter.json
+++ b/problems/tier5/VB_T5_001_counter.json
@@ -30,5 +30,5 @@
   ],
   "vera_check_must_pass": true,
   "vera_verify_tier1": false,
-  "notes": "Tests handle[State<Int>] with get/put, calling a pure helper from within the handler body. State operations must be inlined in the handler body (calling a separate function with effects(<State<Int>>) from within the handler body causes a codegen issue). The handler uses 'with @Int = @Int.0' to update state on put."
+  "notes": "Tests handle[State<Int>] with get/put, calling a pure helper from within the handler body. State operations must be inlined in the handler body (calling a separate function with effects(<State<Int>>) from within the handler body causes a codegen issue). Since Vera 0.1.x intrinsic-hybrid handler semantics (vera#1003), the put clause is written without a 'with' state-update clause \u2014 the intrinsic store threads state natively; 'with @Int = @Int.0' now executes literally as state=old-state (a no-op)."
 }

--- a/problems/tier5/VB_T5_004_accumulator.json
+++ b/problems/tier5/VB_T5_004_accumulator.json
@@ -6,19 +6,50 @@
   "description_neutral": "Compute the sum of integers from 1 to n using a stateful accumulator pattern. Use a helper function for addition.",
   "signature": "public fn sum_with_state(@Nat -> @Int)",
   "contracts": {
-    "requires": ["true"],
-    "ensures": ["true"],
+    "requires": [
+      "true"
+    ],
+    "ensures": [
+      "true"
+    ],
     "effects": "pure"
   },
   "entry_point": "sum_with_state",
-  "tags": ["state-effect", "handler", "pure-helper", "where-block", "loop", "get-put"],
+  "tags": [
+    "state-effect",
+    "handler",
+    "pure-helper",
+    "where-block",
+    "loop",
+    "get-put"
+  ],
   "test_cases": [
-    {"args": [5], "expected": 15},
-    {"args": [0], "expected": 0},
-    {"args": [1], "expected": 1},
-    {"args": [10], "expected": 55}
+    {
+      "args": [
+        5
+      ],
+      "expected": 15
+    },
+    {
+      "args": [
+        0
+      ],
+      "expected": 0
+    },
+    {
+      "args": [
+        1
+      ],
+      "expected": 1
+    },
+    {
+      "args": [
+        10
+      ],
+      "expected": 55
+    }
   ],
   "vera_check_must_pass": true,
-  "vera_verify_tier1": true,
+  "vera_verify_tier1": false,
   "notes": "Tests State<Int> handler pattern with a loop. State operations (get/put) must be inlined in the handler in-block, not called via a separate effectful function. The loop helper uses a where block with effects(<State<Int>>)."
 }

--- a/solutions/ailang/VB_T1_002_clamp.ail
+++ b/solutions/ailang/VB_T1_002_clamp.ail
@@ -1,13 +1,13 @@
 module benchmark/solution
 
-export func clamp(value: int, lo: int, hi: int) -> int =
+export func clamp_to_range(value: int, lo: int, hi: int) -> int =
   if value < lo then lo
   else if value > hi then hi
   else value
 
 export func main() -> () ! {IO} {
-  println(show(clamp(50, 0, 100)));
-  println(show(clamp(-5, 0, 100)));
-  println(show(clamp(150, 0, 100)));
-  println(show(clamp(0, 0, 0)))
+  println(show(clamp_to_range(50, 0, 100)));
+  println(show(clamp_to_range(-5, 0, 100)));
+  println(show(clamp_to_range(150, 0, 100)));
+  println(show(clamp_to_range(0, 0, 0)))
 }

--- a/solutions/aver/VB_T1_002_clamp.av
+++ b/solutions/aver/VB_T1_002_clamp.av
@@ -1,7 +1,7 @@
 module Clamp
     intent = "Clamps an integer value to a given range [lo, hi]."
 
-fn clamp(value: Int, lo: Int, hi: Int) -> Int
+fn clamp_to_range(value: Int, lo: Int, hi: Int) -> Int
     ? "Returns lo if value < lo, hi if value > hi, otherwise value."
     match value < lo
         true  -> lo
@@ -9,15 +9,15 @@ fn clamp(value: Int, lo: Int, hi: Int) -> Int
             true  -> hi
             false -> value
 
-verify clamp
-    clamp(50, 0, 100)   => 50
-    clamp(-5, 0, 100)   => 0
-    clamp(150, 0, 100)  => 100
-    clamp(0, 0, 0)      => 0
+verify clamp_to_range
+    clamp_to_range(50, 0, 100)   => 50
+    clamp_to_range(-5, 0, 100)   => 0
+    clamp_to_range(150, 0, 100)  => 100
+    clamp_to_range(0, 0, 0)      => 0
 
 fn main() -> Unit
     ! [Console.print]
-    Console.print("{clamp(50, 0, 100)}")
-    Console.print("{clamp(-5, 0, 100)}")
-    Console.print("{clamp(150, 0, 100)}")
-    Console.print("{clamp(0, 0, 0)}")
+    Console.print("{clamp_to_range(50, 0, 100)}")
+    Console.print("{clamp_to_range(-5, 0, 100)}")
+    Console.print("{clamp_to_range(150, 0, 100)}")
+    Console.print("{clamp_to_range(0, 0, 0)}")

--- a/solutions/python/VB_T1_002_clamp.py
+++ b/solutions/python/VB_T1_002_clamp.py
@@ -1,11 +1,11 @@
 """VB-T1-002: Clamp -- Python baseline."""
-def clamp(value: int, lo: int, hi: int) -> int:
+def clamp_to_range(value: int, lo: int, hi: int) -> int:
     if value < lo: return lo
     elif value > hi: return hi
     else: return value
 
 if __name__ == "__main__":
-    assert clamp(50, 0, 100) == 50
-    assert clamp(-5, 0, 100) == 0
-    assert clamp(150, 0, 100) == 100
+    assert clamp_to_range(50, 0, 100) == 50
+    assert clamp_to_range(-5, 0, 100) == 0
+    assert clamp_to_range(150, 0, 100) == 100
     print("VB-T1-002 ok")

--- a/solutions/typescript/VB_T1_002_clamp.ts
+++ b/solutions/typescript/VB_T1_002_clamp.ts
@@ -1,8 +1,8 @@
 // VB-T1-002: Clamp -- TypeScript baseline
-function clamp(value: number, lo: number, hi: number): number {
+function clampToRange(value: number, lo: number, hi: number): number {
   if (value < lo) return lo;
   if (value > hi) return hi;
   return value;
 }
-console.assert(clamp(50, 0, 100) === 50);
-console.assert(clamp(-5, 0, 100) === 0);
+console.assert(clampToRange(50, 0, 100) === 50);
+console.assert(clampToRange(-5, 0, 100) === 0);

--- a/solutions/vera/VB-T1-002_clamp.vera
+++ b/solutions/vera/VB-T1-002_clamp.vera
@@ -2,7 +2,7 @@
 -- Clamp a value to a range [lo, hi].
 -- Parameters: clamp(value, lo, hi)
 -- @Int.0 = hi (rightmost), @Int.1 = lo, @Int.2 = value
-public fn clamp(@Int, @Int, @Int -> @Int)
+public fn clamp_to_range(@Int, @Int, @Int -> @Int)
   requires(@Int.1 <= @Int.0)
   ensures(@Int.result >= @Int.1)
   ensures(@Int.result <= @Int.0)

--- a/solutions/vera/VB-T5-001_counter.vera
+++ b/solutions/vera/VB-T5-001_counter.vera
@@ -19,7 +19,7 @@ public fn count_three(@Unit -> @Int)
 {
   handle[State<Int>](@Int = 0) {
     get(@Unit) -> { resume(@Int.0) },
-    put(@Int) -> { resume(()) } with @Int = @Int.0
+    put(@Int) -> { resume(()) }
   } in {
     put(next_count(get(())));
     put(next_count(get(())));

--- a/solutions/vera/VB-T5-004_accumulator.vera
+++ b/solutions/vera/VB-T5-004_accumulator.vera
@@ -18,7 +18,7 @@ public fn sum_with_state(@Nat -> @Int)
 {
   handle[State<Int>](@Int = 0) {
     get(@Unit) -> { resume(@Int.0) },
-    put(@Int) -> { resume(()) } with @Int = @Int.0
+    put(@Int) -> { resume(()) }
   } in {
     sum_loop(@Nat.0, 1)
   }

--- a/solutions/vera/VB-T5-006_state_double.vera
+++ b/solutions/vera/VB-T5-006_state_double.vera
@@ -17,7 +17,7 @@ public fn state_double(@Int -> @Int)
 {
   handle[State<Int>](@Int = @Int.0) {
     get(@Unit) -> { resume(@Int.0) },
-    put(@Int) -> { resume(()) } with @Int = @Int.0
+    put(@Int) -> { resume(()) }
   } in {
     put(double(get(())));
     get(())

--- a/solutions/vera/VB-T5-009_state_max.vera
+++ b/solutions/vera/VB-T5-009_state_max.vera
@@ -22,7 +22,7 @@ public fn state_max(@Nat -> @Int)
 {
   handle[State<Int>](@Int = 0) {
     get(@Unit) -> { resume(@Int.0) },
-    put(@Int) -> { resume(()) } with @Int = @Int.0
+    put(@Int) -> { resume(()) }
   } in {
     max_loop(@Nat.0, 1)
   }

--- a/tests/test_vera_runner_integration.py
+++ b/tests/test_vera_runner_integration.py
@@ -121,7 +121,7 @@ class TestVeraRunnerIntegration:
         r = VeraRunner()
         result = r.run_fn(
             SOLUTIONS_DIR / "VB-T1-002_clamp.vera",
-            "clamp",
+            "clamp_to_range",
             [150, 0, 100],
         )
         assert result.exit_code == 0


### PR DESCRIPTION
## Summary

Restores `vera-bench validate` to **60/60** against Vera HEAD (v0.1.6, `f6f586b0`). Vera's move from v0.0.177 to the 0.1.x line broke 22/60 problems across three distinct compiler changes; this PR resolves all three. **CI has been red on every PR since ~2026-07-20** (including Dependabot #87/#88) because CI installs Vera from HEAD — this is the unblock.

No version bump — CHANGELOG entry is under `[Unreleased]`; the v0.0.16 bump rides the final PR of this batch per the release-atomicity convention (bump-last means `bench-0-0-16` result files can only come from released code).

## The three failure classes

### 1. `clamp` is now a Vera built-in → VB-T1-002 renamed to `clamp_to_range`

Vera 0.1.x adds `clamp` to the built-ins (spec §9.6) and rejects redefinition with `E151` — the diagnostic itself notes redefinition is "silently unsound" (verifier reasons about the built-in's model while codegen runs your body). The problem was **unwritable as specified**: any model asked for `fn clamp` gets rejected at check.

Renamed across: problem JSON (`entry_point`, `signature`, title/description/notes) + all 5 canonical solutions (TS as `clampToRange` per `_snake_to_camel`) + the integration-test lookup. Problem `id` stays `VB-T1-002`. Verified end-to-end in all five languages.

### 2. State-handler `with`-clause is now a silent no-op → removed from 4 solutions

[vera#1003](https://github.com/aallan/vera/issues/1003) (intrinsic-hybrid clause semantics; see also #976/#973/#988): clause bodies used to be type-checked but **never executed** — the runtime always used builtin state-cell semantics. Now they execute, and the old idiom `put(@Int) -> { resume(()) } with @Int = @Int.0` resolves `@Int.0` to the handler **state** (not the put argument), making the update `state = old-state`.

Minimal repro on HEAD: `put(42); get(())` returned **0**.

That's why VB-T5-001 returned 0 instead of 3 and VB-T5-006 failed 3/4 cases. T5-004 and T5-009 passed their tests only incidentally while carrying the same latent no-op. All four now use the canonical no-`with` form (SKILL.md's `run_counter` shape); the intrinsic store threads state natively. All four verified against their test cases.

⚠ **Upstream doc issue to file**: SKILL.md's `sum_with_state` example still teaches the broken `with @Int = @Int.0` form. LLMs writing T5 solutions from SKILL.md will reproduce it. Filing against the Vera repo separately — it needs fixing **before the benchmark sweep** or State-problem scores will be depressed by a doc bug.

### 3. `int_overflow` obligations → `vera_verify_tier1: false` on 19 problems

Vera 0.1.x auto-synthesises `int_overflow` / `nat_to_int_coerce` proof obligations on all integer arithmetic. Census across all 19 failing problems: **every** T3-falling obligation is one of these two kinds. On unbounded `Int`/`Nat` inputs they are legitimately unprovable at Tier 1 — proving them would require adding range preconditions, i.e. changing the published contracts of 19 problems. Runtime checking is the correct classification, so the canonical-validation expectation flag is flipped.

This flag gates **only** canonical validation (`validate.py:130`); LLM `verify@1` is computed from `verify_pass` (`metrics.py:103-109`) and is unaffected — talk numbers don't move.

## Verification

- [x] `vera-bench validate` 60/60 (was 38/60)
- [x] All five VB-T1-002 solutions run end-to-end (python / tsx / aver 0.27.1 / ailang 0.30.0 / `vera run --fn clamp_to_range`)
- [x] `pytest`: 592 passed, coverage 89.30% (≥80 floor). One pre-existing Rich console-width flake (`test_run_ailang_full_path_success`) passes at `COLUMNS=200` and in CI
- [x] `ruff check` / `ruff format --check` clean
- [x] Bonus G0 findings: **Aver 0.27.1 needs no migration** (60/60 check, 36/36 run — v0.0.14 `Int.div` was forward-compatible throughout) and **AILANG v0.30.0 baselines pass 36/36**
- [ ] CI green (this PR is what turns it green)

## After merge

1. `@dependabot rebase` on #87 (setup-python) and #88 (setup-node), merge when green
2. PR 2 (#72 aver diagnostics) and PR 4 (#61 caching) proceed in parallel
3. File the SKILL.md `sum_with_state` doc issue upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Vera 0.1.x during benchmark validation.
  * Corrected range-clamping naming to match Vera 0.1.x expectations.
  * Fixed intrinsic-hybrid state-handler clause behaviour that previously resulted in silent no-ops.
  * Updated verification routing so selected benchmark problems are verified at Tier 3 rather than Tier 1.
* **Documentation**
  * Updated the changelog with Vera compatibility guidance and clarified notes for the affected benchmarks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->