### PR TITLE
Sol@pro routing: openai-pro/ prefix, reasoning mode, token-param swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   explicit exit-code marker when silent) into `error_message`,
   matching the AILANG evaluator's existing pattern. Both evaluators
   now share a `_first_run_error` formatting helper.
+- **`openai-pro/` model-routing prefix — reasoning-mode benchmark
+  entries.** `openai-pro/gpt-5.6-sol` runs Sol at
+  `reasoning.mode: pro` as a distinct benchmark entry from
+  default-mode `gpt-5.6-sol`: same model, different reasoning
+  budget — a controlled comparison of whether Vera's contracts do
+  the work the reasoning budget otherwise would. Mechanics:
+  - `create_client` routes the prefix to `OpenAIClient(...,
+    reasoning_mode="pro")`; the runner needs no changes (the
+    `complete()` Protocol carries no per-call config by design).
+  - The reasoning mode rides `extra_body` alongside the #61
+    `prompt_cache_key`; the pro tier floors the completion budget
+    at 16k tokens (reasoning consumes completion budget).
+  - JSONL rows from pro runs report `model: "<api-model>#pro"` so
+    the two variants are self-describing; results filenames are
+    already distinct (built from the CLI model string).
+  - `OpenAIClient` now sends `max_completion_tokens` (the GPT-5.x
+    reasoning families reject the legacy `max_tokens` kwarg).
+  - `scripts/run_full_benchmark.py` `_detect_provider` recognises
+    the prefix (→ `OPENAI_API_KEY`).
+
 - **Prompt-cache instrumentation for OpenAI and Moonshot clients**
   ([#61](https://github.com/aallan/vera-bench/issues/61)). Both
   providers now cache automatically server-side (OpenAI ≥1024-token

--- a/scripts/run_full_benchmark.py
+++ b/scripts/run_full_benchmark.py
@@ -68,6 +68,7 @@ def _detect_provider(model: str) -> str:
         or model.startswith("o1-")
         or model.startswith("o3-")
         or model.startswith("openai/")
+        or model.startswith("openai-pro/")
     ):
         return "openai"
     if model.startswith("moonshot/"):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -599,7 +599,11 @@ class TestOpenAIProRouting:
     """Sol@pro (openai-pro/ prefix) — the controlled reasoning-budget
     comparison entry. Same model id, distinct mode, distinct results."""
 
-    def _client(self, monkeypatch, model="openai-pro/gpt-5.6-sol"):
+    def _client(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        model: str = "openai-pro/gpt-5.6-sol",
+    ) -> object:
         try:
             from vera_bench.models import create_client
         except ImportError:
@@ -607,7 +611,7 @@ class TestOpenAIProRouting:
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")
         return create_client(model)
 
-    def _ok_response(self):
+    def _ok_response(self) -> MagicMock:
         resp = MagicMock()
         choice = MagicMock()
         choice.message.content = "code"
@@ -618,7 +622,7 @@ class TestOpenAIProRouting:
         resp.usage.prompt_tokens_details.cached_tokens = 0
         return resp
 
-    def _wire(self, client, mock_inner):
+    def _wire(self, client: object, mock_inner: MagicMock) -> None:
         client._client = MagicMock()
         client._client.with_options.return_value = mock_inner
 
@@ -700,3 +704,10 @@ class TestOpenAIProRouting:
         self._wire(client, mock_inner)
         result = client.complete("sys", "user")
         assert result.model == "gpt-5.6-sol"
+
+    def test_bare_openai_pro_prefix_rejected(self, monkeypatch):
+        from vera_bench.models import create_client
+
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        with pytest.raises(ValueError, match="requires a model id"):
+            create_client("openai-pro/")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -593,3 +593,110 @@ class TestMoonshotCachingAndHardening:
         self._wire(client, mock_inner)
         with pytest.raises(RuntimeError, match="empty content"):
             client.complete("sys", "user")
+
+
+class TestOpenAIProRouting:
+    """Sol@pro (openai-pro/ prefix) — the controlled reasoning-budget
+    comparison entry. Same model id, distinct mode, distinct results."""
+
+    def _client(self, monkeypatch, model="openai-pro/gpt-5.6-sol"):
+        try:
+            from vera_bench.models import create_client
+        except ImportError:
+            pytest.skip("openai not installed")
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        return create_client(model)
+
+    def _ok_response(self):
+        resp = MagicMock()
+        choice = MagicMock()
+        choice.message.content = "code"
+        resp.choices = [choice]
+        resp.model = "gpt-5.6-sol"
+        resp.usage.prompt_tokens = 100
+        resp.usage.completion_tokens = 5000
+        resp.usage.prompt_tokens_details.cached_tokens = 0
+        return resp
+
+    def _wire(self, client, mock_inner):
+        client._client = MagicMock()
+        client._client.with_options.return_value = mock_inner
+
+    def test_routing_strips_prefix_and_sets_mode(self, monkeypatch):
+        from vera_bench.models import OpenAIClient
+
+        client = self._client(monkeypatch)
+        assert isinstance(client, OpenAIClient)
+        assert client._model == "gpt-5.6-sol"
+        assert client._reasoning_mode == "pro"
+
+    def test_default_openai_has_no_reasoning_mode(self, monkeypatch):
+        client = self._client(monkeypatch, model="gpt-5.6-sol")
+        assert client._reasoning_mode is None
+
+    def test_unknown_prefix_still_rejected(self, monkeypatch):
+        from vera_bench.models import create_client
+
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        with pytest.raises(ValueError, match="Unknown model"):
+            create_client("mystery/some-model")
+
+    def test_reasoning_mode_sent_in_extra_body(self, monkeypatch):
+        client = self._client(monkeypatch)
+        mock_inner = MagicMock()
+        mock_inner.chat.completions.create.return_value = self._ok_response()
+        self._wire(client, mock_inner)
+        client.complete("sys", "user")
+        kwargs = mock_inner.chat.completions.create.call_args.kwargs
+        assert kwargs["extra_body"]["reasoning"] == {"mode": "pro"}
+        # Cache key still rides alongside (#61)
+        assert "prompt_cache_key" in kwargs["extra_body"]
+
+    def test_default_mode_sends_no_reasoning(self, monkeypatch):
+        client = self._client(monkeypatch, model="gpt-5.6-sol")
+        mock_inner = MagicMock()
+        mock_inner.chat.completions.create.return_value = self._ok_response()
+        self._wire(client, mock_inner)
+        client.complete("sys", "user")
+        kwargs = mock_inner.chat.completions.create.call_args.kwargs
+        assert "reasoning" not in kwargs["extra_body"]
+
+    def test_max_completion_tokens_sent_not_max_tokens(self, monkeypatch):
+        """GPT-5.x reasoning families reject the legacy max_tokens kwarg."""
+        client = self._client(monkeypatch, model="gpt-5.6-sol")
+        mock_inner = MagicMock()
+        mock_inner.chat.completions.create.return_value = self._ok_response()
+        self._wire(client, mock_inner)
+        client.complete("sys", "user", max_tokens=4096)
+        kwargs = mock_inner.chat.completions.create.call_args.kwargs
+        assert kwargs["max_completion_tokens"] == 4096
+        assert "max_tokens" not in kwargs
+
+    def test_pro_mode_floors_completion_budget(self, monkeypatch):
+        """Reasoning eats completion budget — pro floors to 16000 so
+        deliberation can't starve the output (validated live in S2)."""
+        client = self._client(monkeypatch)
+        mock_inner = MagicMock()
+        mock_inner.chat.completions.create.return_value = self._ok_response()
+        self._wire(client, mock_inner)
+        client.complete("sys", "user", max_tokens=4096)
+        kwargs = mock_inner.chat.completions.create.call_args.kwargs
+        assert kwargs["max_completion_tokens"] == 16000
+
+    def test_pro_response_model_gets_mode_suffix(self, monkeypatch):
+        """Both Sol variants report the same API id — the suffix makes
+        JSONL rows self-describing."""
+        client = self._client(monkeypatch)
+        mock_inner = MagicMock()
+        mock_inner.chat.completions.create.return_value = self._ok_response()
+        self._wire(client, mock_inner)
+        result = client.complete("sys", "user")
+        assert result.model == "gpt-5.6-sol#pro"
+
+    def test_default_response_model_unsuffixed(self, monkeypatch):
+        client = self._client(monkeypatch, model="gpt-5.6-sol")
+        mock_inner = MagicMock()
+        mock_inner.chat.completions.create.return_value = self._ok_response()
+        self._wire(client, mock_inner)
+        result = client.complete("sys", "user")
+        assert result.model == "gpt-5.6-sol"

--- a/vera_bench/models.py
+++ b/vera_bench/models.py
@@ -176,7 +176,12 @@ def create_client(model: str) -> LLMClient:
     if model.startswith("claude-") or model.startswith("anthropic/"):
         return AnthropicClient(model)
     if model.startswith("openai-pro/"):
-        return OpenAIClient(model.removeprefix("openai-pro/"), reasoning_mode="pro")
+        bare = model.removeprefix("openai-pro/")
+        if not bare:
+            raise ValueError(
+                "openai-pro/ requires a model id, e.g. openai-pro/gpt-5.6-sol"
+            )
+        return OpenAIClient(bare, reasoning_mode="pro")
     if (
         model.startswith("gpt-")
         or model.startswith("o1-")

--- a/vera_bench/models.py
+++ b/vera_bench/models.py
@@ -165,12 +165,18 @@ def create_client(model: str) -> LLMClient:
 
     - claude-* -> AnthropicClient
     - gpt-*, o1-*, o3-* -> OpenAIClient
+    - openai-pro/* -> OpenAIClient at reasoning mode "pro" (e.g.
+      openai-pro/gpt-5.6-sol runs Sol with reasoning.mode=pro — a
+      distinct benchmark entry from default-mode gpt-5.6-sol; the
+      CLI model string drives distinct results filenames)
     - moonshot/* -> MoonshotClient (OpenAI-compatible)
     - or/* -> OpenRouterClient (OpenAI-compatible; routes to any
       OpenRouter-hosted model, e.g. or/moonshotai/kimi-k2-0905)
     """
     if model.startswith("claude-") or model.startswith("anthropic/"):
         return AnthropicClient(model)
+    if model.startswith("openai-pro/"):
+        return OpenAIClient(model.removeprefix("openai-pro/"), reasoning_mode="pro")
     if (
         model.startswith("gpt-")
         or model.startswith("o1-")
@@ -185,7 +191,7 @@ def create_client(model: str) -> LLMClient:
     raise ValueError(
         f"Unknown model: {model!r}. "
         "Expected claude-*, anthropic/*, gpt-*, o1-*, o3-*, openai/*, "
-        "moonshot/*, or or/* prefix."
+        "openai-pro/*, moonshot/*, or or/* prefix."
     )
 
 
@@ -252,7 +258,7 @@ class AnthropicClient:
 
 
 class OpenAIClient:
-    def __init__(self, model: str) -> None:
+    def __init__(self, model: str, reasoning_mode: str | None = None) -> None:
         try:
             import openai  # noqa: F811
         except ImportError:
@@ -266,6 +272,11 @@ class OpenAIClient:
 
         self._client = openai.OpenAI(api_key=api_key)
         self._model = model.removeprefix("openai/")
+        # Reasoning mode (e.g. "pro" for gpt-5.6-sol's ceiling tier).
+        # Set by the openai-pro/ routing prefix in create_client; never
+        # via the runner (the complete() Protocol carries no per-call
+        # config — see the openai-pro design notes in the v0.0.16 plan).
+        self._reasoning_mode = reasoning_mode
 
     def complete(
         self,
@@ -274,19 +285,38 @@ class OpenAIClient:
         max_tokens: int = 4096,
         timeout: float = 120.0,
     ) -> LLMResponse:
+        # Reasoning consumes completion budget on reasoning models —
+        # a 4096 default can be all deliberation and no output at the
+        # pro tier. Floor the budget when a reasoning mode is active;
+        # smoke test S2 validates against truncation.
+        effective_max = max_tokens
+        if self._reasoning_mode:
+            effective_max = max(max_tokens, 16000)
+
+        # Cache-shard routing for the shared system prefix, passed via
+        # extra_body so it works on any 1.x SDK regardless of
+        # typed-kwarg support (#61). The reasoning mode rides the same
+        # channel ("reasoning.mode" per OpenAI's gpt-5.5-pro
+        # deprecation notice); smoke S2 verifies the exact accepted
+        # shape before the sweep.
+        extra_body: dict = {"prompt_cache_key": _prompt_cache_key(system)}
+        if self._reasoning_mode:
+            extra_body["reasoning"] = {"mode": self._reasoning_mode}
+
         start = time.monotonic()
         response = _call_openai_compatible(
             lambda: self._client.with_options(timeout=timeout).chat.completions.create(
                 model=self._model,
-                max_tokens=max_tokens,
+                # max_completion_tokens supersedes max_tokens on the
+                # GPT-5.x reasoning families (which reject the legacy
+                # kwarg); all matrix OpenAI models are 5.6-family.
+                # Smoke S1 validates acceptance per model.
+                max_completion_tokens=effective_max,
                 messages=[
                     {"role": "system", "content": system},
                     {"role": "user", "content": user},
                 ],
-                # Cache-shard routing for the shared system prefix.
-                # Passed via extra_body so it works on any 1.x SDK
-                # regardless of typed-kwarg support (#61).
-                extra_body={"prompt_cache_key": _prompt_cache_key(system)},
+                extra_body=extra_body,
             ),
             label="OpenAI",
             key_hint="OPENAI_API_KEY",
@@ -295,12 +325,18 @@ class OpenAIClient:
         elapsed = time.monotonic() - start
         text = _validate_openai_response_text(response, "OpenAI", self._model)
         usage = response.usage
+        # Both Sol variants report the same API model id — suffix the
+        # reasoning mode so JSONL rows are self-describing (filenames
+        # are already distinct via the CLI model string).
+        reported_model = response.model or self._model
+        if self._reasoning_mode:
+            reported_model = f"{reported_model}#{self._reasoning_mode}"
         return LLMResponse(
             text=text,
             input_tokens=_as_count(usage.prompt_tokens) if usage else 0,
             output_tokens=_as_count(usage.completion_tokens) if usage else 0,
             wall_time_s=round(elapsed, 2),
-            model=response.model or self._model,
+            model=reported_model,
             cached_tokens=_openai_cached_tokens(usage) if usage else 0,
         )
 


### PR DESCRIPTION
## Summary

Wires the **Sol@pro** benchmark entry — the Fable-tier OpenAI slot in the approved v0.0.16 matrix. `openai-pro/gpt-5.6-sol` runs Sol at `reasoning.mode: pro` as a distinct benchmark entry from default-mode `gpt-5.6-sol`: **same model, different reasoning budget**. If Vera's mandatory contracts make default ≈ pro, the language is doing the work the reasoning budget otherwise would — the controlled comparison no other provider offers, and a key talk slide.

**Stacked on #91** (base = `feature/caching-openai-moonshot`; GitHub retargets to `main` automatically when #91 merges) — it builds directly on the hardened client and shares the `extra_body` channel with the `prompt_cache_key`.

Part of the v0.0.16 batch — CHANGELOG under `[Unreleased]`, no bump.

## Changes

- **Routing**: `create_client` maps `openai-pro/<id>` → `OpenAIClient(<id>, reasoning_mode="pro")`. Zero runner changes — per the design, the `complete()` Protocol carries no per-call config; the mode is parsed at construction and applied inside the client. Unknown-prefix `ValueError` behaviour preserved (pinned by test).
- **Request shape**: `reasoning={"mode": "pro"}` rides `extra_body` alongside the #61 cache key. The spelling follows OpenAI's own deprecation notice (`gpt-5-pro-2025-10-06` → "gpt-5.6-sol (reasoning.mode: pro)"). ⚠ Smoke **S2** verifies the accepted shape live before the sweep — if the API wants a different spelling, the 400 body names it and this is a one-line fix.
- **Token param swap**: `max_tokens` → `max_completion_tokens` — the GPT-5.x reasoning families reject the legacy kwarg, and every OpenAI model in the matrix is 5.6-family. ⚠ Smoke **S1** validates acceptance per model.
- **Pro budget floor**: reasoning consumes completion budget, so pro floors `max_completion_tokens` at 16k (a 4096 default can be all deliberation, no output). S2 checks truncation.
- **Row identity**: pro responses report `model: "gpt-5.6-sol#pro"` in JSONL — both variants otherwise return the same API id. Results *filenames* were already distinct (built from the CLI model string).
- `scripts/run_full_benchmark.py` `_detect_provider` recognises the prefix → `OPENAI_API_KEY`.

## Tests

`TestOpenAIProRouting` — 9 cases: routing/strip/mode set, default-client has no mode, unknown-prefix non-regression, `extra_body` shape for both modes, token-param swap, pro budget floor, `#pro` model suffix on/off. **45 model tests green**, ruff clean.

## Sequencing

Merge **after #91**. Then the smoke gate (S0–S5, attended) validates the two ⚠ items above live, and PR 6 freezes the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for OpenAI Pro model routing via the `openai-pro/` prefix.
  * Enabled pro reasoning mode, including updated completion limits and response model labelling.
  * Added support for forwarding reasoning and prompt-cache settings with requests.

* **Bug Fixes**
  * OpenAI Pro models now use the correct provider and API-key selection.
  * Improved validation for unsupported or incomplete model identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->