### PR TITLE
Prompt-cache instrumentation + client hardening for OpenAI/Moonshot (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Prompt-cache instrumentation for OpenAI and Moonshot clients**
   ([#61](https://github.com/aallan/vera-bench/issues/61)). Both
   providers now cache automatically server-side (OpenAI ≥1024-token
-  prompts; Moonshot prefix-caches all requests) — the work here is
+  prompts; Moonshot longest-prefix matching — a request cache-hits
+  only when it shares a prefix with a prior request) — the work is
   routing and observability, not cache management:
   - New `cached_tokens` field on `LLMResponse` and `ProblemResult`
     (JSONL rows): the cache-hit portion of `input_tokens`. Anthropic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   explicit exit-code marker when silent) into `error_message`,
   matching the AILANG evaluator's existing pattern. Both evaluators
   now share a `_first_run_error` formatting helper.
+- **Prompt-cache instrumentation for OpenAI and Moonshot clients**
+  ([#61](https://github.com/aallan/vera-bench/issues/61)). Both
+  providers now cache automatically server-side (OpenAI ≥1024-token
+  prompts; Moonshot prefix-caches all requests) — the work here is
+  routing and observability, not cache management:
+  - New `cached_tokens` field on `LLMResponse` and `ProblemResult`
+    (JSONL rows): the cache-hit portion of `input_tokens`. Anthropic
+    reports `cache_read_input_tokens`; OpenAI-compatible providers
+    report `usage.prompt_tokens_details.cached_tokens` (read via a
+    shared `_openai_cached_tokens` guard that tolerates absent /
+    None / non-int fields). Sweep cost analysis can now compute
+    cache-hit rates per provider directly from result files.
+  - OpenAI requests carry a stable `prompt_cache_key` (SHA-256 of
+    the system prompt, via `extra_body`) so same-prefix requests
+    route to the same cache shard — recommended by OpenAI for the
+    GPT-5.6 family. During sweeps the ~28k-token SKILL.md prefix
+    gets its own shard per language-mode.
+  - Moonshot sends no cache parameter — their Context Caching is
+    fully automatic with no routing key (their earlier explicit
+    X-Msh-* header scheme is obsolete).
+- **OpenAI and Moonshot clients hardened to the OpenRouter error
+  standard**: `AuthenticationError` → `EnvironmentError` (abort the
+  run — retrying 60 problems on a bad key is waste), `RateLimitError`
+  / `BadRequestError` / `APIStatusError` → clean `RuntimeError`
+  messages, and explicit errors on empty `choices` / empty `content`
+  (previously returned `text=""` and the harness blamed the model
+  for "did not define entry point").
 
 ### Fixed
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -404,6 +404,16 @@ class TestCachedTokensHelpers:
         usage.prompt_tokens_details.cached_tokens = 27000
         assert _openai_cached_tokens(usage) == 27000
 
+    def test_openai_cached_tokens_rejects_bool(self):
+        """bool is an int subclass — a provider quirk returning True
+        must not count as 1 cached token (type() check, not
+        isinstance)."""
+        from vera_bench.models import _openai_cached_tokens
+
+        usage = MagicMock()
+        usage.prompt_tokens_details.cached_tokens = True
+        assert _openai_cached_tokens(usage) == 0
+
     def test_openai_cached_tokens_absent_details(self):
         from vera_bench.models import _openai_cached_tokens
 
@@ -436,7 +446,7 @@ class TestCachedTokensHelpers:
 class TestOpenAICachingAndHardening:
     """#61: cache instrumentation + OpenRouter-standard error handling."""
 
-    def _client(self, monkeypatch):
+    def _client(self, monkeypatch: pytest.MonkeyPatch) -> object:
         try:
             from vera_bench.models import OpenAIClient
         except ImportError:
@@ -444,11 +454,11 @@ class TestOpenAICachingAndHardening:
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")
         return OpenAIClient("gpt-test")
 
-    def _wire(self, client, mock_inner):
+    def _wire(self, client: object, mock_inner: MagicMock) -> None:
         client._client = MagicMock()
         client._client.with_options.return_value = mock_inner
 
-    def _ok_response(self, cached=0):
+    def _ok_response(self, cached: int = 0) -> MagicMock:
         resp = MagicMock()
         choice = MagicMock()
         choice.message.content = "hello"
@@ -524,7 +534,7 @@ class TestOpenAICachingAndHardening:
 class TestMoonshotCachingAndHardening:
     """#61: Moonshot caching is automatic — accounting + hardening only."""
 
-    def _client(self, monkeypatch):
+    def _client(self, monkeypatch: pytest.MonkeyPatch) -> object:
         try:
             from vera_bench.models import MoonshotClient
         except ImportError:
@@ -532,7 +542,7 @@ class TestMoonshotCachingAndHardening:
         monkeypatch.setenv("MOONSHOT_API_KEY", "test-key")
         return MoonshotClient("moonshot/kimi-test")
 
-    def _wire(self, client, mock_inner):
+    def _wire(self, client: object, mock_inner: MagicMock) -> None:
         client._client = MagicMock()
         client._client.with_options.return_value = mock_inner
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -392,3 +392,194 @@ class TestOpenRouterComplete:
 
         with pytest.raises(RuntimeError, match="rate-limited"):
             client.complete("sys", "user")
+
+
+class TestCachedTokensHelpers:
+    """Unit tests for the #61 cache-accounting helpers."""
+
+    def test_openai_cached_tokens_real_int(self):
+        from vera_bench.models import _openai_cached_tokens
+
+        usage = MagicMock()
+        usage.prompt_tokens_details.cached_tokens = 27000
+        assert _openai_cached_tokens(usage) == 27000
+
+    def test_openai_cached_tokens_absent_details(self):
+        from vera_bench.models import _openai_cached_tokens
+
+        assert _openai_cached_tokens(object()) == 0
+
+    def test_openai_cached_tokens_none_details(self):
+        from vera_bench.models import _openai_cached_tokens
+
+        usage = MagicMock()
+        usage.prompt_tokens_details = None
+        assert _openai_cached_tokens(usage) == 0
+
+    def test_openai_cached_tokens_magicmock_leak_guard(self):
+        from vera_bench.models import _openai_cached_tokens
+
+        # A bare MagicMock auto-creates attributes — the isinstance
+        # guard must refuse the non-int and report 0, never leak a
+        # mock object into token accounting.
+        assert _openai_cached_tokens(MagicMock()) == 0
+
+    def test_prompt_cache_key_stable_and_distinct(self):
+        from vera_bench.models import _prompt_cache_key
+
+        k1 = _prompt_cache_key("prefix A")
+        assert k1 == _prompt_cache_key("prefix A")
+        assert k1 != _prompt_cache_key("prefix B")
+        assert k1.startswith("vera-bench-")
+
+
+class TestOpenAICachingAndHardening:
+    """#61: cache instrumentation + OpenRouter-standard error handling."""
+
+    def _client(self, monkeypatch):
+        try:
+            from vera_bench.models import OpenAIClient
+        except ImportError:
+            pytest.skip("openai not installed")
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        return OpenAIClient("gpt-test")
+
+    def _wire(self, client, mock_inner):
+        client._client = MagicMock()
+        client._client.with_options.return_value = mock_inner
+
+    def _ok_response(self, cached=0):
+        resp = MagicMock()
+        choice = MagicMock()
+        choice.message.content = "hello"
+        resp.choices = [choice]
+        resp.model = "gpt-test"
+        resp.usage.prompt_tokens = 30000
+        resp.usage.completion_tokens = 50
+        resp.usage.prompt_tokens_details.cached_tokens = cached
+        return resp
+
+    def test_cached_tokens_flow_into_response(self, monkeypatch):
+        client = self._client(monkeypatch)
+        mock_inner = MagicMock()
+        mock_inner.chat.completions.create.return_value = self._ok_response(
+            cached=28000
+        )
+        self._wire(client, mock_inner)
+        result = client.complete("sys", "user")
+        assert result.cached_tokens == 28000
+        assert result.input_tokens == 30000
+
+    def test_prompt_cache_key_sent_via_extra_body(self, monkeypatch):
+        from vera_bench.models import _prompt_cache_key
+
+        client = self._client(monkeypatch)
+        mock_inner = MagicMock()
+        mock_inner.chat.completions.create.return_value = self._ok_response()
+        self._wire(client, mock_inner)
+        client.complete("the system prefix", "user")
+        kwargs = mock_inner.chat.completions.create.call_args.kwargs
+        assert kwargs["extra_body"] == {
+            "prompt_cache_key": _prompt_cache_key("the system prefix")
+        }
+
+    def test_authentication_error_aborts(self, monkeypatch):
+        try:
+            import openai
+        except ImportError:
+            pytest.skip("openai not installed")
+        client = self._client(monkeypatch)
+        mock_inner = MagicMock()
+        mock_inner.chat.completions.create.side_effect = openai.AuthenticationError(
+            message="Invalid API key", response=MagicMock(), body=None
+        )
+        self._wire(client, mock_inner)
+        with pytest.raises(EnvironmentError, match="OpenAI authentication"):
+            client.complete("sys", "user")
+
+    def test_empty_choices_raises(self, monkeypatch):
+        client = self._client(monkeypatch)
+        mock_inner = MagicMock()
+        resp = MagicMock()
+        resp.choices = []
+        mock_inner.chat.completions.create.return_value = resp
+        self._wire(client, mock_inner)
+        with pytest.raises(RuntimeError, match="no choices"):
+            client.complete("sys", "user")
+
+    def test_empty_content_raises(self, monkeypatch):
+        client = self._client(monkeypatch)
+        mock_inner = MagicMock()
+        resp = MagicMock()
+        choice = MagicMock()
+        choice.message.content = None
+        choice.finish_reason = "content_filter"
+        resp.choices = [choice]
+        mock_inner.chat.completions.create.return_value = resp
+        self._wire(client, mock_inner)
+        with pytest.raises(RuntimeError, match="empty content"):
+            client.complete("sys", "user")
+
+
+class TestMoonshotCachingAndHardening:
+    """#61: Moonshot caching is automatic — accounting + hardening only."""
+
+    def _client(self, monkeypatch):
+        try:
+            from vera_bench.models import MoonshotClient
+        except ImportError:
+            pytest.skip("openai not installed")
+        monkeypatch.setenv("MOONSHOT_API_KEY", "test-key")
+        return MoonshotClient("moonshot/kimi-test")
+
+    def _wire(self, client, mock_inner):
+        client._client = MagicMock()
+        client._client.with_options.return_value = mock_inner
+
+    def test_no_cache_param_sent(self, monkeypatch):
+        """Moonshot's Context Caching is fully automatic — the request
+        must NOT carry an extra_body cache key (their API, their
+        routing)."""
+        client = self._client(monkeypatch)
+        mock_inner = MagicMock()
+        resp = MagicMock()
+        choice = MagicMock()
+        choice.message.content = "hi"
+        resp.choices = [choice]
+        resp.model = "kimi-test"
+        resp.usage.prompt_tokens = 100
+        resp.usage.completion_tokens = 10
+        resp.usage.prompt_tokens_details.cached_tokens = 64
+        mock_inner.chat.completions.create.return_value = resp
+        self._wire(client, mock_inner)
+        result = client.complete("sys", "user")
+        kwargs = mock_inner.chat.completions.create.call_args.kwargs
+        assert "extra_body" not in kwargs
+        assert result.cached_tokens == 64
+
+    def test_authentication_error_aborts(self, monkeypatch):
+        try:
+            import openai
+        except ImportError:
+            pytest.skip("openai not installed")
+        client = self._client(monkeypatch)
+        mock_inner = MagicMock()
+        mock_inner.chat.completions.create.side_effect = openai.AuthenticationError(
+            message="Invalid API key", response=MagicMock(), body=None
+        )
+        self._wire(client, mock_inner)
+        with pytest.raises(EnvironmentError, match="Moonshot authentication"):
+            client.complete("sys", "user")
+
+    def test_empty_content_raises(self, monkeypatch):
+        client = self._client(monkeypatch)
+        mock_inner = MagicMock()
+        resp = MagicMock()
+        choice = MagicMock()
+        choice.message.content = None
+        choice.finish_reason = "length"
+        resp.choices = [choice]
+        mock_inner.chat.completions.create.return_value = resp
+        self._wire(client, mock_inner)
+        with pytest.raises(RuntimeError, match="empty content"):
+            client.complete("sys", "user")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3097,10 +3097,11 @@ class TestEnvironmentErrorAbortsSweep:
 
     @patch("vera_bench.runner.run_single_problem")
     def test_sequential_aborts_on_environment_error(self, mock_run, tmp_path):
+        from vera_bench.models import AuthError
         from vera_bench.runner import run_benchmark
 
-        mock_run.side_effect = EnvironmentError("bad API key")
-        with pytest.raises(EnvironmentError, match="bad API key"):
+        mock_run.side_effect = AuthError("bad API key")
+        with pytest.raises(AuthError, match="bad API key"):
             run_benchmark(
                 problems=[self._problem("VB-X-0"), self._problem("VB-X-1")],
                 client=MagicMock(),
@@ -3124,6 +3125,7 @@ class TestEnvironmentErrorAbortsSweep:
         remaining problem fires a doomed API call."""
         import time as _time
 
+        from vera_bench.models import AuthError
         from vera_bench.runner import run_benchmark
 
         invoked: list[str] = []
@@ -3132,12 +3134,12 @@ class TestEnvironmentErrorAbortsSweep:
             invoked.append(problem["id"])
             if problem["id"] == "VB-X-0":
                 _time.sleep(0.05)
-                raise EnvironmentError("bad API key")
+                raise AuthError("bad API key")
             _time.sleep(0.5)  # keep the second worker busy past the abort
             return []
 
         mock_run.side_effect = _side_effect
-        with pytest.raises(EnvironmentError, match="bad API key"):
+        with pytest.raises(AuthError, match="bad API key"):
             run_benchmark(
                 problems=[self._problem(f"VB-X-{i}") for i in range(6)],
                 client=MagicMock(),
@@ -3200,11 +3202,12 @@ class TestEnvironmentErrorPropagatesFromClient:
         }
 
     def test_attempt1_reraises_environment_error(self, tmp_path):
+        from vera_bench.models import AuthError
         from vera_bench.runner import run_single_problem
 
         client = MagicMock()
-        client.complete.side_effect = EnvironmentError("bad API key")
-        with pytest.raises(EnvironmentError, match="bad API key"):
+        client.complete.side_effect = AuthError("bad API key")
+        with pytest.raises(AuthError, match="bad API key"):
             run_single_problem(
                 problem=self._problem(),
                 client=client,
@@ -3233,11 +3236,12 @@ class TestEnvironmentErrorPropagatesFromClient:
     def test_end_to_end_abort_through_real_run_single_problem(self, tmp_path):
         """The full chain: client raises -> run_single_problem re-raises
         -> run_benchmark aborts with no rows written."""
+        from vera_bench.models import AuthError
         from vera_bench.runner import run_benchmark
 
         client = MagicMock(_model="m")
-        client.complete.side_effect = EnvironmentError("bad API key")
-        with pytest.raises(EnvironmentError, match="bad API key"):
+        client.complete.side_effect = AuthError("bad API key")
+        with pytest.raises(AuthError, match="bad API key"):
             run_benchmark(
                 problems=[self._problem()],
                 client=client,
@@ -3249,3 +3253,39 @@ class TestEnvironmentErrorPropagatesFromClient:
             )
         out = tmp_path / "out.jsonl"
         assert not out.exists() or out.read_text() == ""
+
+
+class TestConnectionErrorDoesNotAbortSweep:
+    """AuthError is deliberately narrower than EnvironmentError.
+
+    EnvironmentError IS OSError, so re-raising it broadly would abort
+    the whole sweep on a transient ConnectionError from the HTTP
+    client. A network blip must cost one problem, not the run."""
+
+    def _problem(self) -> dict:
+        return {
+            "id": "VB-X-0",
+            "entry_point": "f",
+            "description": "d",
+            "description_neutral": "d",
+            "test_cases": [],
+        }
+
+    def test_connection_error_becomes_a_row_not_an_abort(self, tmp_path):
+        from vera_bench.runner import run_benchmark
+
+        client = MagicMock(_model="m")
+        client.complete.side_effect = ConnectionError("connection reset by peer")
+        results = run_benchmark(
+            problems=[self._problem()],
+            client=client,
+            skill_md="",
+            vera=None,
+            language="python",
+            output_path=tmp_path / "out.jsonl",
+            parallel=1,
+        )
+        # Recorded, not raised.
+        assert len(results) == 1
+        assert "connection reset by peer" in results[0].error_message
+        assert (tmp_path / "out.jsonl").read_text().strip()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3088,9 +3088,11 @@ class TestAilangCLI:
 class TestEnvironmentErrorAbortsSweep:
     """Auth failures must abort the whole sweep, not become 60 crash
     rows — EnvironmentError re-raises through the crash-recording
-    layer in both benchmark paths (#61 hardening, CR follow-up)."""
+    layer in both benchmark paths, and the parallel path cancels
+    queued futures so no further doomed API calls fire (#61
+    hardening, CR follow-ups)."""
 
-    def _problem(self, pid):
+    def _problem(self, pid: str) -> dict:
         return {"id": pid, "test_cases": []}
 
     @patch("vera_bench.runner.run_single_problem")
@@ -3108,18 +3110,36 @@ class TestEnvironmentErrorAbortsSweep:
                 output_path=tmp_path / "out.jsonl",
                 parallel=1,
             )
-        # Aborted on the first problem — no crash rows written.
+        # Aborted on the FIRST problem: exactly one invocation, no rows.
+        assert mock_run.call_count == 1
         out = tmp_path / "out.jsonl"
         assert not out.exists() or out.read_text() == ""
 
     @patch("vera_bench.runner.run_single_problem")
-    def test_parallel_aborts_on_environment_error(self, mock_run, tmp_path):
+    def test_parallel_aborts_and_cancels_queued_futures(self, mock_run, tmp_path):
+        """With 2 workers and 4 problems, the auth failure on the first
+        must cancel the two QUEUED futures — without the explicit
+        executor.shutdown(cancel_futures=True), the with-block's
+        implicit shutdown(wait=True) drains the queue and every
+        remaining problem fires a doomed API call."""
+        import time as _time
+
         from vera_bench.runner import run_benchmark
 
-        mock_run.side_effect = EnvironmentError("bad API key")
+        invoked: list[str] = []
+
+        def _side_effect(problem: dict, **kw: object) -> list:
+            invoked.append(problem["id"])
+            if problem["id"] == "VB-X-0":
+                _time.sleep(0.05)
+                raise EnvironmentError("bad API key")
+            _time.sleep(0.5)  # keep the second worker busy past the abort
+            return []
+
+        mock_run.side_effect = _side_effect
         with pytest.raises(EnvironmentError, match="bad API key"):
             run_benchmark(
-                problems=[self._problem(f"VB-X-{i}") for i in range(3)],
+                problems=[self._problem(f"VB-X-{i}") for i in range(6)],
                 client=MagicMock(),
                 skill_md="",
                 vera=None,
@@ -3127,6 +3147,13 @@ class TestEnvironmentErrorAbortsSweep:
                 output_path=tmp_path / "out.jsonl",
                 parallel=2,
             )
+        # Inherent race: a freed worker may dequeue ONE more task before
+        # the main thread processes the failed future — cancel_futures
+        # can only stop work that hasn't been dequeued. The guarantee
+        # under test is that the queue TAIL is cancelled: without the
+        # explicit shutdown(cancel_futures=True), all six problems run.
+        assert len(invoked) <= 3
+        assert set(invoked).isdisjoint({"VB-X-3", "VB-X-4", "VB-X-5"})
         out = tmp_path / "out.jsonl"
         assert not out.exists() or out.read_text() == ""
 
@@ -3137,7 +3164,7 @@ class TestEnvironmentErrorAbortsSweep:
 
         from vera_bench.runner import run_benchmark
 
-        def _side_effect(problem, **kw):
+        def _side_effect(problem: dict, **kw: object) -> list:
             raise RuntimeError("worker blew up")
 
         mock_run.side_effect = _side_effect

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3180,3 +3180,72 @@ class TestEnvironmentErrorAbortsSweep:
         assert len(results) == 1
         row = _json.loads((tmp_path / "out.jsonl").read_text().strip())
         assert "worker blew up" in row["error_message"]
+
+
+class TestEnvironmentErrorPropagatesFromClient:
+    """CR #91 critical: the abort path is only real if EnvironmentError
+    survives run_single_problem — its client.complete() guards catch
+    Exception and previously converted auth failures into per-problem
+    'API error' rows, making the run_benchmark abort handlers dead
+    code. These tests mock the CLIENT, not run_single_problem, so the
+    real swallowing layer is exercised."""
+
+    def _problem(self) -> dict:
+        return {
+            "id": "VB-X-0",
+            "entry_point": "f",
+            "description": "d",
+            "description_neutral": "d",
+            "test_cases": [],
+        }
+
+    def test_attempt1_reraises_environment_error(self, tmp_path):
+        from vera_bench.runner import run_single_problem
+
+        client = MagicMock()
+        client.complete.side_effect = EnvironmentError("bad API key")
+        with pytest.raises(EnvironmentError, match="bad API key"):
+            run_single_problem(
+                problem=self._problem(),
+                client=client,
+                skill_md="",
+                vera=None,
+                work_dir=tmp_path,
+                language="python",
+            )
+
+    def test_non_auth_api_error_still_becomes_row(self, tmp_path):
+        from vera_bench.runner import run_single_problem
+
+        client = MagicMock()
+        client.complete.side_effect = RuntimeError("rate-limited")
+        results = run_single_problem(
+            problem=self._problem(),
+            client=client,
+            skill_md="",
+            vera=None,
+            work_dir=tmp_path,
+            language="python",
+        )
+        assert len(results) == 1
+        assert "API error: rate-limited" in results[0].error_message
+
+    def test_end_to_end_abort_through_real_run_single_problem(self, tmp_path):
+        """The full chain: client raises -> run_single_problem re-raises
+        -> run_benchmark aborts with no rows written."""
+        from vera_bench.runner import run_benchmark
+
+        client = MagicMock(_model="m")
+        client.complete.side_effect = EnvironmentError("bad API key")
+        with pytest.raises(EnvironmentError, match="bad API key"):
+            run_benchmark(
+                problems=[self._problem()],
+                client=client,
+                skill_md="",
+                vera=None,
+                language="python",
+                output_path=tmp_path / "out.jsonl",
+                parallel=1,
+            )
+        out = tmp_path / "out.jsonl"
+        assert not out.exists() or out.read_text() == ""

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3083,3 +3083,73 @@ class TestAilangCLI:
         # The filename slug includes the AILANG version (cli.py:256-257) —
         # appears in the "Output: ..." line printed by cli.py:274.
         assert "ailang-0-21-0" in (result.output or "")
+
+
+class TestEnvironmentErrorAbortsSweep:
+    """Auth failures must abort the whole sweep, not become 60 crash
+    rows — EnvironmentError re-raises through the crash-recording
+    layer in both benchmark paths (#61 hardening, CR follow-up)."""
+
+    def _problem(self, pid):
+        return {"id": pid, "test_cases": []}
+
+    @patch("vera_bench.runner.run_single_problem")
+    def test_sequential_aborts_on_environment_error(self, mock_run, tmp_path):
+        from vera_bench.runner import run_benchmark
+
+        mock_run.side_effect = EnvironmentError("bad API key")
+        with pytest.raises(EnvironmentError, match="bad API key"):
+            run_benchmark(
+                problems=[self._problem("VB-X-0"), self._problem("VB-X-1")],
+                client=MagicMock(),
+                skill_md="",
+                vera=None,
+                language="python",
+                output_path=tmp_path / "out.jsonl",
+                parallel=1,
+            )
+        # Aborted on the first problem — no crash rows written.
+        out = tmp_path / "out.jsonl"
+        assert not out.exists() or out.read_text() == ""
+
+    @patch("vera_bench.runner.run_single_problem")
+    def test_parallel_aborts_on_environment_error(self, mock_run, tmp_path):
+        from vera_bench.runner import run_benchmark
+
+        mock_run.side_effect = EnvironmentError("bad API key")
+        with pytest.raises(EnvironmentError, match="bad API key"):
+            run_benchmark(
+                problems=[self._problem(f"VB-X-{i}") for i in range(3)],
+                client=MagicMock(),
+                skill_md="",
+                vera=None,
+                language="python",
+                output_path=tmp_path / "out.jsonl",
+                parallel=2,
+            )
+        out = tmp_path / "out.jsonl"
+        assert not out.exists() or out.read_text() == ""
+
+    @patch("vera_bench.runner.run_single_problem")
+    def test_other_exceptions_still_recorded_as_crashes(self, mock_run, tmp_path):
+        """Non-auth crashes keep the v0.0.15 crash-row semantics."""
+        import json as _json
+
+        from vera_bench.runner import run_benchmark
+
+        def _side_effect(problem, **kw):
+            raise RuntimeError("worker blew up")
+
+        mock_run.side_effect = _side_effect
+        results = run_benchmark(
+            problems=[self._problem("VB-X-0")],
+            client=MagicMock(_model="m"),
+            skill_md="",
+            vera=None,
+            language="python",
+            output_path=tmp_path / "out.jsonl",
+            parallel=1,
+        )
+        assert len(results) == 1
+        row = _json.loads((tmp_path / "out.jsonl").read_text().strip())
+        assert "worker blew up" in row["error_message"]

--- a/vera_bench/models.py
+++ b/vera_bench/models.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import hashlib
 import os
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Any, Protocol, TypeVar
+
+_T = TypeVar("_T")
 
 
 @dataclass
@@ -50,7 +53,9 @@ def _prompt_cache_key(system: str) -> str:
     return f"vera-bench-{digest}"
 
 
-def _call_openai_compatible(create_fn, label: str, key_hint: str, model: str):
+def _call_openai_compatible(
+    create_fn: Callable[[], _T], label: str, key_hint: str, model: str
+) -> _T:
     """Invoke an OpenAI-compatible create() with the standard error map.
 
     Shared by OpenAIClient / MoonshotClient / OpenRouterClient — same
@@ -91,7 +96,7 @@ def _call_openai_compatible(create_fn, label: str, key_hint: str, model: str):
         ) from e
 
 
-def _validate_openai_response_text(response, label: str, model: str) -> str:
+def _validate_openai_response_text(response: Any, label: str, model: str) -> str:
     """Extract text from an OpenAI-compatible response, or raise.
 
     Explicit errors on empty choices / empty content — without these

--- a/vera_bench/models.py
+++ b/vera_bench/models.py
@@ -50,6 +50,72 @@ def _prompt_cache_key(system: str) -> str:
     return f"vera-bench-{digest}"
 
 
+def _call_openai_compatible(create_fn, label: str, key_hint: str, model: str):
+    """Invoke an OpenAI-compatible create() with the standard error map.
+
+    Shared by OpenAIClient / MoonshotClient / OpenRouterClient — same
+    exception taxonomy, provider-specific label and credential hint:
+    - APITimeoutError -> TimeoutError
+    - AuthenticationError -> EnvironmentError (abort the run —
+      retrying 60 problems with the same bad key is pure waste; the
+      benchmark loop re-raises EnvironmentError rather than recording
+      per-problem crash rows)
+    - RateLimitError / BadRequestError / APIStatusError -> clean
+      RuntimeError messages instead of raw multi-line openai reprs
+      landing in JSONL
+    """
+    import openai
+
+    try:
+        return create_fn()
+    except openai.APITimeoutError as e:
+        raise TimeoutError(f"{label} API timed out: {e}") from e
+    except openai.AuthenticationError as e:
+        raise EnvironmentError(
+            f"{label} authentication failed (check {key_hint}): {e}"
+        ) from e
+    except openai.RateLimitError as e:
+        raise RuntimeError(
+            f"{label} rate-limited the model={model!r} "
+            f"request: {e}. Slow the sweep or use a higher tier."
+        ) from e
+    except openai.BadRequestError as e:
+        raise RuntimeError(
+            f"{label} rejected the request to model={model!r}: {e}. "
+            "Often model id wrong or prompt exceeds context."
+        ) from e
+    except openai.APIStatusError as e:
+        raise RuntimeError(
+            f"{label} API error (status={getattr(e, 'status_code', '?')}) "
+            f"on model={model!r}: {e}"
+        ) from e
+
+
+def _validate_openai_response_text(response, label: str, model: str) -> str:
+    """Extract text from an OpenAI-compatible response, or raise.
+
+    Explicit errors on empty choices / empty content — without these
+    the harness would receive text="" and blame the model for "did
+    not define entry point" when the real fault is API-side (content
+    filter, tool-call-only response, truncation).
+    """
+    if not response.choices:
+        finish_reason = getattr(response, "finish_reason", "no choices")
+        raise RuntimeError(
+            f"{label} returned no choices for model={model!r} "
+            f"(finish_reason={finish_reason})"
+        )
+    choice = response.choices[0]
+    text = choice.message.content if choice.message else None
+    if not text:
+        finish_reason = getattr(choice, "finish_reason", "unknown")
+        raise RuntimeError(
+            f"{label} returned empty content for model={model!r} "
+            f"(finish_reason={finish_reason})"
+        )
+    return text
+
+
 class LLMClient(Protocol):
     def complete(
         self,
@@ -170,13 +236,9 @@ class OpenAIClient:
         max_tokens: int = 4096,
         timeout: float = 120.0,
     ) -> LLMResponse:
-        import openai
-
         start = time.monotonic()
-        try:
-            response = self._client.with_options(
-                timeout=timeout
-            ).chat.completions.create(
+        response = _call_openai_compatible(
+            lambda: self._client.with_options(timeout=timeout).chat.completions.create(
                 model=self._model,
                 max_tokens=max_tokens,
                 messages=[
@@ -187,49 +249,13 @@ class OpenAIClient:
                 # Passed via extra_body so it works on any 1.x SDK
                 # regardless of typed-kwarg support (#61).
                 extra_body={"prompt_cache_key": _prompt_cache_key(system)},
-            )
-        except openai.APITimeoutError as e:
-            raise TimeoutError(f"OpenAI API timed out: {e}") from e
-        except openai.AuthenticationError as e:
-            # Bad API key — abort the run. Retrying 60 problems with the
-            # same bad key is pure waste.
-            raise EnvironmentError(
-                f"OpenAI authentication failed (check OPENAI_API_KEY): {e}"
-            ) from e
-        except openai.RateLimitError as e:
-            raise RuntimeError(
-                f"OpenAI rate-limited the model={self._model!r} "
-                f"request: {e}. Slow the sweep or use a higher tier."
-            ) from e
-        except openai.BadRequestError as e:
-            raise RuntimeError(
-                f"OpenAI rejected the request to model={self._model!r}: {e}. "
-                "Often model id wrong or prompt exceeds context."
-            ) from e
-        except openai.APIStatusError as e:
-            raise RuntimeError(
-                f"OpenAI API error (status={getattr(e, 'status_code', '?')}) "
-                f"on model={self._model!r}: {e}"
-            ) from e
-
+            ),
+            label="OpenAI",
+            key_hint="OPENAI_API_KEY",
+            model=self._model,
+        )
         elapsed = time.monotonic() - start
-
-        if not response.choices:
-            finish_reason = getattr(response, "finish_reason", "no choices")
-            raise RuntimeError(
-                f"OpenAI returned no choices for model={self._model!r} "
-                f"(finish_reason={finish_reason})"
-            )
-
-        choice = response.choices[0]
-        text = choice.message.content if choice.message else None
-        if not text:
-            finish_reason = getattr(choice, "finish_reason", "unknown")
-            raise RuntimeError(
-                f"OpenAI returned empty content for model={self._model!r} "
-                f"(finish_reason={finish_reason})"
-            )
-
+        text = _validate_openai_response_text(response, "OpenAI", self._model)
         usage = response.usage
         return LLMResponse(
             text=text,
@@ -270,13 +296,9 @@ class MoonshotClient:
         max_tokens: int = 4096,
         timeout: float = 120.0,
     ) -> LLMResponse:
-        import openai
-
         start = time.monotonic()
-        try:
-            response = self._client.with_options(
-                timeout=timeout
-            ).chat.completions.create(
+        response = _call_openai_compatible(
+            lambda: self._client.with_options(timeout=timeout).chat.completions.create(
                 model=self._model,
                 max_tokens=max_tokens,
                 messages=[
@@ -286,47 +308,13 @@ class MoonshotClient:
                 # No cache parameter: Moonshot's Context Caching is fully
                 # automatic (prefix matching on all requests, no headers
                 # or cache-lifecycle calls — see #61 research notes).
-            )
-        except openai.APITimeoutError as e:
-            raise TimeoutError(f"Moonshot API timed out: {e}") from e
-        except openai.AuthenticationError as e:
-            raise EnvironmentError(
-                f"Moonshot authentication failed (check MOONSHOT_API_KEY): {e}"
-            ) from e
-        except openai.RateLimitError as e:
-            raise RuntimeError(
-                f"Moonshot rate-limited the model={self._model!r} "
-                f"request: {e}. Slow the sweep or use a higher tier."
-            ) from e
-        except openai.BadRequestError as e:
-            raise RuntimeError(
-                f"Moonshot rejected the request to model={self._model!r}: {e}. "
-                "Often model id wrong or prompt exceeds context."
-            ) from e
-        except openai.APIStatusError as e:
-            raise RuntimeError(
-                f"Moonshot API error (status={getattr(e, 'status_code', '?')}) "
-                f"on model={self._model!r}: {e}"
-            ) from e
-
+            ),
+            label="Moonshot",
+            key_hint="MOONSHOT_API_KEY",
+            model=self._model,
+        )
         elapsed = time.monotonic() - start
-
-        if not response.choices:
-            finish_reason = getattr(response, "finish_reason", "no choices")
-            raise RuntimeError(
-                f"Moonshot returned no choices for model={self._model!r} "
-                f"(finish_reason={finish_reason})"
-            )
-
-        choice = response.choices[0]
-        text = choice.message.content if choice.message else None
-        if not text:
-            finish_reason = getattr(choice, "finish_reason", "unknown")
-            raise RuntimeError(
-                f"Moonshot returned empty content for model={self._model!r} "
-                f"(finish_reason={finish_reason})"
-            )
-
+        text = _validate_openai_response_text(response, "Moonshot", self._model)
         usage = response.usage
         return LLMResponse(
             text=text,
@@ -374,71 +362,22 @@ class OpenRouterClient:
         max_tokens: int = 4096,
         timeout: float = 120.0,
     ) -> LLMResponse:
-        import openai
-
         start = time.monotonic()
-        try:
-            response = self._client.with_options(
-                timeout=timeout
-            ).chat.completions.create(
+        response = _call_openai_compatible(
+            lambda: self._client.with_options(timeout=timeout).chat.completions.create(
                 model=self._model,
                 max_tokens=max_tokens,
                 messages=[
                     {"role": "system", "content": system},
                     {"role": "user", "content": user},
                 ],
-            )
-        except openai.APITimeoutError as e:
-            raise TimeoutError(f"OpenRouter API timed out: {e}") from e
-        except openai.AuthenticationError as e:
-            # Bad API key — abort the run. Retrying 60 problems with the
-            # same bad key is pure waste.
-            raise EnvironmentError(
-                f"OpenRouter authentication failed (check OPENROUTER_API_KEY): {e}"
-            ) from e
-        except openai.RateLimitError as e:
-            raise RuntimeError(
-                f"OpenRouter rate-limited the model={self._model!r} "
-                f"request: {e}. Slow the sweep or use a higher tier."
-            ) from e
-        except openai.BadRequestError as e:
-            raise RuntimeError(
-                f"OpenRouter rejected the request to model={self._model!r}: {e}. "
-                "Often model id wrong or prompt exceeds context."
-            ) from e
-        except openai.APIStatusError as e:
-            # Catch-all for any other API-side failure (5xx, etc.) — these
-            # used to propagate raw and land as multi-line openai-repr
-            # `error_message` rows in JSONL. Wrap with a clean message.
-            raise RuntimeError(
-                f"OpenRouter API error (status={getattr(e, 'status_code', '?')}) "
-                f"on model={self._model!r}: {e}"
-            ) from e
-
+            ),
+            label="OpenRouter",
+            key_hint="OPENROUTER_API_KEY",
+            model=self._model,
+        )
         elapsed = time.monotonic() - start
-
-        # Explicit error if the API returns no choices — without this,
-        # we'd return text="" and the harness would blame the model for
-        # "did not define entry point" when the real fault is API-side.
-        if not response.choices:
-            finish_reason = getattr(response, "finish_reason", "no choices")
-            raise RuntimeError(
-                f"OpenRouter returned no choices for model={self._model!r} "
-                f"(finish_reason={finish_reason})"
-            )
-
-        choice = response.choices[0]
-        # If the choice exists but content is None (e.g. content-filter or
-        # tool-call without text), that's also worth surfacing rather than
-        # silently becoming text="".
-        text = choice.message.content if choice.message else None
-        if not text:
-            finish_reason = getattr(choice, "finish_reason", "unknown")
-            raise RuntimeError(
-                f"OpenRouter returned empty content for model={self._model!r} "
-                f"(finish_reason={finish_reason})"
-            )
-
+        text = _validate_openai_response_text(response, "OpenRouter", self._model)
         usage = response.usage
         return LLMResponse(
             text=text,

--- a/vera_bench/models.py
+++ b/vera_bench/models.py
@@ -12,6 +12,30 @@ from typing import Any, Protocol, TypeVar
 _T = TypeVar("_T")
 
 
+class AuthError(EnvironmentError):
+    """API credential failure — aborts the whole sweep.
+
+    Subclasses EnvironmentError so existing callers and tests that
+    catch/expect EnvironmentError keep working, but gives the runner a
+    precise type to re-raise on. That precision matters: EnvironmentError
+    IS OSError, so catching it broadly would also abort the sweep on a
+    transient ConnectionError from the HTTP client — a network blip
+    should cost one problem, not the whole run.
+    """
+
+
+def _as_count(value: object) -> int:
+    """Normalise a provider-reported token counter to a safe int.
+
+    Providers occasionally report None (field absent), and mocks report
+    MagicMock. Either reaches ProblemResult and then json.dumps, which
+    raises "Object of type X is not JSON serializable" mid-sweep — after
+    the API spend. Negative values are equally nonsensical. type() not
+    isinstance(): bool is an int subclass.
+    """
+    return value if type(value) is int and value >= 0 else 0
+
+
 @dataclass
 class LLMResponse:
     text: str
@@ -78,9 +102,7 @@ def _call_openai_compatible(
     except openai.APITimeoutError as e:
         raise TimeoutError(f"{label} API timed out: {e}") from e
     except openai.AuthenticationError as e:
-        raise EnvironmentError(
-            f"{label} authentication failed (check {key_hint}): {e}"
-        ) from e
+        raise AuthError(f"{label} authentication failed (check {key_hint}): {e}") from e
     except openai.RateLimitError as e:
         raise RuntimeError(
             f"{label} rate-limited the model={model!r} "
@@ -113,8 +135,13 @@ def _validate_openai_response_text(response: Any, label: str, model: str) -> str
             f"(finish_reason={finish_reason})"
         )
     choice = response.choices[0]
-    text = choice.message.content if choice.message else None
-    if not text:
+    message = getattr(choice, "message", None)
+    text = getattr(message, "content", None) if message is not None else None
+    # isinstance check, not just truthiness: newer APIs can return
+    # structured content (a list of blocks) where a bare truthiness test
+    # would pass a non-str through to LLMResponse.text, and extract_code's
+    # regex would then fail far from the cause.
+    if not isinstance(text, str) or not text:
         finish_reason = getattr(choice, "finish_reason", "unknown")
         raise RuntimeError(
             f"{label} returned empty content for model={model!r} "
@@ -212,11 +239,15 @@ class AnthropicClient:
         cache_read = getattr(usage, "cache_read_input_tokens", 0) or 0
         return LLMResponse(
             text=text,
-            input_tokens=usage.input_tokens + cache_creation + cache_read,
-            output_tokens=usage.output_tokens,
+            input_tokens=(
+                _as_count(usage.input_tokens)
+                + _as_count(cache_creation)
+                + _as_count(cache_read)
+            ),
+            output_tokens=_as_count(usage.output_tokens),
             wall_time_s=round(elapsed, 2),
             model=response.model,
-            cached_tokens=cache_read if isinstance(cache_read, int) else 0,
+            cached_tokens=_as_count(cache_read),
         )
 
 
@@ -266,8 +297,8 @@ class OpenAIClient:
         usage = response.usage
         return LLMResponse(
             text=text,
-            input_tokens=usage.prompt_tokens if usage else 0,
-            output_tokens=usage.completion_tokens if usage else 0,
+            input_tokens=_as_count(usage.prompt_tokens) if usage else 0,
+            output_tokens=_as_count(usage.completion_tokens) if usage else 0,
             wall_time_s=round(elapsed, 2),
             model=response.model or self._model,
             cached_tokens=_openai_cached_tokens(usage) if usage else 0,
@@ -325,8 +356,8 @@ class MoonshotClient:
         usage = response.usage
         return LLMResponse(
             text=text,
-            input_tokens=usage.prompt_tokens if usage else 0,
-            output_tokens=usage.completion_tokens if usage else 0,
+            input_tokens=_as_count(usage.prompt_tokens) if usage else 0,
+            output_tokens=_as_count(usage.completion_tokens) if usage else 0,
             wall_time_s=round(elapsed, 2),
             model=response.model or self._model,
             cached_tokens=_openai_cached_tokens(usage) if usage else 0,
@@ -388,8 +419,8 @@ class OpenRouterClient:
         usage = response.usage
         return LLMResponse(
             text=text,
-            input_tokens=usage.prompt_tokens if usage else 0,
-            output_tokens=usage.completion_tokens if usage else 0,
+            input_tokens=_as_count(usage.prompt_tokens) if usage else 0,
+            output_tokens=_as_count(usage.completion_tokens) if usage else 0,
             wall_time_s=round(elapsed, 2),
             model=response.model or self._model,
             cached_tokens=_openai_cached_tokens(usage) if usage else 0,

--- a/vera_bench/models.py
+++ b/vera_bench/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 import time
 from dataclasses import dataclass
@@ -15,6 +16,38 @@ class LLMResponse:
     output_tokens: int
     wall_time_s: float
     model: str
+    # Cache-hit portion of input_tokens (0 when the provider reports
+    # nothing). Anthropic: cache_read_input_tokens. OpenAI-compatible:
+    # usage.prompt_tokens_details.cached_tokens. Issue #61.
+    cached_tokens: int = 0
+
+
+def _openai_cached_tokens(usage: object) -> int:
+    """Extract usage.prompt_tokens_details.cached_tokens defensively.
+
+    OpenAI-compatible providers (OpenAI, Moonshot, OpenRouter) report
+    cache hits under prompt_tokens_details, but the field is absent on
+    older SDKs / non-caching providers and may be None. The isinstance
+    guard also keeps MagicMock-based tests honest — an auto-created
+    mock attribute is not an int and must not leak into accounting.
+    """
+    details = getattr(usage, "prompt_tokens_details", None)
+    cached = getattr(details, "cached_tokens", 0) if details is not None else 0
+    return cached if isinstance(cached, int) else 0
+
+
+def _prompt_cache_key(system: str) -> str:
+    """Stable cache-routing key for requests sharing a system prefix.
+
+    OpenAI's prompt caching is automatic (>=1024 tokens) but
+    `prompt_cache_key` improves hit rates by routing same-prefix
+    requests to the same cache shard — recommended for the GPT-5.6
+    family. Keyed on the system prompt (the ~28k-token SKILL.md /
+    llms.txt prefix during sweeps) so each language-mode gets its own
+    stable shard.
+    """
+    digest = hashlib.sha256(system.encode("utf-8")).hexdigest()[:16]
+    return f"vera-bench-{digest}"
 
 
 class LLMClient(Protocol):
@@ -110,6 +143,7 @@ class AnthropicClient:
             output_tokens=usage.output_tokens,
             wall_time_s=round(elapsed, 2),
             model=response.model,
+            cached_tokens=cache_read if isinstance(cache_read, int) else 0,
         )
 
 
@@ -149,24 +183,61 @@ class OpenAIClient:
                     {"role": "system", "content": system},
                     {"role": "user", "content": user},
                 ],
+                # Cache-shard routing for the shared system prefix.
+                # Passed via extra_body so it works on any 1.x SDK
+                # regardless of typed-kwarg support (#61).
+                extra_body={"prompt_cache_key": _prompt_cache_key(system)},
             )
         except openai.APITimeoutError as e:
             raise TimeoutError(f"OpenAI API timed out: {e}") from e
+        except openai.AuthenticationError as e:
+            # Bad API key — abort the run. Retrying 60 problems with the
+            # same bad key is pure waste.
+            raise EnvironmentError(
+                f"OpenAI authentication failed (check OPENAI_API_KEY): {e}"
+            ) from e
+        except openai.RateLimitError as e:
+            raise RuntimeError(
+                f"OpenAI rate-limited the model={self._model!r} "
+                f"request: {e}. Slow the sweep or use a higher tier."
+            ) from e
+        except openai.BadRequestError as e:
+            raise RuntimeError(
+                f"OpenAI rejected the request to model={self._model!r}: {e}. "
+                "Often model id wrong or prompt exceeds context."
+            ) from e
+        except openai.APIStatusError as e:
+            raise RuntimeError(
+                f"OpenAI API error (status={getattr(e, 'status_code', '?')}) "
+                f"on model={self._model!r}: {e}"
+            ) from e
 
         elapsed = time.monotonic() - start
-        choice = response.choices[0] if response.choices else None
-        text = (
-            choice.message.content
-            if choice and choice.message and choice.message.content
-            else ""
-        )
+
+        if not response.choices:
+            finish_reason = getattr(response, "finish_reason", "no choices")
+            raise RuntimeError(
+                f"OpenAI returned no choices for model={self._model!r} "
+                f"(finish_reason={finish_reason})"
+            )
+
+        choice = response.choices[0]
+        text = choice.message.content if choice.message else None
+        if not text:
+            finish_reason = getattr(choice, "finish_reason", "unknown")
+            raise RuntimeError(
+                f"OpenAI returned empty content for model={self._model!r} "
+                f"(finish_reason={finish_reason})"
+            )
+
         usage = response.usage
         return LLMResponse(
-            text=text or "",
+            text=text,
             input_tokens=usage.prompt_tokens if usage else 0,
             output_tokens=usage.completion_tokens if usage else 0,
             wall_time_s=round(elapsed, 2),
             model=response.model or self._model,
+            cached_tokens=_openai_cached_tokens(usage) if usage else 0,
         )
 
 
@@ -212,24 +283,58 @@ class MoonshotClient:
                     {"role": "system", "content": system},
                     {"role": "user", "content": user},
                 ],
+                # No cache parameter: Moonshot's Context Caching is fully
+                # automatic (prefix matching on all requests, no headers
+                # or cache-lifecycle calls — see #61 research notes).
             )
         except openai.APITimeoutError as e:
             raise TimeoutError(f"Moonshot API timed out: {e}") from e
+        except openai.AuthenticationError as e:
+            raise EnvironmentError(
+                f"Moonshot authentication failed (check MOONSHOT_API_KEY): {e}"
+            ) from e
+        except openai.RateLimitError as e:
+            raise RuntimeError(
+                f"Moonshot rate-limited the model={self._model!r} "
+                f"request: {e}. Slow the sweep or use a higher tier."
+            ) from e
+        except openai.BadRequestError as e:
+            raise RuntimeError(
+                f"Moonshot rejected the request to model={self._model!r}: {e}. "
+                "Often model id wrong or prompt exceeds context."
+            ) from e
+        except openai.APIStatusError as e:
+            raise RuntimeError(
+                f"Moonshot API error (status={getattr(e, 'status_code', '?')}) "
+                f"on model={self._model!r}: {e}"
+            ) from e
 
         elapsed = time.monotonic() - start
-        choice = response.choices[0] if response.choices else None
-        text = (
-            choice.message.content
-            if choice and choice.message and choice.message.content
-            else ""
-        )
+
+        if not response.choices:
+            finish_reason = getattr(response, "finish_reason", "no choices")
+            raise RuntimeError(
+                f"Moonshot returned no choices for model={self._model!r} "
+                f"(finish_reason={finish_reason})"
+            )
+
+        choice = response.choices[0]
+        text = choice.message.content if choice.message else None
+        if not text:
+            finish_reason = getattr(choice, "finish_reason", "unknown")
+            raise RuntimeError(
+                f"Moonshot returned empty content for model={self._model!r} "
+                f"(finish_reason={finish_reason})"
+            )
+
         usage = response.usage
         return LLMResponse(
-            text=text or "",
+            text=text,
             input_tokens=usage.prompt_tokens if usage else 0,
             output_tokens=usage.completion_tokens if usage else 0,
             wall_time_s=round(elapsed, 2),
             model=response.model or self._model,
+            cached_tokens=_openai_cached_tokens(usage) if usage else 0,
         )
 
 
@@ -341,4 +446,5 @@ class OpenRouterClient:
             output_tokens=usage.completion_tokens if usage else 0,
             wall_time_s=round(elapsed, 2),
             model=response.model or self._model,
+            cached_tokens=_openai_cached_tokens(usage) if usage else 0,
         )

--- a/vera_bench/models.py
+++ b/vera_bench/models.py
@@ -36,7 +36,9 @@ def _openai_cached_tokens(usage: object) -> int:
     """
     details = getattr(usage, "prompt_tokens_details", None)
     cached = getattr(details, "cached_tokens", 0) if details is not None else 0
-    return cached if isinstance(cached, int) else 0
+    # type() check, not isinstance: bool is an int subclass, and a
+    # provider quirk returning True must not count as 1 cached token.
+    return cached if type(cached) is int else 0
 
 
 def _prompt_cache_key(system: str) -> str:

--- a/vera_bench/runner.py
+++ b/vera_bench/runner.py
@@ -1022,6 +1022,11 @@ def run_single_problem(
             user=prompt["user"],
             max_tokens=max_tokens,
         )
+    except EnvironmentError:
+        # Auth failures abort the sweep — never convert to a
+        # per-problem error row (run_benchmark's abort path
+        # depends on this propagating; CR #91 critical).
+        raise
     except Exception as e:
         results.append(
             ProblemResult(
@@ -1093,6 +1098,9 @@ def run_single_problem(
                 user=fix_prompt["user"],
                 max_tokens=max_tokens,
             )
+        except EnvironmentError:
+            # Auth failures abort the sweep (see attempt-1 handler).
+            raise
         except Exception as e:
             results.append(
                 ProblemResult(
@@ -1148,6 +1156,9 @@ def run_single_problem(
                 user=fix_prompt["user"],
                 max_tokens=max_tokens,
             )
+        except EnvironmentError:
+            # Auth failures abort the sweep (see attempt-1 handler).
+            raise
         except Exception as e:
             results.append(
                 ProblemResult(
@@ -1193,6 +1204,9 @@ def run_single_problem(
                 user=fix_prompt["user"],
                 max_tokens=max_tokens,
             )
+        except EnvironmentError:
+            # Auth failures abort the sweep (see attempt-1 handler).
+            raise
         except Exception as e:
             results.append(
                 ProblemResult(

--- a/vera_bench/runner.py
+++ b/vera_bench/runner.py
@@ -1324,6 +1324,13 @@ def run_benchmark(
                             bench_version=bench_version,
                             vera_version=vera_version,
                         )
+                    except EnvironmentError:
+                        # Auth failures (bad API key) abort the whole
+                        # sweep — the model clients raise
+                        # EnvironmentError for exactly this reason.
+                        # Recording 60 crash rows on the same bad key
+                        # would defeat that abort semantics.
+                        raise
                     except Exception as exc:  # noqa: BLE001
                         tb = traceback.format_exc()
                         pid = problem.get("id", "?")
@@ -1368,6 +1375,12 @@ def run_benchmark(
                         problem = futures[fut]
                         try:
                             problem_results = fut.result()
+                        except EnvironmentError:
+                            # Bad API key — abort the sweep (see the
+                            # sequential path). Propagating out of the
+                            # executor context cancels the run rather
+                            # than writing a crash row per problem.
+                            raise
                         except Exception as exc:  # noqa: BLE001
                             tb = traceback.format_exc()
                             pid = problem.get("id", "?")

--- a/vera_bench/runner.py
+++ b/vera_bench/runner.py
@@ -72,6 +72,7 @@ class ProblemResult:
     tests_passed: int = 0
     input_tokens: int = 0
     output_tokens: int = 0
+    cached_tokens: int = 0
     wall_time_s: float = 0.0
     timestamp: str = ""
     error_message: str | None = None
@@ -1062,6 +1063,7 @@ def run_single_problem(
             attempt=1,
             input_tokens=llm_response.input_tokens,
             output_tokens=llm_response.output_tokens,
+            cached_tokens=llm_response.cached_tokens,
             wall_time_s=llm_response.wall_time_s,
             timestamp=_now(),
             bench_version=bench_version,
@@ -1118,6 +1120,7 @@ def run_single_problem(
                 attempt=2,
                 input_tokens=fix_response.input_tokens,
                 output_tokens=fix_response.output_tokens,
+                cached_tokens=fix_response.cached_tokens,
                 wall_time_s=fix_response.wall_time_s,
                 timestamp=_now(),
                 bench_version=bench_version,
@@ -1172,6 +1175,7 @@ def run_single_problem(
                 attempt=2,
                 input_tokens=fix_response.input_tokens,
                 output_tokens=fix_response.output_tokens,
+                cached_tokens=fix_response.cached_tokens,
                 wall_time_s=fix_response.wall_time_s,
                 timestamp=_now(),
                 bench_version=bench_version,
@@ -1216,6 +1220,7 @@ def run_single_problem(
                 attempt=2,
                 input_tokens=fix_response.input_tokens,
                 output_tokens=fix_response.output_tokens,
+                cached_tokens=fix_response.cached_tokens,
                 wall_time_s=fix_response.wall_time_s,
                 timestamp=_now(),
                 bench_version=bench_version,

--- a/vera_bench/runner.py
+++ b/vera_bench/runner.py
@@ -1377,9 +1377,13 @@ def run_benchmark(
                             problem_results = fut.result()
                         except EnvironmentError:
                             # Bad API key — abort the sweep (see the
-                            # sequential path). Propagating out of the
-                            # executor context cancels the run rather
-                            # than writing a crash row per problem.
+                            # sequential path). Cancel queued futures
+                            # explicitly: the with-block's implicit
+                            # shutdown(wait=True) would otherwise DRAIN
+                            # the queue, firing one doomed API call per
+                            # remaining problem before the exception
+                            # propagates.
+                            executor.shutdown(wait=False, cancel_futures=True)
                             raise
                         except Exception as exc:  # noqa: BLE001
                             tb = traceback.format_exc()

--- a/vera_bench/runner.py
+++ b/vera_bench/runner.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from rich.console import Console
 from rich.progress import Progress
 
-from vera_bench.models import LLMClient
+from vera_bench.models import AuthError, LLMClient
 from vera_bench.prompts import (
     build_ailang_fix_prompt,
     build_aver_fix_prompt,
@@ -1022,10 +1022,12 @@ def run_single_problem(
             user=prompt["user"],
             max_tokens=max_tokens,
         )
-    except EnvironmentError:
+    except AuthError:
         # Auth failures abort the sweep — never convert to a
         # per-problem error row (run_benchmark's abort path
-        # depends on this propagating; CR #91 critical).
+        # depends on this propagating). AuthError is precise:
+        # a bare OSError/ConnectionError from the HTTP client
+        # must stay a one-problem failure, not kill the run.
         raise
     except Exception as e:
         results.append(
@@ -1098,7 +1100,7 @@ def run_single_problem(
                 user=fix_prompt["user"],
                 max_tokens=max_tokens,
             )
-        except EnvironmentError:
+        except AuthError:
             # Auth failures abort the sweep (see attempt-1 handler).
             raise
         except Exception as e:
@@ -1156,7 +1158,7 @@ def run_single_problem(
                 user=fix_prompt["user"],
                 max_tokens=max_tokens,
             )
-        except EnvironmentError:
+        except AuthError:
             # Auth failures abort the sweep (see attempt-1 handler).
             raise
         except Exception as e:
@@ -1204,7 +1206,7 @@ def run_single_problem(
                 user=fix_prompt["user"],
                 max_tokens=max_tokens,
             )
-        except EnvironmentError:
+        except AuthError:
             # Auth failures abort the sweep (see attempt-1 handler).
             raise
         except Exception as e:
@@ -1338,7 +1340,7 @@ def run_benchmark(
                             bench_version=bench_version,
                             vera_version=vera_version,
                         )
-                    except EnvironmentError:
+                    except AuthError:
                         # Auth failures (bad API key) abort the whole
                         # sweep — the model clients raise
                         # EnvironmentError for exactly this reason.
@@ -1389,7 +1391,7 @@ def run_benchmark(
                         problem = futures[fut]
                         try:
                             problem_results = fut.result()
-                        except EnvironmentError:
+                        except AuthError:
                             # Bad API key — abort the sweep (see the
                             # sequential path). Cancel queued futures
                             # explicitly: the with-block's implicit


### PR DESCRIPTION
## Summary

Closes #61. Prompt-cache instrumentation for the OpenAI and Moonshot clients, plus hardening both to the OpenRouter error-handling standard. Part of the v0.0.16 batch — CHANGELOG under `[Unreleased]`, no bump.

**Research outcome that reshaped the issue**: both providers now cache automatically server-side — OpenAI on ≥1024-token prompts (30-min TTL on the GPT-5.6 family), Moonshot prefix-caching on *all* requests (their earlier explicit `X-Msh-*` header scheme is obsolete). So the work is **routing + observability**, not cache lifecycle management. During sweeps, the ~28k-token SKILL.md prefix caches on both providers with no further effort.

## Changes

### Cache accounting — `cached_tokens` end-to-end
- New `cached_tokens: int = 0` on `LLMResponse` **and** `ProblemResult` → every sweep JSONL row now reports its cache-hit portion. Cost analysis can compute per-provider hit rates directly from result files (and smoke test S3 gates on exactly this field being > 0 on a warm second call).
- Anthropic: populated from `cache_read_input_tokens` (reads only — writes aren't hits).
- OpenAI / Moonshot / OpenRouter: shared `_openai_cached_tokens()` guard reads `usage.prompt_tokens_details.cached_tokens`, tolerating absent/None/non-int (the `isinstance` guard also prevents MagicMock leakage — **all 23 pre-existing model tests pass unmodified**).

### Cache routing — `prompt_cache_key` for OpenAI
- Stable key `vera-bench-{sha256(system)[:16]}` sent via `extra_body` (portable across 1.x SDKs). Same-prefix requests route to the same cache shard — OpenAI recommends this for GPT-5.6+. Each language-mode's system prefix gets its own shard for the whole sweep.
- Moonshot deliberately sends **no** cache parameter (fully automatic, no routing key exists) — pinned by `test_no_cache_param_sent`.

### Hardening (mirrors `OpenRouterClient`, the in-repo standard)
Both clients now: `AuthenticationError` → `EnvironmentError` (abort — retrying 60 problems on a bad key is waste), `RateLimitError`/`BadRequestError`/`APIStatusError` → clean `RuntimeError`s, and explicit errors on empty `choices`/`content` with `finish_reason` surfaced. Previously only `APITimeoutError` was caught; empty content silently became `text=""` and the harness blamed the model for "did not define entry point".

## Tests

- `TestCachedTokensHelpers` (5): incl. MagicMock leak guard + key stability/distinctness
- `TestOpenAICachingAndHardening` (5): cached flow, `extra_body` key assertion, auth abort, empty choices, empty content
- `TestMoonshotCachingAndHardening` (3): no-cache-param pin, auth abort, empty content
- 36 model + 191 runner tests green; `ruff` clean

## Sweep relevance

With SKILL.md at ~27.5k tokens, a 60-problem Vera target sends ~1.7M raw input tokens per model. Anthropic already cached (~85% billed reduction); this PR gets OpenAI's automatic caching properly shard-routed and makes hit rates observable for all providers — directly informing the pro-tier cost checkpoint in the sweep runbook.

**Note for PR 5**: the Sol@pro routing PR builds on this one (same class) — it inherits the hardened error paths and adds `reasoning_mode` on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Report cached tokens in benchmark results, including for retry attempts.
  * Added prompt-cache routing for OpenAI-compatible clients; caching for Moonshot is fully automatic.
* **Bug Fixes**
  * Hardened completion handling for empty `choices` and missing/empty response text.
  * Standardised OpenRouter error handling and improved cached-token extraction across providers.
  * `EnvironmentError` now aborts the entire sweep (including in parallel runs).
* **Documentation**
  * Updated the changelog with prompt-cache observability and OpenRouter error-standard details.
* **Tests**
  * Added coverage for cached-token accounting, prompt-cache key determinism, and sweep-abort behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->