### PR TITLE
Per-test run-failure diagnostics for the Aver evaluator (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Per-test subprocess-failure diagnostics for the Aver evaluator**
+  ([#72](https://github.com/aallan/vera-bench/issues/72)). The
+  `_evaluate_aver_code` per-test loop previously `continue`d silently
+  on timeout and non-zero exit — a model whose type-correct Aver
+  crashed at runtime was indistinguishable in JSONL from one with
+  wrong logic (`error_message=None, check_pass=True,
+  run_correct=False`). The loop now captures the first failing
+  test's diagnostic (stderr-or-stdout coalesce, 400-char truncation,
+  explicit exit-code marker when silent) into `error_message`,
+  matching the AILANG evaluator's existing pattern. Both evaluators
+  now share a `_first_run_error` formatting helper.
+
 ### Fixed
 
 - **Vera 0.1.x compatibility for the problem set and canonical

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ This file tracks **forward-looking** milestones. For what has shipped in each re
 - [x] Strengthen postconditions to catch slot-swap bugs (issue #14)
 - [ ] Improve SKILL.md coverage of where blocks (issue #15)
 - [x] Test coverage ([issue #5](https://github.com/aallan/vera-bench/issues/5), ongoing — target 90%) — CI enforces 80% floor via `--cov-fail-under=80` in [ci.yml](.github/workflows/ci.yml), current coverage shown by [![codecov](https://codecov.io/gh/aallan/vera-bench/graph/badge.svg)](https://codecov.io/gh/aallan/vera-bench)
-- [ ] Per-test subprocess-failure diagnostics — Aver and AILANG evaluators currently `continue` on per-test failures without capturing stderr, unlike the Python/TypeScript paths. Small shared-helper refactor (issue [#72](https://github.com/aallan/vera-bench/issues/72))
+- [x] Per-test subprocess-failure diagnostics — shared `_first_run_error` helper; Aver evaluator now captures first-failure stderr like AILANG (issue [#72](https://github.com/aallan/vera-bench/issues/72), [PR #90](https://github.com/aallan/vera-bench/pull/90))
 
 ## Milestone 2: Longitudinal tracking
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1158,6 +1158,104 @@ class TestEvaluateAverCode:
         assert result["check_pass"] is True
         assert result["verify_pass"] is False
 
+    @patch("vera_bench.runner.subprocess.run")
+    def test_run_failure_captures_stderr(self, mock_run, tmp_path):
+        """Issue #72: a per-test runtime failure must land its stderr in
+        error_message — previously the loop silently `continue`d and the
+        row was indistinguishable from wrong-logic output."""
+        from vera_bench.runner import _evaluate_aver_code
+
+        mock_run.side_effect = [
+            self._mock_subprocess(returncode=0),  # aver check
+            self._mock_subprocess(returncode=0),  # aver verify
+            self._mock_subprocess(returncode=1, stderr="panic: div by zero"),
+        ]
+        problem = self._sample_problem(test_cases=[{"args": [1], "expected": 1}])
+        result = _evaluate_aver_code(
+            'module T\n    intent = "t"\n\nfn absolute_value(x: Int) -> Int\n    x\n',
+            problem,
+            tmp_path,
+            1,
+        )
+        assert result["run_correct"] is False
+        assert "test 0: panic: div by zero" in result["error_message"]
+
+    @patch("vera_bench.runner.subprocess.run")
+    def test_run_timeout_captures_diagnostic(self, mock_run, tmp_path):
+        """Issue #72: per-test timeout is recorded, first-error-wins."""
+        from vera_bench.runner import _evaluate_aver_code
+
+        mock_run.side_effect = [
+            self._mock_subprocess(returncode=0),  # aver check
+            self._mock_subprocess(returncode=0),  # aver verify
+            subprocess.TimeoutExpired(cmd="aver", timeout=30),  # tc0
+            self._mock_subprocess(returncode=1, stderr="later error"),  # tc1
+        ]
+        problem = self._sample_problem(
+            test_cases=[
+                {"args": [1], "expected": 1},
+                {"args": [2], "expected": 2},
+            ]
+        )
+        result = _evaluate_aver_code(
+            'module T\n    intent = "t"\n\nfn absolute_value(x: Int) -> Int\n    x\n',
+            problem,
+            tmp_path,
+            1,
+        )
+        assert result["run_correct"] is False
+        # First error wins: the timeout on tc0, not tc1's stderr.
+        assert result["error_message"] == "test 0: aver run timed out after 30s"
+
+    @patch("vera_bench.runner.subprocess.run")
+    def test_run_failure_does_not_clobber_upstream_error(self, mock_run, tmp_path):
+        """A check-stage error_message must survive a later run failure."""
+        from vera_bench.runner import _evaluate_aver_code
+
+        mock_run.side_effect = [
+            self._mock_subprocess(returncode=1, stderr="type error at 3:1"),
+        ]
+        problem = self._sample_problem(test_cases=[{"args": [1], "expected": 1}])
+        result = _evaluate_aver_code("bad code", problem, tmp_path, 1)
+        assert result["check_pass"] is False
+        assert "type error at 3:1" in result["error_message"]
+
+
+class TestFirstRunError:
+    """Unit tests for the shared per-test diagnostic formatter (#72)."""
+
+    def test_timeout_marker(self):
+        from vera_bench.runner import _first_run_error
+
+        assert _first_run_error(3, None, "aver") == (
+            "test 3: aver run timed out after 30s"
+        )
+
+    def test_stderr_preferred(self):
+        from vera_bench.runner import _first_run_error
+
+        proc = MagicMock(returncode=1, stderr="boom", stdout="ignored")
+        assert _first_run_error(0, proc, "ailang") == "test 0: boom"
+
+    def test_stdout_fallback(self):
+        from vera_bench.runner import _first_run_error
+
+        proc = MagicMock(returncode=2, stderr="", stdout="compile diag")
+        assert _first_run_error(1, proc, "aver") == "test 1: compile diag"
+
+    def test_no_output_marker(self):
+        from vera_bench.runner import _first_run_error
+
+        proc = MagicMock(returncode=137, stderr="", stdout="")
+        assert _first_run_error(2, proc, "aver") == "test 2: exit 137 (no output)"
+
+    def test_truncation_at_400(self):
+        from vera_bench.runner import _first_run_error
+
+        proc = MagicMock(returncode=1, stderr="x" * 1000, stdout="")
+        msg = _first_run_error(0, proc, "aver")
+        assert len(msg) == len("test 0: ") + 400
+
 
 class TestRunSingleProblemAver:
     def _mock_client(self, text):

--- a/vera_bench/runner.py
+++ b/vera_bench/runner.py
@@ -408,6 +408,28 @@ def _evaluate_typescript_code(
     return result
 
 
+def _first_run_error(
+    i: int, proc: subprocess.CompletedProcess | None, tool: str
+) -> str:
+    """Format a per-test-case run-failure diagnostic (issue #72).
+
+    ``proc is None`` means the subprocess timed out. Otherwise coalesce
+    stderr-or-stdout (runtime errors usually land on stderr, but quiet
+    modes and some compile-stage diagnostics land on stdout), truncate
+    to keep JSONL rows readable, and fall back to an explicit exit-code
+    marker when the process produced no output at all.
+
+    Callers keep first-error-wins semantics: only the first failing
+    test's diagnostic is captured per evaluation.
+    """
+    if proc is None:
+        return f"test {i}: {tool} run timed out after 30s"
+    err = (proc.stderr or proc.stdout or "").strip()[:400]
+    if err:
+        return f"test {i}: {err}"
+    return f"test {i}: exit {proc.returncode} (no output)"
+
+
 def _evaluate_aver_code(
     code: str,
     problem: dict,
@@ -487,6 +509,12 @@ def _evaluate_aver_code(
     code_without_main = _strip_module_effects(_strip_aver_main(code))
 
     all_pass = True
+    # Capture the first per-test failure diagnostic — without this, a
+    # model whose type-correct Aver crashes at runtime is
+    # indistinguishable in JSONL from one with wrong logic
+    # (error_message=None, check_pass=True, run_correct=False).
+    # Mirrors the AILANG evaluator's pattern (issue #72).
+    last_run_error: str | None = None
     for i, tc in enumerate(test_cases):
         if not isinstance(tc, dict):
             continue
@@ -531,10 +559,14 @@ def _evaluate_aver_code(
             )
         except subprocess.TimeoutExpired:
             all_pass = False
+            if last_run_error is None:
+                last_run_error = _first_run_error(i, None, "aver")
             continue
 
         if run_proc.returncode != 0:
             all_pass = False
+            if last_run_error is None:
+                last_run_error = _first_run_error(i, run_proc, "aver")
             continue
 
         actual_output = run_proc.stdout.strip()
@@ -545,6 +577,10 @@ def _evaluate_aver_code(
             all_pass = False
 
     result["run_correct"] = all_pass
+    # Only attach if no upstream error (e.g. from the check step) —
+    # preserve the original failure mode.
+    if last_run_error is not None and not result.get("error_message"):
+        result["error_message"] = last_run_error
     return result
 
 
@@ -802,21 +838,12 @@ def _evaluate_ailang_code(
             )
         except subprocess.TimeoutExpired:
             if last_run_error is None:
-                last_run_error = f"test {i}: ailang run timed out after 30s"
+                last_run_error = _first_run_error(i, None, "ailang")
             continue
 
         if run_proc.returncode != 0:
             if last_run_error is None:
-                # stderr-or-stdout coalesce: AILANG runtime errors land on
-                # stderr in most cases, but quiet mode + some compile-stage
-                # diagnostics land on stdout. Truncate to keep JSONL rows
-                # readable.
-                err = (run_proc.stderr or run_proc.stdout or "").strip()[:400]
-                last_run_error = (
-                    f"test {i}: {err}"
-                    if err
-                    else (f"test {i}: exit {run_proc.returncode} (no output)")
-                )
+                last_run_error = _first_run_error(i, run_proc, "ailang")
             continue
 
         actual = run_proc.stdout.strip()


### PR DESCRIPTION
## Summary

Closes #72. The `_evaluate_aver_code` per-test loop silently `continue`d on both timeout and non-zero exit — a model whose type-correct Aver crashed at runtime was indistinguishable in JSONL from wrong-logic output (`error_message=None, check_pass=True, run_correct=False`). The AILANG evaluator gained first-failure capture in the PR #70 review cycle (the "C3" finding); this brings the Aver path to parity and extracts the shared logic into one helper.

Part of the v0.0.16 batch — CHANGELOG entry under `[Unreleased]`, no version bump (rides the final PR).

## Changes

- **New `_first_run_error(i, proc | None, tool)` helper** — the per-test diagnostic formatter: timeout marker, stderr-or-stdout coalesce (runtime errors usually land on stderr, but quiet modes and compile-stage diagnostics land on stdout), `.strip()[:400]` truncation for JSONL readability, explicit `exit N (no output)` fallback.
- **Aver loop**: `last_run_error` captured on both failure branches (first-error-wins), attached after the loop only when no upstream check-stage error exists.
- **AILANG loop**: the inline 12-line coalesce block is replaced by the helper — zero behaviour change, covered by the existing `TestEvaluateAilangCode` suite (28/28 green).

**Scope note**: baseline runners are deliberately out of scope — they run the solution's own `main()` once and line-parse stdout, so there's no per-test subprocess whose stderr can be lost (per the #72 analysis).

## Tests

- 3 new aver-path cases in `TestEvaluateAverCode`: stderr capture (`test 0: panic: div by zero`), timeout first-error-wins across two test cases, upstream check-error preservation
- New 5-case `TestFirstRunError` unit class: timeout marker, stderr preference, stdout fallback, no-output marker, 400-char truncation
- Full `tests/test_runner.py`: 191 passed
- `ruff check` / `format --check` clean

## Why this matters for the sweep

We're about to run an 8-model benchmark sweep including Aver generation on 4 models. When an LLM's Aver crashes at runtime mid-sweep, the JSONL row now says *why* — before this, diagnosing a `tests_passed: 0` row meant re-running by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Aver/AILANG per-test failure reporting to retain the first relevant diagnostic instead of silently continuing or overwriting earlier results.
  - Captures stderr (with stdout fallback) for non-zero exits and includes an explicit message when failures produce no output.
  - Truncates long diagnostics for readability and preserves earlier check-stage errors.
- **Tests**
  - Added regression coverage for timeouts, first-error-wins precedence, stderr/stdout selection, stdout fallback, and truncation behavior.
- **Documentation**
  - Updated the changelog and roadmap to reflect the improved diagnostic handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->