### PR TITLE
v0.0.16: 3-tier matrix, charts, and four harness fixes found by preflight

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,6 @@ What does this PR do?
 - [ ] All new `.vera` solutions pass `vera verify`
 - [ ] Problem JSON definitions have all required fields
 - [ ] Test cases have correct expected outputs
-- [ ] Python/TypeScript baselines match Vera solutions
-- [ ] `scripts/validate_problems.py` passes
+- [ ] Python, TypeScript, Aver and AILANG baselines match the Vera solutions
+- [ ] `vera-bench validate` passes (or `scripts/validate_problems.py`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Claude Fable 5 returned no code at all.** `AnthropicClient.complete`
+  read `response.content[0].text`, but models with extended thinking
+  return `ThinkingBlock` entries *ahead of* the `TextBlock` — so every
+  Fable 5 call died with `'ThinkingBlock' object has no attribute
+  'text'`, recorded as an API-error row with no generated code. The
+  whole fable tier of the v0.0.16 matrix would have come back empty.
+  A new `_anthropic_text` helper selects blocks by `.type == "text"`
+  and joins them, ignoring thinking and redacted-thinking blocks.
+  Caught by smoke S1 (2026-07-23); the pre-existing unit test missed it
+  because a bare `MagicMock` auto-supplies any attribute, including the
+  `.text` the real `ThinkingBlock` lacks.
+- **`openai-pro/` sent a parameter the API does not accept.** The
+  reasoning tier was passed as `extra_body={"reasoning": {"mode":
+  "pro"}}` — the *Responses API* shape. Chat Completions rejects it
+  with `400 Unknown parameter: 'reasoning'`, so every Sol@pro call
+  failed. Chat Completions takes a typed `reasoning_effort` kwarg from
+  a fixed set (`none`/`minimal`/`low`/`medium`/`high`/`xhigh`/`max`),
+  with no `"pro"` member; the user-facing "pro" name is retained (it is
+  baked into model strings, filenames and slides) and mapped to the API
+  ceiling `"max"` via `REASONING_MODE_EFFORT`. An unmapped mode now
+  raises rather than silently sending no reasoning parameter — that
+  failure mode would have run the "pro" entry at default effort and
+  turned the headline pro-vs-default comparison into a model compared
+  against itself. Confirms the CodeRabbit finding on
+  [#92](https://github.com/aallan/vera-bench/pull/92) that was declined
+  pending evidence.
+- **Long result paths wrapped mid-token in console output.** `Output:
+  <path>` was printed through rich, which wraps at the console width
+  (80 when not a tty — CI, and any sweep log piped to a file), breaking
+  paths across lines mid-word and making them un-greppable and
+  un-copy-pasteable. Now printed with `soft_wrap=True`. This was also
+  failing `test_run_ailang_full_path_success` on `main`.
+- **`aver`/`ailang` version-probe timeouts reported the wrong cause.**
+  A `TimeoutExpired` from `--version` was either unhandled (ailang) or
+  folded into the not-found branch (aver), which advised reinstalling a
+  compiler that is already installed. Both now report the timeout
+  distinctly.
 - **AILANG version parsing corrupted result filenames.** `run
   --language ailang` built its output filename from the compiler's
   raw `--version` stdout. `ailang --version` prints a **seven-line**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,12 +29,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `create_client` routes the prefix to `OpenAIClient(...,
     reasoning_mode="pro")`; the runner needs no changes (the
     `complete()` Protocol carries no per-call config by design).
-  - The reasoning mode rides `extra_body` alongside the #61
-    `prompt_cache_key`; the pro tier floors the completion budget
-    at 16k tokens (reasoning consumes completion budget).
-  - JSONL rows from pro runs report `model: "<api-model>#pro"` so
-    the two variants are self-describing; results filenames are
+  - Both Sol arms run through the **Responses API**, which is the
+    only endpoint carrying `reasoning.mode`, and both get the same
+    16k output floor — an unequal budget would be a second variable
+    in a comparison that claims to have one. `gpt-5.6-terra` is not
+    half of the pair and stays on Chat Completions.
+  - JSONL rows are self-describing: `model: "<api-model>#pro"` and
+    `"<api-model>#standard"` respectively. Result filenames are
     already distinct (built from the CLI model string).
+  - The response echoes the *effective* mode, and a mismatch — or an
+    absent echo — raises rather than being recorded as a pro result.
   - `OpenAIClient` now sends `max_completion_tokens` (the GPT-5.x
     reasoning families reject the legacy `max_tokens` kwarg).
   - `scripts/run_full_benchmark.py` `_detect_provider` recognises

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (previously returned `text=""` and the harness blamed the model
   for "did not define entry point").
 
+### Changed
+
+- **Minimum `openai` SDK raised from `>=1.50` to `>=2.45`.** The
+  `openai-pro/` path calls `responses.create` with `prompt_cache_key`
+  and `reasoning={"mode": "pro"}`; the declared floor supported none of
+  the three. Verified against the wheels rather than inferred:
+  `responses.create` arrived in 1.66.0, `prompt_cache_key` in 2.0.0,
+  and `reasoning.mode` in 2.45.0. 2.0 would in fact work at runtime —
+  `maybe_transform` forwards keys a TypedDict does not declare, and the
+  response model is pydantic `extra="allow"` — but relying on that
+  makes a silent failure possible: if either behaviour changed, the
+  "pro" entry would run in standard mode, the effective-mode guard
+  would no-op, and the reasoning chart would compare a model against
+  itself while looking entirely normal.
+
 ### Fixed
 
 - **Claude Fable 5 returned no code at all.** `AnthropicClient.complete`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `extract_data` treats a file with nothing gradeable as *missing*
   rather than plotting it as a genuine 0% — the same conflation the
   `missing` set already prevents for absent files, one layer down.
+- **`vera run` failures were indistinguishable from wrong answers.**
+  The per-test loop in `_evaluate_vera_code` discarded the exit code and
+  stderr on failure, and swallowed every exception through a bare
+  `except Exception` with no message — so a compiler crash was recorded
+  as `error_message=None, check_pass=True, run_correct=False`, byte-identical
+  to a model writing a wrong program. The #72 diagnostics work reached the
+  Aver and AILANG evaluators but never the Vera path, which is the
+  headline number. Now captures the first failure via a `_vera_run_error`
+  sibling of `_first_run_error`, including **signal detection**:
+  `subprocess` reports a signal death as a negative return code, so a
+  compiler SIGBUS arrives as `exit_code == -10` and is now named as such.
+  Not hypothetical — vera SIGBUS'd repeatedly on 2026-07-23
+  ([aallan/vera#1145](https://github.com/aallan/vera/issues/1145)), and
+  every one of those would have been scored against the model.
+- **`preflight.sh` now exits non-zero when the gate fails.** It could
+  print `*** pro may be SILENTLY IGNORED ***` — the one finding that
+  invalidates the reasoning slide — and still exit 0, because the S2 and
+  S3 analyses printed their verdicts from inside Python heredocs without
+  touching the pass/fail counters. A chained
+  `preflight.sh && run_full_benchmark.py` would have sailed straight
+  past it. S2's verdict now feeds the counters and the script ends on
+  its own tally.
 - **Both Sol arms now send `store=False`.** The Responses API defaults
   to `store=True` where Chat Completions does not persist at all, so
   the pro routing silently introduced 30-day server-side retention of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A sweep with most calls failing could report an excellent score**
+  ([#95](https://github.com/aallan/vera-bench/issues/95)). `run_correct`
+  is measured over `run_eligible` — problems whose attempt compiled —
+  so rows that never reached the compiler (API errors, auth rejections,
+  timeouts) left the denominator entirely. Verified: **40 API failures
+  plus 20 successes reported `run_correct = 100%`**, and nothing in the
+  output said so; `check@1` merely dropped, which is a normal result
+  for a model struggling with Vera. The rate itself is unchanged, since
+  altering it would break comparability with published results.
+  Instead `BenchmarkMetrics` gained `run_eligible` and `errored`, the
+  CLI summary now prints the graded denominator whenever it differs
+  from the problem count plus an `errored: N/60` row in red, and
+  `extract_data` treats a file with nothing gradeable as *missing*
+  rather than plotting it as a genuine 0% — the same conflation the
+  `missing` set already prevents for absent files, one layer down.
+- **Both Sol arms now send `store=False`.** The Responses API defaults
+  to `store=True` where Chat Completions does not persist at all, so
+  the pro routing silently introduced 30-day server-side retention of
+  every prompt and completion. Beyond the data-handling question,
+  retained content could feed cross-run caching or personalisation —
+  and a benchmark whose second run is informed by its first is not
+  measuring what it claims to.
 - **Claude Fable 5 returned no code at all.** `AnthropicClient.complete`
   read `response.content[0].text`, but models with extended thinking
   return `ThinkingBlock` entries *ahead of* the `TextBlock` — so every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **AILANG version parsing corrupted result filenames.** `run
+  --language ailang` built its output filename from the compiler's
+  raw `--version` stdout. `ailang --version` prints a **seven-line**
+  banner (version, commit, full SHA, build stamp, blank, tagline,
+  copyright), and the old `.strip().replace("ailang ", "")` matched
+  nothing in it — the binary prints `AILANG v0.30.0`, capitalised.
+  The entire banner therefore landed in the filename, producing a
+  216-character name containing embedded newlines and colons. macOS
+  creates such a file happily, so this failed silently: every shell
+  glob in the sweep runbook, the `file_prefix` matching in
+  `plot_results.py`, and the release tarball would all have missed
+  the AILANG results. Never caught because `baselines --language
+  ailang` uses a separate code path that does not embed versions.
+  Both the Aver and AILANG probes now share a `_parse_version_banner`
+  helper that takes the first line and extracts the numeric version
+  token, falling back to `"unknown"` (which callers already treat as
+  "omit the version from the filename"). The AILANG probe also now
+  catches `TimeoutExpired`, matching the Aver probe.
 - **Vera 0.1.x compatibility for the problem set and canonical
   solutions.** Vera moved from v0.0.177 to v0.1.6+ (the v0.1.0 bug
   burndown plus the 0.1.x line) and three compiler changes broke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.0.16] - 2026-07-23
 
 ### Added
 
@@ -639,7 +639,8 @@ Vera, Vera spec-from-NL, Python, and TypeScript scoring is unaffected.
 - Claude Sonnet 4: 96% check@1, 96% verify@1, 83% run_correct (50 problems, full-spec mode)
 - Python canonical baselines: 100% run_correct (24 testable problems)
 
-[Unreleased]: https://github.com/aallan/vera-bench/compare/v0.0.15...HEAD
+[Unreleased]: https://github.com/aallan/vera-bench/compare/v0.0.16...HEAD
+[0.0.16]: https://github.com/aallan/vera-bench/compare/v0.0.15...v0.0.16
 [0.0.15]: https://github.com/aallan/vera-bench/compare/v0.0.14...v0.0.15
 [0.0.14]: https://github.com/aallan/vera-bench/compare/v0.0.13...v0.0.14
 [0.0.13]: https://github.com/aallan/vera-bench/compare/v0.0.12...v0.0.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   model compared against itself. Confirms the CodeRabbit finding on
   [#92](https://github.com/aallan/vera-bench/pull/92) that was declined
   pending evidence.
+
+  **Both Sol entries are pinned to the Responses API** via
+  `RESPONSES_API_MODELS`, with the default entry sending an explicit
+  `reasoning.mode: "standard"`. Pro mode exists only on Responses, so
+  leaving the default arm on Chat Completions would vary endpoint and
+  mode together and the reasoning-budget comparison could not attribute
+  its delta to deliberation. The 16000-token output floor applies to
+  both arms for the same reason. `gpt-5.6-terra` is a separate tier row
+  rather than half of a controlled pair, and stays on Chat Completions.
+  Sol rows now report `model` as `gpt-5.6-sol#standard` /
+  `gpt-5.6-sol#pro`; charts key on filenames, which are unchanged.
 - **Long result paths wrapped mid-token in console output.** `Output:
   <path>` was printed through rich, which wraps at the console width
   (80 when not a tty — CI, and any sweep log piped to a file), breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,19 +82,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Caught by smoke S1 (2026-07-23); the pre-existing unit test missed it
   because a bare `MagicMock` auto-supplies any attribute, including the
   `.text` the real `ThinkingBlock` lacks.
-- **`openai-pro/` sent a parameter the API does not accept.** The
-  reasoning tier was passed as `extra_body={"reasoning": {"mode":
-  "pro"}}` — the *Responses API* shape. Chat Completions rejects it
-  with `400 Unknown parameter: 'reasoning'`, so every Sol@pro call
-  failed. Chat Completions takes a typed `reasoning_effort` kwarg from
-  a fixed set (`none`/`minimal`/`low`/`medium`/`high`/`xhigh`/`max`),
-  with no `"pro"` member; the user-facing "pro" name is retained (it is
-  baked into model strings, filenames and slides) and mapped to the API
-  ceiling `"max"` via `REASONING_MODE_EFFORT`. An unmapped mode now
-  raises rather than silently sending no reasoning parameter — that
-  failure mode would have run the "pro" entry at default effort and
-  turned the headline pro-vs-default comparison into a model compared
-  against itself. Confirms the CodeRabbit finding on
+- **`openai-pro/` went to the wrong endpoint — now uses the Responses
+  API.** The reasoning tier was passed as `extra_body={"reasoning":
+  {"mode": "pro"}}` on Chat Completions, which rejects it with `400
+  Unknown parameter: 'reasoning'`, so every Sol@pro call failed. Per
+  OpenAI's reasoning guide, **mode and effort are independent axes** —
+  mode selects standard vs pro *execution*, effort controls how much
+  reasoning happens — and `reasoning.mode` exists only on the Responses
+  API (`Literal["standard", "pro"]` in openai-python 2.47). Pro is
+  therefore not expressible on Chat Completions at all: `reasoning` is
+  rejected as unknown, and `reasoning_effort="max"` is rejected too
+  (`gpt-5.6-sol` accepts only `none`/`low`/`medium`/`high`/`xhigh`
+  there — `max` is Responses-only). A client with a reasoning mode set
+  now routes to `responses.create` with `instructions`/`input`/
+  `max_output_tokens` and reads usage from `input_tokens` /
+  `output_tokens` / `input_tokens_details.cached_tokens`. Two new
+  guards: an unknown mode raises at construction, and a response whose
+  echoed *effective* `reasoning.mode` differs from the requested one
+  raises rather than being recorded as a pro result — a silent
+  downgrade would turn the headline pro-vs-default comparison into a
+  model compared against itself. Confirms the CodeRabbit finding on
   [#92](https://github.com/aallan/vera-bench/pull/92) that was declined
   pending evidence.
 - **Long result paths wrapped mid-token in console output.** `Output:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,4 +138,22 @@ vera-bench baselines --language ailang     # AILANG baselines
 vera-bench report results/DIR/         # generate report
 ```
 
+```bash
+bash scripts/preflight.sh              # pre-sweep gate: ids, auth, params, toolchains
+bash scripts/preflight.sh s2 s5        # re-run only these stages (calls cost money)
+```
+
+Run `preflight.sh` before any large sweep. It gates every model in
+`run_full_benchmark.py` — reading that list rather than duplicating it — plus
+provider auth, the request parameters each model accepts, and the Vera / Aver /
+AILANG toolchains, at one problem per check. It judges **result rows, not exit
+codes**: `vera-bench run` records an API error as a JSONL row and still exits 0,
+so a check reading `$?` reports success for a model that never answered. Details
+in [`scripts/README.md`](scripts/README.md#preflightsh--pre-sweep-gate).
+
+**There is no resume.** `vera-bench run` unlinks the output file for that
+model × language × mode at startup, and filenames carry no timestamp — an
+interrupted target must be re-run in full, and its partial results are gone.
+Never plan to "top up" a sweep.
+
 `--parallel N` dispatches problems to a `ThreadPoolExecutor` with N workers. Default `parallel=1` preserves the sequential path. Workers are I/O-bound on LLM calls + subprocess `check`/`run`, so the GIL is not a bottleneck. Use this when sweeping slow models (e.g. Kimi K2.5 at ~50s/problem sequentially drops to ~5s/problem at `--parallel 10`). JSONL output ordering is by completion order in parallel mode; each line is self-contained (carries `problem_id`) so downstream consumers can sort if needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ VeraBench is a HumanEval/MBPP-style benchmark for [Vera](https://github.com/aall
 
 ```bash
 pip install git+https://github.com/aallan/vera.git
-vera version   # should print vera 0.0.103 or later
+vera version   # should print vera 0.1.6 or later
 ```
 
 ## Problem structure
@@ -78,14 +78,14 @@ Both issues have caused false baseline failures (VB-T4-003 for Python, VB-T1-006
 
 ### Adding a new comparison language
 
-The pattern for adding a new language is established by the Python, TypeScript, and Aver implementations:
+The pattern for adding a new language is established by the Python, TypeScript, Aver, and AILANG implementations:
 
 1. **Prompt builder** (`prompts.py`) — `build_{lang}_prompt()` that uses `description_neutral` + the language's reference doc
 2. **Code evaluator** (`runner.py`) — `_evaluate_{lang}_code()` that writes code to a temp file, runs the compiler/interpreter, and checks output
 3. **Baseline runner** (`baseline_runner.py`) — `run_{lang}_baseline()` for canonical solutions
 4. **CLI integration** (`cli.py`) — add to `--language` choices
 5. **Canonical solutions** (`solutions/{lang}/`) — one per problem
-6. **Reference doc** — fetched at runtime (SKILL.md for Vera, llms.txt for Aver)
+6. **Reference doc** — SKILL.md for Vera and llms.txt for Aver are fetched at runtime; AILANG's is read from the installed compiler (`ailang prompt --source embedded`), which keeps it version-locked to the binary being graded
 
 ### Aver
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,14 +21,19 @@ New benchmark problems are welcome. For each new problem, you must produce:
 3. A Python baseline in `solutions/python/`.
 4. A TypeScript baseline in `solutions/typescript/`.
 5. An Aver baseline in `solutions/aver/`.
+6. An AILANG baseline in `solutions/ailang/`.
+
+Every comparison language needs a baseline, or `vera-bench baselines --language
+{lang}` drops below the full problem count and the cross-language numbers stop
+being like-for-like.
 
 See [CLAUDE.md](CLAUDE.md) for problem structure, tier definitions, and Vera gotchas.
 
 ### Adding a New Comparison Language
 
-VeraBench supports cross-language comparison. Currently: Vera, Python, TypeScript, and Aver. To add a new language:
+VeraBench supports cross-language comparison. Currently: Vera, Python, TypeScript, Aver, and AILANG. To add a new language:
 
-1. **Canonical solutions** — Create `solutions/{lang}/` with one solution per problem (50 files). Each must produce correct output for all test cases.
+1. **Canonical solutions** — Create `solutions/{lang}/` with one solution per problem (60 files). Each must produce correct output for all test cases.
 
 2. **Prompt builder** — Add `build_{lang}_prompt()` to `vera_bench/prompts.py`. Use `description_neutral` (not `description`, which is Vera-specific). If the language has a reference doc (like SKILL.md or llms.txt), fetch it at runtime.
 
@@ -44,7 +49,12 @@ VeraBench supports cross-language comparison. Currently: Vera, Python, TypeScrip
 
 8. **CodeRabbit exclusions** — Add `!**/*.{ext}` and `!solutions/{lang}/**` to `.coderabbit.yaml` path_filters (CodeRabbit doesn't understand novel languages).
 
-See PR [#48](https://github.com/aallan/vera-bench/pull/48) (Aver support) as a reference implementation.
+Reference implementations: PR [#48](https://github.com/aallan/vera-bench/pull/48)
+(Aver) and PR [#70](https://github.com/aallan/vera-bench/pull/70) (AILANG). The
+AILANG one is the better model if your language ships its teaching prompt inside
+its own CLI rather than at a URL — it shells out to `ailang prompt --source
+embedded` instead of fetching a doc, which keeps the prompt version-locked to
+the installed compiler.
 
 ### Code Contributions
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -51,7 +51,7 @@ For each problem × model combination:
 - **fix@1** — Given the error message from a failed first attempt, can the model fix it in one turn?
 - **run_correct** — Does the best passing attempt produce the correct output for all test cases?
 
-Aggregate rates are computed per tier and overall. Cross-language baselines (Python, TypeScript, Aver) measure the same problems for comparison. Python and TypeScript are heavily represented in LLM training data; Aver (like Vera) has zero training data, providing a second data point for the zero-training-data thesis.
+Aggregate rates are computed per tier and overall. Cross-language baselines (Python, TypeScript, Aver, AILANG) measure the same problems for comparison. Python and TypeScript are heavily represented in LLM training data; Aver and AILANG (like Vera) have zero training data, giving two further data points for the zero-training-data thesis.
 
 ---
 
@@ -59,13 +59,13 @@ Aggregate rates are computed per tier and overall. Cross-language baselines (Pyt
 
 **Problem descriptions are natural language, not code stubs.** Unlike HumanEval (which gives a Python function signature + docstring), VeraBench gives a natural language description + the Vera function signature + optionally the contracts.
 
-**Two description fields: `description` and `description_neutral`.** The `description` field contains Vera-specific language (slot references, contract clauses). The `description_neutral` field is language-agnostic and is used for all non-Vera languages (Python, TypeScript, Aver). This is a fairness correction: non-Vera languages should not receive Vera-flavoured prompts. The neutral descriptions are functionally equivalent to spec-from-NL descriptions — the model must infer language-specific constructs from natural language.
+**Two description fields: `description` and `description_neutral`.** The `description` field contains Vera-specific language (slot references, contract clauses). The `description_neutral` field is language-agnostic and is used for all non-Vera languages (Python, TypeScript, Aver, AILANG). This is a fairness correction: non-Vera languages should not receive Vera-flavoured prompts. The neutral descriptions are functionally equivalent to spec-from-NL descriptions — the model must infer language-specific constructs from natural language.
 
 **Contracts can be provided or omitted.** For Tiers 1–2, provide the contracts in the prompt (full-spec mode). For Tiers 3–5, a spec-from-NL variant where the agent must also write the contracts.
 
-**The SKILL.md is always provided.** Unlike benchmarks for well-known languages, Vera is not in any model's training data. The SKILL.md is the sole source of language knowledge. Similarly, Aver's `llms.txt` is fetched and provided for Aver benchmarks.
+**The SKILL.md is always provided.** Unlike benchmarks for well-known languages, Vera is not in any model's training data. The SKILL.md is the sole source of language knowledge. Similarly, Aver's `llms.txt` is fetched for Aver benchmarks, and AILANG's teaching prompt is read from the installed compiler via `ailang prompt --source embedded` — version-locked to the binary rather than fetched, so the prompt cannot drift from the compiler grading it.
 
-**Comparison languages with zero training data are first-class.** Aver (Haskell-inspired, zero training data) is included alongside Python and TypeScript to test whether the zero-training-data thesis holds for languages beyond Vera. Adding further zero-training-data languages (e.g., MoonBit — see issue [#49](https://github.com/aallan/vera-bench/issues/49)) strengthens the comparison.
+**Comparison languages with zero training data are first-class.** Aver (Haskell-inspired) and AILANG are included alongside Python and TypeScript to test whether the zero-training-data thesis holds for languages beyond Vera. Two such languages rather than one matters: a single comparator cannot distinguish "designed-for-LLM languages work" from "this particular language works". Adding further zero-training-data languages (e.g., MoonBit — see issue [#49](https://github.com/aallan/vera-bench/issues/49)) strengthens the comparison.
 
 **Retry with error feedback is a first-class metric.** Vera's error messages are designed to be agent-friendly (natural language, concrete fix suggestions). This is a competitive advantage worth measuring.
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -23,18 +23,25 @@ For language gotchas (Vera and Aver syntax rules), see
 
 [CVE-2026-3219](https://nvd.nist.gov/vuln/detail/CVE-2026-3219) is a
 vulnerability in pip 26.0.1's archive handling. It was fixed in pip 26.1
-(released 2026-04-26). However, `actions/setup-python@v6` bakes pip
-26.0.1 into its Python 3.12 toolchain image, so `pip-audit` running
-inside the runner reports the runner's own pip as vulnerable until
-GitHub refreshes the toolchain image.
+(released 2026-04-26). However, the `actions/setup-python` toolchain
+image baked pip 26.0.1 into its Python 3.12 environment, so `pip-audit`
+running inside the runner reported the runner's own pip as vulnerable
+until GitHub refreshed the image.
 
 The workaround is a `pip install --upgrade pip` step before `pip-audit`
 runs, pulling pip 26.1 from PyPI to replace the bundled 26.0.1.
 
-**Removal trigger:** when `actions/setup-python@v6` ships a runner
-image with pip ≥ 26.1 natively, drop the `pip install --upgrade pip &&`
-prefix from the `Install dependencies and pip-audit` step. Verification
-guidance is in issue #63.
+**Status:** issue #63 is **closed**, but the workaround is still present
+in `ci.yml` and the action has since been bumped to `@v7`. Nobody has
+verified whether the `@v7` image ships pip ≥ 26.1 natively, so the step
+may now be redundant.
+
+**Removal trigger:** confirm what pip version the current
+`actions/setup-python@v7` image ships (add a temporary `pip --version`
+step, or check a recent run log). If it is ≥ 26.1, drop the
+`pip install --upgrade pip &&` prefix from the `Install dependencies and
+pip-audit` step and delete this entry. If it is still older, reopen #63
+so the trigger has a live home again.
 
 ---
 
@@ -91,13 +98,21 @@ because:
   rolled into the same field, so the *count* is comparable but the
   *per-token cost* implicit in that count is not.
 
-For analyses that need the breakdown, see
-[issue #61](https://github.com/aallan/vera-bench/issues/61) — the
-follow-up to expose `cached_tokens` separately is tracked there.
+**Resolved as of v0.0.16:** [#61](https://github.com/aallan/vera-bench/issues/61)
+landed, and `cached_tokens` is now a first-class field on `ProblemResult`
+and in every JSONL row, for Anthropic, OpenAI and Moonshot alike. The
+breakdown is therefore structurally available going forward:
+`input_tokens` is still the total billed input, and `cached_tokens` says
+how much of it was a cache read.
 
-**Removal trigger:** none — this is a permanent provenance note about
-a metric semantic change. Will eventually move to a CHANGELOG note
-once #61 is resolved and the breakdown is exposed structurally.
+The caveat above still applies to **JSONL written between PR #60 and
+v0.0.16** — those rows have the summed `input_tokens` with no way to
+recover the split. Treat that window's per-token cost as unknowable
+rather than inferring it.
+
+**Removal trigger:** none — this is a permanent provenance note about a
+metric semantic change in historical data. It stops being load-bearing
+once no published analysis draws on results from that window.
 
 ---
 
@@ -121,10 +136,45 @@ git clone https://github.com/aallan/vera.git /tmp/vera
 pip install -e /tmp/vera
 ```
 
-Verify with `vera version` — should print `vera 0.0.111` or later, not
+Verify with `vera version` — should print `vera 0.1.6` or later, not
 the Homebrew tool's banner.
+
+`VERA_PATH` overrides the lookup if you need to point at a specific
+binary without reordering `$PATH`:
+
+```bash
+export VERA_PATH="$PWD/.venv/bin/vera"
+```
 
 **Removal trigger:** none — this is a permanent dev-env hazard
 caused by a name collision with an unrelated tool. Will stay until
 either Homebrew's package renames or we ship a wrapper that errors out
 helpfully when invoked from the wrong path.
+
+### AILANG installs into the venv, and has no `$PATH` override
+
+**Affected:** `vera-bench run --language ailang`, `baselines --language
+ailang`, and the `s5` stage of `scripts/preflight.sh`.
+
+The `ailang` binary is a ~90 MB Go build that ends up **inside
+`.venv/bin/`**, despite not being a Python package. Two consequences:
+
+1. `pip install -e ".[dev,llm]"` will **not** restore it, and
+   `rm -rf .venv` **deletes it**. Any venv rebuild silently costs you
+   the AILANG targets until you reinstall from
+   [ailang](https://github.com/sunholo-data/ailang).
+2. Unlike `vera` (which honours `VERA_PATH`) and `aver` (which is
+   normally installed globally by `cargo`), the harness resolves AILANG
+   **by `$PATH` only** — there is no `AILANG_PATH` escape hatch. A shell
+   without `.venv/bin` on `$PATH` reports `ailang not found on PATH`,
+   which reads like "not installed" when it is merely not visible.
+
+So any shell running AILANG targets needs:
+
+```bash
+export PATH="$PWD/.venv/bin:$PATH"
+```
+
+**Removal trigger:** if the harness grows an `AILANG_PATH` override
+(mirroring `VERA_PATH`), point 2 goes away and this entry shrinks to the
+venv-fragility note.

--- a/README.md
+++ b/README.md
@@ -158,6 +158,18 @@ vera-bench report results/
 python scripts/run_full_benchmark.py
 ```
 
+Before committing to a large sweep, run the preflight gate. It checks every
+configured model id, provider auth, the request parameters each model accepts,
+and all four toolchains — one problem per check, so the whole thing is a couple
+of dollars against a sweep that is hours and no resume:
+
+```bash
+bash scripts/preflight.sh
+```
+
+See [`scripts/README.md`](scripts/README.md#preflightsh--pre-sweep-gate) for the
+stage breakdown and how to re-run individual stages while fixing something.
+
 Supported providers: [Anthropic](https://anthropic.com) (Claude), [OpenAI](https://openai.com) (GPT), [Kimi](https://platform.kimi.ai) (Moonshot), and [OpenRouter](https://openrouter.ai/) (used for AILANG-capable models). Set the appropriate API key environment variable (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `MOONSHOT_API_KEY`, or `OPENROUTER_API_KEY`).
 
 The Vera language reference ([SKILL.md](https://veralang.dev/SKILL.md)) is fetched automatically from veralang.dev when running Vera benchmarks. To use a local copy instead (e.g., for testing unreleased language features):
@@ -168,7 +180,11 @@ vera-bench run --model claude-sonnet-4-6 --skill-md /path/to/SKILL.md
 
 ## Report generation
 
-Running `vera-bench report results/` generates `results/summary.md` with a summary table, per-tier breakdowns, and per-problem detail. Each `vera-bench run` writes incremental JSONL results (one line per problem attempt), so partial runs are resumable and always reportable. Results files are in `.gitignore` — they are generated artifacts, not checked in.
+Running `vera-bench report results/` generates `results/summary.md` with a summary table, per-tier breakdowns, and per-problem detail. Each `vera-bench run` writes incremental JSONL results (one line per problem attempt), so a run that stops early is still reportable up to the problem it reached.
+
+> **There is no resume.** `vera-bench run` deletes any existing output file for that model × language × mode before it starts, so re-running an interrupted target repeats it from problem 1 rather than topping it up. Filenames carry no timestamp, so the old results are gone. Budget a full re-run for any target that does not finish.
+
+Results files are in `.gitignore` — they are generated artifacts, not checked in.
 
 ## Prior art
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ Afterwards you should be able to print the Vera version from the terminal,
 vera version   
 ```
 
-this should return v0.0.108 or later.
+this should return v0.1.6 or later. Vera 0.1.x changed several semantics the
+benchmark depends on, so older compilers will fail validation.
 
 ## Quick start
 
@@ -125,25 +126,25 @@ vera-bench validate
 
 # Run benchmark against a model
 export ANTHROPIC_API_KEY=sk-ant-...
-vera-bench run --model claude-sonnet-4-6
+vera-bench run --model claude-sonnet-5
 
 # Run a single tier
-vera-bench run --model claude-sonnet-4-6 --tier 1
+vera-bench run --model claude-sonnet-5 --tier 1
 
 # Run a single problem
-vera-bench run --model claude-sonnet-4-6 --problem VB-T1-001
+vera-bench run --model claude-sonnet-5 --problem VB-T1-001
 
 # Spec-from-NL mode (agent writes its own contracts)
-vera-bench run --model claude-sonnet-4-6 --mode spec-from-nl
+vera-bench run --model claude-sonnet-5 --mode spec-from-nl
 
 # Ask the same model to write Python, TypeScript, Aver, or AILANG for comparison
-vera-bench run --model claude-sonnet-4-6 --language python
-vera-bench run --model claude-sonnet-4-6 --language typescript
-vera-bench run --model claude-sonnet-4-6 --language aver
-vera-bench run --model claude-sonnet-4-6 --language ailang
+vera-bench run --model claude-sonnet-5 --language python
+vera-bench run --model claude-sonnet-5 --language typescript
+vera-bench run --model claude-sonnet-5 --language aver
+vera-bench run --model claude-sonnet-5 --language ailang
 
 # Slow model? Dispatch problems concurrently (default is sequential)
-vera-bench run --model kimi-k2.5 --parallel 10
+vera-bench run --model moonshot/kimi-k2.6 --parallel 10
 
 # Run canonical baselines as a reference
 vera-bench baselines
@@ -154,7 +155,7 @@ vera-bench baselines --language ailang
 # Generate a combined report
 vera-bench report results/
 
-# Or run the full benchmark suite (all 8 targets) with one command
+# Or run the full benchmark suite (all 10 targets) with one command
 python scripts/run_full_benchmark.py
 ```
 
@@ -175,7 +176,7 @@ Supported providers: [Anthropic](https://anthropic.com) (Claude), [OpenAI](https
 The Vera language reference ([SKILL.md](https://veralang.dev/SKILL.md)) is fetched automatically from veralang.dev when running Vera benchmarks. To use a local copy instead (e.g., for testing unreleased language features):
 
 ```bash
-vera-bench run --model claude-sonnet-4-6 --skill-md /path/to/SKILL.md
+vera-bench run --model claude-sonnet-5 --skill-md /path/to/SKILL.md
 ```
 
 ## Report generation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vera-bench"
-version = "0.0.15"
+version = "0.0.16"
 description = "HumanEval/MBPP-style benchmark for the Vera programming language"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,24 @@ dependencies = [
 [project.optional-dependencies]
 llm = [
     "anthropic>=0.40",
-    "openai>=1.50",
+    # Floor verified by inspecting wheels, not inferred:
+    #   1.66.0  responses.create yes, prompt_cache_key NO, reasoning.mode NO
+    #   2.0.0   prompt_cache_key   yes, reasoning.mode NO
+    #   2.44.0  reasoning.mode     NO
+    #   2.45.0  reasoning.mode     yes  <- floor
+    # The openai-pro/ path needs all three: it calls responses.create with
+    # prompt_cache_key and reasoning={"mode": "pro"}.
+    #
+    # 2.0 would in fact work at runtime — maybe_transform forwards keys the
+    # TypedDict does not declare, and the response model is pydantic
+    # extra="allow", so mode survives both directions. We do not rely on
+    # that. Both are undocumented implementation details, and if either
+    # changed the failure would be silent: the "pro" entry would run in
+    # standard mode, the effective-mode guard would no-op, and the
+    # reasoning-budget chart would look entirely normal while comparing a
+    # model against itself. Requiring the version where the field is
+    # actually declared makes that failure impossible instead of unlikely.
+    "openai>=2.45",
 ]
 dev = [
     "pytest>=7.0",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -333,7 +333,7 @@ each model × mode combination:
 | Aver (opt-in) | `{prefix}-aver-bench-{X-Y-Z}-aver-*.jsonl` |
 
 Where `{prefix}` is the model's `file_prefix` from the `MODELS` registry
-(e.g. `claude-opus-4-8`, `moonshot-kimi-k2.5`). Dots in the version are
+(e.g. `claude-opus-4-8`, `moonshot-kimi-k2.6`). Dots in the version are
 converted to dashes to match the filename convention; Anthropic's
 4.6-generation dateless IDs (e.g. `claude-opus-4-8`) already match the
 filename convention without conversion.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,10 +5,62 @@ the installed package, but kept in-repo for reproducibility.
 
 | Script | Purpose |
 |--------|---------|
+| [`preflight.sh`](#preflightsh--pre-sweep-gate) | Pre-sweep gate: model ids, auth, API parameters and every toolchain, one problem each |
 | [`run_full_benchmark.py`](#run_full_benchmarkpy--full-matrix-benchmark-runner) | Runs every target (Vera, spec-from-NL, Python, TypeScript, Aver + baselines) for one model |
 | [`plot_results.py`](#plot_resultspy--benchmark-comparison-chart) | Generates the headline benchmark comparison chart |
 | [`plot_slide.py`](#plot_slidepy--v007-talk-slide-renderer) | Renders v0.0.7 result panels as 16:9 slides for talk presentation (specialised; v0.0.7 lineup pinned) |
 | [`validate_problems.py`](#validate_problemspy--problem-set-validation) | Validates every problem JSON + canonical Vera solution |
+
+---
+
+## `preflight.sh` — pre-sweep gate
+
+Run this **before** committing to a full sweep. A sweep is ~40 target-runs with
+no resume (see [Output files](#output-files)), so a wrong model id, a rejected
+API parameter, or a compiler missing from `PATH` costs hours and real money to
+discover late. Every check here is a single problem — the whole gate is roughly
+$1–2.
+
+```bash
+export ANTHROPIC_API_KEY=... OPENAI_API_KEY=... MOONSHOT_API_KEY=...
+bash scripts/preflight.sh                 # all stages
+bash scripts/preflight.sh s2 s3           # only these stages
+SMOKE_SKIP_MODELS="claude-fable-5" bash scripts/preflight.sh s1
+```
+
+Stage selection and `SMOKE_SKIP_MODELS` exist because the calls cost money: a
+stage that already passed should not be paid for twice while you iterate on a
+fix.
+
+| Stage | Checks | Cost |
+|-------|--------|------|
+| `s0` | Every configured model id exists, via each provider's `/v1/models` | free |
+| `s1` | Auth, id acceptance and request parameters — one problem per model, Python target (no ~28k-token prefix) | cheap |
+| `s2` | The reasoning-budget pair actually differs — same model, same problem, mode the only variable | 2 calls |
+| `s3` | Prompt-cache accounting: `cached_tokens` on a second call sharing the system prefix | 1 call |
+| `s5` | All six target languages end-to-end, proving the Vera / Aver / AILANG toolchains work *through the harness* | 6 calls |
+
+The model list is **not** duplicated in the script — `s0` and `s1` read it from
+`run_full_benchmark.py` (including its `_detect_provider`), so a model added to
+the sweep is gated automatically rather than silently skipped. The `s2` pair and
+the `s5` canary are roles rather than the whole matrix, so they are named at the
+top of the script and overridable via `PREFLIGHT_REASON_BASE`,
+`PREFLIGHT_REASON_PRO` and `PREFLIGHT_CANARY`.
+
+Two behaviours worth knowing:
+
+- **It judges result rows, not exit codes.** `vera-bench run` records an API
+  error as a JSONL row and still exits `0` — deliberate, so a transient failure
+  costs one problem rather than the sweep. A gate reading `$?` therefore reports
+  success for a model that never answered; both fable-tier models passed that
+  way on 2026-07-23 while failing every call.
+- **Each stage writes to its own directory.** Result filenames carry no
+  timestamp and `run` unlinks an existing file, so two stages running the same
+  model × language × mode would otherwise silently overwrite each other.
+
+Output goes to `/tmp/vb-smoke-<date>-<time>/`, never `results/`, so a gate run
+cannot pollute a real sweep. No key is ever printed; the report is safe to
+paste. Targets bash 3.2 (macOS system bash).
 
 ---
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -414,6 +414,13 @@ of a room). Three slide types:
 - `all-modes` — every model × the 4 core modes in a single grouped-bar panel
 - `ztd` — zero-training-data slide: Vera vs Aver vs AILANG on the models
   that ran those generation targets (opt-in; not part of `--type all`)
+- `reasoning` — the reasoning-budget slide: one model at two effort
+  levels (`REASONING_PAIR`, default `GPT-5.6 Sol` vs `GPT-5.6 Sol (pro)`)
+  across every core mode, with the per-language delta annotated. Answers
+  "does more deliberation help, and does it help *less* on Vera?" — the
+  controlled comparison no other provider offers, since both entries are
+  the same underlying model. Opt-in; needs both halves of the pair in
+  the results directory
 
 ### Scope and lifecycle
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -46,11 +46,11 @@ python scripts/run_full_benchmark.py
 
 # Autonomous mode (CI-friendly)
 ANTHROPIC_API_KEY=sk-ant-... \
-  python scripts/run_full_benchmark.py --model claude-sonnet-4-6
+  python scripts/run_full_benchmark.py --model claude-sonnet-5
 
 # Pass the key as a flag (avoid in shell history / CI logs — prefer env var)
 python scripts/run_full_benchmark.py \
-  --model gpt-4.1-2025-04-14 --api-key sk-...
+  --model gpt-5.6-terra --api-key sk-...
 
 # Skip baselines when sweeping multiple models
 python scripts/run_full_benchmark.py \
@@ -65,7 +65,7 @@ right env var:
 | Provider | Model-string prefix | Env var |
 |----------|---------------------|---------|
 | Anthropic | `claude-*` or `anthropic/*` | `ANTHROPIC_API_KEY` |
-| OpenAI | `gpt-*`, `o1-*`, `o3-*`, `openai/*` | `OPENAI_API_KEY` |
+| OpenAI | `gpt-*`, `o1-*`, `o3-*`, `openai/*`, `openai-pro/*` | `OPENAI_API_KEY` |
 | Moonshot | `moonshot/*` | `MOONSHOT_API_KEY` |
 
 Missing env var + no `--api-key` + no TTY → the script exits with an error.
@@ -84,11 +84,13 @@ export MOONSHOT_API_KEY=...
 # Run baselines once (they don't depend on the model)
 # — or pass --skip-baselines on every call if they're already fresh.
 for model in \
+  claude-fable-5 \
   claude-opus-4-8 \
-  claude-sonnet-4-6 \
-  gpt-4.1-2025-04-14 \
-  gpt-4o \
-  moonshot/kimi-k2.5 \
+  claude-sonnet-5 \
+  openai-pro/gpt-5.6-sol \
+  gpt-5.6-sol \
+  gpt-5.6-terra \
+  moonshot/kimi-k3 \
   moonshot/kimi-k2.6; do
   python scripts/run_full_benchmark.py --model "$model" --skip-baselines
 done
@@ -105,20 +107,23 @@ python scripts/plot_results.py
 
 ### Timing expectations
 
-Rough per-model totals observed on v0.0.9 (60 problems, 2026-04):
+Rough per-model totals observed on v0.0.9 (60 problems, 2026-04) with the
+*then-current* lineup — kept as an order-of-magnitude guide; the v0.0.16
+matrix is a different set of models and has not been swept yet:
 
-| Provider / model | Full suite (10 targets) |
+| Provider / model (v0.0.9 era) | Full suite (10 targets) |
 |------------------|-----------------------|
 | Claude Opus 4 | ~17 min |
 | Claude Sonnet 4 | ~15 min |
 | GPT-4.1 / GPT-4o | ~10–12 min |
 | Moonshot K2.5 | ~3.5 h (slow provider; Aver especially) |
-| Moonshot K2.6 | TBD (no sweep against this model yet — see #68) |
-| Moonshot K2 Turbo *(historical; SKU deprecated 2026-05-25)* | ~1.5 h |
 
-The Moonshot models dominate the sweep wall-clock; expect 5–8 hours
-end-to-end. K2.6 timings will be filled in after the first full sweep
-once we have data to attribute.
+Moonshot dominated the wall-clock; expect 5–8 hours end-to-end for a
+full multi-model sweep. Two v0.0.16-specific expectations: reasoning-mode
+entries (`openai-pro/*`) are latency-dominated and can run several times
+longer per problem than their default-mode sibling, and per-provider
+rate limits mean the practical speed-up comes from running providers
+concurrently rather than raising `--parallel` on one.
 
 ### Output files
 
@@ -137,8 +142,11 @@ For model `M` at bench version `V` and compiler versions `VV` (Vera) / `AV` (Ave
 
 Each JSONL line is **one attempt on one problem** — failed `vera check`/`aver
 check` runs produce multiple lines per problem (the model is asked to fix
-and retry). The harness auto-resumes: rerunning the same invocation skips
-problems that already have a passing attempt on file.
+and retry). **There is no resume**: `vera-bench run` unlinks any existing
+output file at startup (`vera_bench/cli.py`), so re-running the same
+invocation re-runs every problem from scratch. A crashed sweep leaves a
+partial JSONL for forensics, but recovering it means re-running that whole
+model x target.
 
 ### Exit codes
 
@@ -156,7 +164,7 @@ at the end if any failed. This makes partial-run recovery straightforward.
 ## `plot_results.py` — benchmark comparison chart
 
 Produces `assets/results-graph.png`: a four-panel chart showing
-`run_correct` rates across six models × four modes (Vera full-spec, Vera
+`run_correct` rates across every model in the registry × four modes (Vera full-spec, Vera
 spec-from-NL, Python, TypeScript). This is the canonical chart shown in
 the top-level README.
 
@@ -316,9 +324,12 @@ MODELS: list[ModelSpec] = [
   the split is "current flagship" vs "previous-gen / cost-tier" by
   convention.
 
-The script expects **exactly three models per tier** for the panels to lay
-out correctly. If you want four-and-four, adjust the subplot sizing in
-`main()`.
+Row 1 renders **one panel per populated tier**, in `TIER_TITLES` order
+(`fable`, `opus`, `sonnet`, plus the legacy `flagship` for historical
+2-tier data). Both the tier count and the models-per-tier count are
+data-driven, so an incomplete row is fine — the v0.0.16 fable tier has two
+entries because Moonshot ships no ceiling-above-flagship model. A tier with
+no models is skipped entirely rather than rendering an empty panel.
 
 ### Adding a new mode
 
@@ -398,8 +409,11 @@ of a room). Three slide types:
 
 - `delta` — the "Does Vera beat Python / TypeScript?" horizontal-bar
   chart (the headline storytelling slide)
-- `tiers` — Flagship and Sonnet tier comparisons side-by-side
-- `all-modes` — all 6 models × 4 modes in a single grouped-bar panel
+- `tiers` — per-tier comparison panels side-by-side (2 for historical
+  2-tier data, 3 for the fable/opus/sonnet matrix)
+- `all-modes` — every model × the 4 core modes in a single grouped-bar panel
+- `ztd` — zero-training-data slide: Vera vs Aver vs AILANG on the models
+  that ran those generation targets (opt-in; not part of `--type all`)
 
 ### Scope and lifecycle
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,7 +8,7 @@ the installed package, but kept in-repo for reproducibility.
 | [`preflight.sh`](#preflightsh--pre-sweep-gate) | Pre-sweep gate: model ids, auth, API parameters and every toolchain, one problem each |
 | [`run_full_benchmark.py`](#run_full_benchmarkpy--full-matrix-benchmark-runner) | Runs every target (Vera, spec-from-NL, Python, TypeScript, Aver, AILANG + baselines) for one model |
 | [`plot_results.py`](#plot_resultspy--benchmark-comparison-chart) | Generates the headline benchmark comparison chart |
-| [`plot_slide.py`](#plot_slidepy--v007-talk-slide-renderer) | Renders v0.0.7 result panels as 16:9 slides for talk presentation (specialised; v0.0.7 lineup pinned) |
+| [`plot_slide.py`](#plot_slidepy--talk-slide-renderer) | Renders result panels as 16:9 slides for talk presentation |
 | [`validate_problems.py`](#validate_problemspy--problem-set-validation) | Validates every problem JSON + canonical Vera solution |
 
 ---
@@ -455,9 +455,9 @@ this script.
 
 ---
 
-## `plot_slide.py` — v0.0.7 talk-slide renderer
+## `plot_slide.py` — talk-slide renderer
 
-Renders the v0.0.7 result panels as **16:9 slides** sized and styled for
+Renders result panels as **16:9 slides** sized and styled for
 talk presentation (2880×1620 px, slide-readable typography from the back
 of a room). Five slide types:
 
@@ -468,8 +468,8 @@ of a room). Five slide types:
 - `all-modes` — every model × the 4 core modes in a single grouped-bar panel
 - `ztd` — zero-training-data slide: Vera vs Aver vs AILANG on the models
   that ran those generation targets (opt-in; not part of `--type all`)
-- `reasoning` — the reasoning-budget slide: one model at two effort
-  levels (`REASONING_PAIR`, default `GPT-5.6 Sol` vs `GPT-5.6 Sol (pro)`)
+- `reasoning` — the reasoning-budget slide: one model at two reasoning
+  modes (`standard` vs `pro`) (`REASONING_PAIR`, default `GPT-5.6 Sol` vs `GPT-5.6 Sol (pro)`)
   across every core mode, with the per-language delta annotated. Answers
   "does more deliberation help, and does it help *less* on Vera?" — the
   controlled comparison no other provider offers, since both entries are
@@ -478,13 +478,20 @@ of a room). Five slide types:
 
 ### Scope and lifecycle
 
-This is a **specialised, talk-specific** script — not a general slide
-renderer. The v0.0.7 model lineup (Claude Opus 4 / GPT-4.1 / Kimi K2.5
-in flagship; Claude Sonnet 4 / GPT-4o / Kimi K2 Turbo in sonnet) is
-hard-coded in `MODELS_V_0_0_7`, because the live `plot_results.MODELS`
-registry has since been updated to reflect the K2.6 migration (PR #69).
-If you want slides for a future release, either generalise the script
-or duplicate it with the new lineup.
+The script renders against whichever lineup matches the `--version` you
+ask for:
+
+- `--version 0.0.7` uses the frozen `MODELS_V_0_0_7` lineup (Claude Opus 4
+  / GPT-4.1 / Kimi K2.5 in flagship; Claude Sonnet 4 / GPT-4o / Kimi K2
+  Turbo in sonnet). Those slides must keep rendering identically, and the
+  live registry has moved on, so the historical lineup is pinned in code
+  rather than reconstructed.
+- **Any other version** uses the live `plot_results.MODELS`, so slides
+  track the current matrix without further edits.
+
+⚠ `--version` still **defaults to `0.0.7`**. A bare
+`python scripts/plot_slide.py` therefore renders the frozen historical
+lineup, not your current results — pass `--version` explicitly.
 
 It reuses palette, typography constants, and `extract_data()` from
 `plot_results.py` so the slide numbers match the README chart by

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,7 +6,7 @@ the installed package, but kept in-repo for reproducibility.
 | Script | Purpose |
 |--------|---------|
 | [`preflight.sh`](#preflightsh--pre-sweep-gate) | Pre-sweep gate: model ids, auth, API parameters and every toolchain, one problem each |
-| [`run_full_benchmark.py`](#run_full_benchmarkpy--full-matrix-benchmark-runner) | Runs every target (Vera, spec-from-NL, Python, TypeScript, Aver + baselines) for one model |
+| [`run_full_benchmark.py`](#run_full_benchmarkpy--full-matrix-benchmark-runner) | Runs every target (Vera, spec-from-NL, Python, TypeScript, Aver, AILANG + baselines) for one model |
 | [`plot_results.py`](#plot_resultspy--benchmark-comparison-chart) | Generates the headline benchmark comparison chart |
 | [`plot_slide.py`](#plot_slidepy--v007-talk-slide-renderer) | Renders v0.0.7 result panels as 16:9 slides for talk presentation (specialised; v0.0.7 lineup pinned) |
 | [`validate_problems.py`](#validate_problemspy--problem-set-validation) | Validates every problem JSON + canonical Vera solution |
@@ -38,7 +38,7 @@ fix.
 | `s1` | Auth, id acceptance and request parameters — one problem per model, Python target (no ~28k-token prefix) | cheap |
 | `s2` | The reasoning-budget pair actually differs — same model, same problem, mode the only variable | 2 calls |
 | `s3` | Prompt-cache accounting: `cached_tokens` on a second call sharing the system prefix | 1 call |
-| `s5` | All six target languages end-to-end, proving the Vera / Aver / AILANG toolchains work *through the harness* | 6 calls |
+| `s5` | All six target variants end-to-end (five languages — Vera runs in both full-spec and spec-from-NL), proving the Vera / Aver / AILANG toolchains work *through the harness* | 6 calls |
 
 The model list is **not** duplicated in the script — `s0` and `s1` read it from
 `run_full_benchmark.py` (including its `_detect_provider`), so a model added to
@@ -362,19 +362,21 @@ Edit the `MODELS` list near the top of `plot_results.py`:
 
 ```python
 MODELS: list[ModelSpec] = [
-    ModelSpec("Claude Opus 4", "claude-opus-4-20250514", "flagship"),
+    ModelSpec("Claude Fable 5", "claude-fable-5", "fable"),
+    ModelSpec("Claude Opus 4.8", "claude-opus-4-8", "opus"),
     ...
-    ModelSpec("My New Model", "my-new-model-id", "flagship"),
+    ModelSpec("My New Model", "my-new-model-id", "sonnet"),
 ]
 ```
 
 - `display` — shown on the chart (keep short, ~12 chars)
 - `file_prefix` — the model-ID portion of the result filename (run
   `vera-bench run --model X ...` and inspect the resulting filename)
-- `tier` — `"flagship"` (top-left panel) or `"sonnet"` (top-right panel).
-  This is purely a layout decision about which panel the model renders in;
-  the split is "current flagship" vs "previous-gen / cost-tier" by
-  convention.
+- `tier` — any key in `TIER_TITLES`: `"fable"` (ceiling), `"opus"`
+  (flagship), `"sonnet"` (workhorse), plus the legacy `"flagship"` used by
+  historical 2-tier data. This is purely a layout decision about which
+  panel the model renders in. A tier not listed in `TIER_TITLES` still
+  renders, in a trailing panel with a title-cased fallback name.
 
 Row 1 renders **one panel per populated tier**, in `TIER_TITLES` order
 (`fable`, `opus`, `sonnet`, plus the legacy `flagship` for historical
@@ -457,7 +459,7 @@ this script.
 
 Renders the v0.0.7 result panels as **16:9 slides** sized and styled for
 talk presentation (2880×1620 px, slide-readable typography from the back
-of a room). Three slide types:
+of a room). Five slide types:
 
 - `delta` — the "Does Vera beat Python / TypeScript?" horizontal-bar
   chart (the headline storytelling slide)

--- a/scripts/plot_results.py
+++ b/scripts/plot_results.py
@@ -56,6 +56,7 @@ COLORS = {
     "Python": ORANGE_400,
     "TypeScript": BROWN_300,
     "Aver": "#6B4FBB",  # indigo — visually distinct from the Vera greens
+    "AILANG": "#C2185B",  # magenta — distinct from Aver's indigo
 }
 
 # Neutral grey shades for the delta-chart legend (not per-language green/red).
@@ -87,28 +88,41 @@ matplotlib.rcParams.update(
 
 @dataclass(frozen=True)
 class ModelSpec:
-    display: str  # Shown on the chart (e.g. "Claude Opus 4")
+    display: str  # Shown on the chart (e.g. "Claude Fable 5")
     file_prefix: str  # Model-id portion of result filename
-    tier: str  # "flagship" or "sonnet" — controls chart layout
+    tier: str  # Key into TIER_TITLES — controls chart layout
 
+
+# Tier display order + panel titles. Any tier present in MODELS but not
+# listed here renders last with a title-cased fallback; a tier listed
+# here but absent from MODELS is skipped (no empty panel).
+TIER_TITLES: dict[str, str] = {
+    "fable": "Fable Tier (ceiling)",
+    "opus": "Opus Tier (flagship)",
+    # Legacy "flagship" sits between opus and sonnet so historical
+    # 2-tier renders (plot_slide's frozen v0.0.7 lineup) keep their
+    # original left-to-right order: Flagship, then Sonnet.
+    "flagship": "Flagship Tier",
+    "sonnet": "Sonnet Tier (workhorse)",
+}
 
 MODELS: list[ModelSpec] = [
-    # Flagship row — current top-tier model from each provider.
-    # Claude Opus 4.8 replaces the deprecated Opus 4 (claude-opus-4-20250514,
-    # retiring 2026-06-15) as Anthropic's flagship slot. Per Anthropic's
-    # 4.6-generation naming convention, the model ID is dateless and is itself
-    # a pinned snapshot, not an evergreen alias.
-    ModelSpec("Claude Opus 4.8", "claude-opus-4-8", "flagship"),
-    ModelSpec("GPT-4.1", "gpt-4.1-2025-04-14", "flagship"),
-    ModelSpec("Kimi K2.6", "moonshot-kimi-k2.6", "flagship"),
-    # Sonnet row — previous-generation / secondary slot from each provider.
-    # Kimi K2.5 moves here from flagship after Moonshot promoted K2.6 to
-    # the active flagship-line slot (kimi-k2-turbo-preview deprecated
-    # 2026-05-25, see #68). Claude Sonnet 4.6 replaces the deprecated
-    # Sonnet 4 (claude-sonnet-4-20250514, also retiring 2026-06-15).
-    ModelSpec("Claude Sonnet 4.6", "claude-sonnet-4-6", "sonnet"),
-    ModelSpec("GPT-4o", "gpt-4o", "sonnet"),
-    ModelSpec("Kimi K2.5", "moonshot-kimi-k2.5", "sonnet"),
+    # v0.0.16 matrix — three tiers mapped onto Anthropic's naming.
+    # The fable row is intentionally incomplete: Moonshot ships no
+    # ceiling-above-flagship model. openai-pro-gpt-5.6-sol is Sol at
+    # reasoning.mode=pro — same model as the opus-tier entry, different
+    # reasoning budget (the controlled comparison: if Vera's contracts
+    # make default ~= pro, the language is doing the work).
+    # ⚠ file_prefix must byte-match what cli.py writes (CLI string,
+    # '/'->'-'): verify against a real results filename before a sweep.
+    ModelSpec("Claude Fable 5", "claude-fable-5", "fable"),
+    ModelSpec("GPT-5.6 Sol (pro)", "openai-pro-gpt-5.6-sol", "fable"),
+    ModelSpec("Claude Opus 4.8", "claude-opus-4-8", "opus"),
+    ModelSpec("GPT-5.6 Sol", "gpt-5.6-sol", "opus"),
+    ModelSpec("Kimi K3", "moonshot-kimi-k3", "opus"),
+    ModelSpec("Claude Sonnet 5", "claude-sonnet-5", "sonnet"),
+    ModelSpec("GPT-5.6 Terra", "gpt-5.6-terra", "sonnet"),
+    ModelSpec("Kimi K2.6", "moonshot-kimi-k2.6", "sonnet"),
 ]
 
 # Mode label -> glob pattern fragment inserted between prefix and bench-VER.
@@ -121,15 +135,21 @@ MODE_PATTERNS: dict[str, str] = {
     "Python": "python-",  # {prefix}-python-bench-{v}.jsonl
     "TypeScript": "typescript-",  # {prefix}-typescript-bench-{v}.jsonl
     "Aver": "aver-",  # {prefix}-aver-bench-{v}-aver-*.jsonl
+    "AILANG": "ailang-",  # {prefix}-ailang-bench-{v}-ailang-*.jsonl
 }
 
-# Modes that have a trailing "-vera-{compiler}" or "-aver-{compiler}" suffix.
-_COMPILER_SUFFIXED = {"Vera": "vera", "Vera NL": "vera", "Aver": "aver"}
+# Modes that have a trailing "-{compiler}-{ver}" suffix in the filename.
+_COMPILER_SUFFIXED = {
+    "Vera": "vera",
+    "Vera NL": "vera",
+    "Aver": "aver",
+    "AILANG": "ailang",
+}
 
 # Default chart: Python + TypeScript as comparison languages. Opt in to Aver
-# (or future languages) via --extra.
+# / AILANG (or future languages) via --extra.
 DEFAULT_COMPARISON_MODES = ["Python", "TypeScript"]
-OPTIONAL_COMPARISON_MODES = {"aver": "Aver"}
+OPTIONAL_COMPARISON_MODES = {"aver": "Aver", "ailang": "AILANG"}
 
 
 def _version_to_filename(version: str) -> str:
@@ -164,17 +184,20 @@ def _load_jsonl(path: Path) -> list[dict]:
 
 def extract_data(
     results_dir: Path, version: str, modes: list[str]
-) -> tuple[dict, dict, list[str], list[Path]]:
+) -> tuple[dict[str, dict], list[str], list[Path]]:
     """Extract run_correct percentages for every MODEL × MODE.
 
     Args:
         results_dir: Directory containing JSONL result files.
-        version: Bench version (e.g. "0.0.9").
+        version: Bench version (e.g. "0.0.16").
         modes: Mode labels to extract, in display order. Must be keys in
             MODE_PATTERNS.
 
-    Returns (flagship, sonnet, warnings, used_paths).
-    flagship/sonnet: dict[display_name] -> dict[mode_label] -> int percentage
+    Returns (tiers, warnings, used_paths).
+    tiers: dict[tier_key] -> dict[display_name] -> dict[mode_label] -> int
+        percentage. Tier keys appear in TIER_TITLES order (unknown tiers
+        last, in MODELS order); only tiers with at least one model are
+        present — an unpopulated tier gets no empty panel.
     warnings: human-readable list of missing files.
     used_paths: the actual JSONL files consulted (one per successful lookup).
         Downstream code should derive subtitle metadata (compiler version,
@@ -182,8 +205,7 @@ def extract_data(
         can pick up stale files that _find_result_file's mtime tie-breaker
         would have rejected.
     """
-    flagship: dict[str, dict[str, int]] = {}
-    sonnet: dict[str, dict[str, int]] = {}
+    tiers: dict[str, dict[str, dict[str, int]]] = {}
     warnings: list[str] = []
     used_paths: list[Path] = []
 
@@ -202,9 +224,13 @@ def extract_data(
             rate = metrics.run_correct_rate or 0.0
             row[mode] = round(rate * 100)
 
-        (flagship if model.tier == "flagship" else sonnet)[model.display] = row
+        tiers.setdefault(model.tier, {})[model.display] = row
 
-    return flagship, sonnet, warnings, used_paths
+    # Order tiers: TIER_TITLES order first, then any unknown tiers in
+    # first-seen order.
+    ordered = {k: tiers[k] for k in TIER_TITLES if k in tiers}
+    ordered.update({k: v for k, v in tiers.items() if k not in ordered})
+    return ordered, warnings, used_paths
 
 
 def _style_ax(ax):
@@ -264,13 +290,13 @@ def plot_tier(ax, data: dict, title: str, comparison_modes: list[str]):
     ax.legend(loc="lower left", fontsize=9, framealpha=0.8, edgecolor=BROWN_300)
 
 
-def plot_vera_vs_comparison(
-    ax, flagship: dict, sonnet: dict, comparison_modes: list[str]
-):
+def plot_vera_vs_comparison(ax, tiers: dict[str, dict], comparison_modes: list[str]):
     """Horizontal bars: Vera run_correct minus each comparison language, per model."""
     from matplotlib.patches import Patch  # noqa: E402
 
-    all_data = {**flagship, **sonnet}
+    all_data: dict = {}
+    for tier_data in tiers.values():
+        all_data.update(tier_data)
     models = list(all_data.keys())
 
     # Per-comparison delta arrays and bar objects (one row per mode).
@@ -368,9 +394,11 @@ def plot_vera_vs_comparison(
 plot_vera_vs_both = plot_vera_vs_comparison
 
 
-def plot_all_modes(ax, flagship: dict, sonnet: dict, modes: list[str]):
+def plot_all_modes(ax, tiers: dict[str, dict], modes: list[str]):
     """Grouped comparison: all modes (Vera + Vera NL + comparisons) per model."""
-    all_data = {**flagship, **sonnet}
+    all_data: dict = {}
+    for tier_data in tiers.values():
+        all_data.update(tier_data)
     models = list(all_data.keys())
     x = np.arange(len(models))
     width = 0.8 / len(modes)
@@ -519,9 +547,7 @@ def main():
             suffixes.append("_with-" + "-".join(args.extra))
         out = f"assets/results-graph{''.join(suffixes)}.png"
 
-    flagship, sonnet, warnings, used_paths = extract_data(
-        results_dir, version, all_modes
-    )
+    tiers, warnings, used_paths = extract_data(results_dir, version, all_modes)
     if warnings:
         print("Warnings:")
         for w in warnings:
@@ -544,9 +570,12 @@ def main():
         color=BROWN_900,
     )
 
+    # Row 1 holds one panel per populated tier (2 for legacy data,
+    # 3 for the v0.0.16 matrix); rows 2-4 span the full width.
+    n_tiers = max(len(tiers), 1)
     gs = fig.add_gridspec(
         4,
-        2,
+        n_tiers,
         hspace=0.35,
         wspace=0.3,
         height_ratios=[1, 1, 1, 0.3],
@@ -556,20 +585,21 @@ def main():
         bottom=0.04,
     )
 
-    # Row 1: tier comparisons
-    ax1 = fig.add_subplot(gs[0, 0])
-    plot_tier(ax1, flagship, "Flagship Tier \u2014 run_correct", comparison_modes)
-
-    ax2 = fig.add_subplot(gs[0, 1])
-    plot_tier(ax2, sonnet, "Sonnet Tier \u2014 run_correct", comparison_modes)
+    # Row 1: one tier panel per populated tier, in TIER_TITLES order.
+    for col, (tier_key, tier_data) in enumerate(tiers.items()):
+        ax_t = fig.add_subplot(gs[0, col])
+        title = TIER_TITLES.get(tier_key, tier_key.title())
+        plot_tier(
+            ax_t, tier_data, f"{title} \u2014 run_correct", comparison_modes
+        )
 
     # Row 2: delta chart
     ax3 = fig.add_subplot(gs[1, :])
-    plot_vera_vs_comparison(ax3, flagship, sonnet, comparison_modes)
+    plot_vera_vs_comparison(ax3, tiers, comparison_modes)
 
     # Row 3: all modes
     ax4 = fig.add_subplot(gs[2, :])
-    plot_all_modes(ax4, flagship, sonnet, all_modes)
+    plot_all_modes(ax4, tiers, all_modes)
 
     # Row 4: footer — explanation (left 3/4) + branding (right 1/4)
     # Footer spans full width

--- a/scripts/plot_results.py
+++ b/scripts/plot_results.py
@@ -184,7 +184,7 @@ def _load_jsonl(path: Path) -> list[dict]:
 
 def extract_data(
     results_dir: Path, version: str, modes: list[str]
-) -> tuple[dict[str, dict], list[str], list[Path]]:
+) -> tuple[dict[str, dict], list[str], list[Path], set[tuple[str, str]]]:
     """Extract run_correct percentages for every MODEL × MODE.
 
     Args:
@@ -193,7 +193,7 @@ def extract_data(
         modes: Mode labels to extract, in display order. Must be keys in
             MODE_PATTERNS.
 
-    Returns (tiers, warnings, used_paths).
+    Returns (tiers, warnings, used_paths, missing).
     tiers: dict[tier_key] -> dict[display_name] -> dict[mode_label] -> int
         percentage. Tier keys appear in TIER_TITLES order (unknown tiers
         last, in MODELS order); only tiers with at least one model are
@@ -204,10 +204,22 @@ def extract_data(
         problem count) from this list rather than re-globbing — re-globbing
         can pick up stale files that _find_result_file's mtime tie-breaker
         would have rejected.
+    missing: {(display_name, mode_label)} for which no result file existed.
+
+        A missing cell is still written into `tiers` as 0, because the
+        comprehensive doc chart deliberately renders it as a visible 0%
+        gap you can go and fill. But 0-because-absent and 0-because-the
+        -model-scored-nothing are then indistinguishable in `tiers`
+        alone, and for the specialised slides that difference is the
+        whole point: plotting an un-run language at 0% on the
+        zero-training-data slide would read as a catastrophic result for
+        that language rather than as no data. Renderers that must not
+        fabricate a bar consult this set.
     """
     tiers: dict[str, dict[str, dict[str, int]]] = {}
     warnings: list[str] = []
     used_paths: list[Path] = []
+    missing: set[tuple[str, str]] = set()
 
     for model in MODELS:
         row: dict[str, int] = {}
@@ -218,6 +230,7 @@ def extract_data(
                     f"  {model.display} / {mode}: no file matching bench-{version}"
                 )
                 row[mode] = 0
+                missing.add((model.display, mode))
                 continue
             used_paths.append(path)
             metrics = compute_metrics(_load_jsonl(path))
@@ -230,7 +243,7 @@ def extract_data(
     # first-seen order.
     ordered = {k: tiers[k] for k in TIER_TITLES if k in tiers}
     ordered.update({k: v for k, v in tiers.items() if k not in ordered})
-    return ordered, warnings, used_paths
+    return ordered, warnings, used_paths, missing
 
 
 def _style_ax(ax):
@@ -547,7 +560,9 @@ def main():
             suffixes.append("_with-" + "-".join(args.extra))
         out = f"assets/results-graph{''.join(suffixes)}.png"
 
-    tiers, warnings, used_paths = extract_data(results_dir, version, all_modes)
+    tiers, warnings, used_paths, _missing = extract_data(
+        results_dir, version, all_modes
+    )
     if warnings:
         print("Warnings:")
         for w in warnings:

--- a/scripts/plot_results.py
+++ b/scripts/plot_results.py
@@ -246,6 +246,26 @@ def extract_data(
     return ordered, warnings, used_paths, missing
 
 
+def complete_models(
+    all_data: dict, missing: set[tuple[str, str]] | None, modes: list[str]
+) -> list[str]:
+    """Models with a real result file for every mode in `modes`.
+
+    `extract_data` writes 0 for an absent file, so `mode in row` cannot
+    answer this — every key is always present.
+
+    A *bar* of 0 is the documented doc-chart behaviour: a visible gap you
+    go and fill. A *delta* against an absent file is a different animal.
+    It fabricates a number that carries a sign and a colour, and on the
+    "Does Vera beat Python?" panel an un-run Python target renders as
+    Vera winning by 100 — the strongest possible version of the claim
+    the chart exists to make, produced entirely by missing data. Any
+    renderer computing a difference must filter through this.
+    """
+    absent = missing or set()
+    return [m for m in all_data if all((m, mode) not in absent for mode in modes)]
+
+
 def _style_ax(ax):
     """Apply site styling to an axes."""
     ax.spines["top"].set_visible(False)
@@ -303,14 +323,21 @@ def plot_tier(ax, data: dict, title: str, comparison_modes: list[str]):
     ax.legend(loc="lower left", fontsize=9, framealpha=0.8, edgecolor=BROWN_300)
 
 
-def plot_vera_vs_comparison(ax, tiers: dict[str, dict], comparison_modes: list[str]):
+def plot_vera_vs_comparison(
+    ax,
+    tiers: dict[str, dict],
+    comparison_modes: list[str],
+    missing: set[tuple[str, str]] | None = None,
+):
     """Horizontal bars: Vera run_correct minus each comparison language, per model."""
     from matplotlib.patches import Patch  # noqa: E402
 
     all_data: dict = {}
     for tier_data in tiers.values():
         all_data.update(tier_data)
-    models = list(all_data.keys())
+    # A model missing any of Vera / the comparison languages would yield a
+    # fabricated delta rather than a visible gap — see complete_models.
+    models = complete_models(all_data, missing, ["Vera", *comparison_modes])
 
     # Per-comparison delta arrays and bar objects (one row per mode).
     deltas = {
@@ -560,9 +587,7 @@ def main():
             suffixes.append("_with-" + "-".join(args.extra))
         out = f"assets/results-graph{''.join(suffixes)}.png"
 
-    tiers, warnings, used_paths, _missing = extract_data(
-        results_dir, version, all_modes
-    )
+    tiers, warnings, used_paths, missing = extract_data(results_dir, version, all_modes)
     if warnings:
         print("Warnings:")
         for w in warnings:
@@ -608,7 +633,7 @@ def main():
 
     # Row 2: delta chart
     ax3 = fig.add_subplot(gs[1, :])
-    plot_vera_vs_comparison(ax3, tiers, comparison_modes)
+    plot_vera_vs_comparison(ax3, tiers, comparison_modes, missing=missing)
 
     # Row 3: all modes
     ax4 = fig.add_subplot(gs[2, :])

--- a/scripts/plot_results.py
+++ b/scripts/plot_results.py
@@ -589,9 +589,7 @@ def main():
     for col, (tier_key, tier_data) in enumerate(tiers.items()):
         ax_t = fig.add_subplot(gs[0, col])
         title = TIER_TITLES.get(tier_key, tier_key.title())
-        plot_tier(
-            ax_t, tier_data, f"{title} \u2014 run_correct", comparison_modes
-        )
+        plot_tier(ax_t, tier_data, f"{title} \u2014 run_correct", comparison_modes)
 
     # Row 2: delta chart
     ax3 = fig.add_subplot(gs[1, :])

--- a/scripts/plot_results.py
+++ b/scripts/plot_results.py
@@ -234,8 +234,22 @@ def extract_data(
                 continue
             used_paths.append(path)
             metrics = compute_metrics(_load_jsonl(path))
-            rate = metrics.run_correct_rate or 0.0
-            row[mode] = round(rate * 100)
+            if metrics.run_correct_rate is None:
+                # The file exists but nothing in it was gradeable — every
+                # attempt errored or failed to compile, so `run_eligible`
+                # is 0. `or 0.0` would turn "no measurement" into a
+                # plotted 0%, which is the same conflation this `missing`
+                # set exists to prevent, one layer down: absent *data*
+                # rather than an absent *file*.
+                warnings.append(
+                    f"  {model.display} / {mode}: file exists but 0 of "
+                    f"{metrics.total_problems} problems were gradeable "
+                    f"({metrics.errored} errored) — {path.name}"
+                )
+                row[mode] = 0
+                missing.add((model.display, mode))
+                continue
+            row[mode] = round(metrics.run_correct_rate * 100)
 
         tiers.setdefault(model.tier, {})[model.display] = row
 

--- a/scripts/plot_slide.py
+++ b/scripts/plot_slide.py
@@ -511,6 +511,12 @@ def render_ztd(
         models = [
             m for m, row in all_data.items() if all(md in row for md in ZTD_MODES)
         ]
+    if not models:
+        # Both paths empty. Without this the renderer writes a blank but
+        # otherwise well-formed 16:9 PNG — which is worse than an error,
+        # because you find out it is empty when it is already on screen.
+        print(f"  ztd slide: no model has all of {ZTD_MODES} — skipping")
+        return
 
     fig, ax = plt.subplots(figsize=(16, 9), dpi=180)
     x = np.arange(len(models))

--- a/scripts/plot_slide.py
+++ b/scripts/plot_slide.py
@@ -79,6 +79,7 @@ from scripts.plot_results import (  # noqa: E402
     GREEN,
     RED,
     ModelSpec,
+    complete_models,
     extract_data,
 )
 
@@ -208,8 +209,15 @@ def render_delta(
 ) -> None:
     """The 'Does Vera beat …?' horizontal-bar chart at 16:9."""
     all_data = _merge_tiers(tiers)
-    models = list(all_data.keys())
     comparison_modes = ["Python", "TypeScript"]
+    # Every bar here is a difference, so a missing file cannot be allowed
+    # through: Vera 100 minus an absent Python renders as +100 in Vera's
+    # favour — the strongest form of this slide's own claim, manufactured
+    # entirely from data that does not exist.
+    models = complete_models(all_data, missing, ["Vera", *comparison_modes])
+    if not models:
+        print("  delta slide: no model ran Vera + all comparisons — skipping")
+        return
 
     deltas = {
         mode: [all_data[m]["Vera"] - all_data[m][mode] for m in models]
@@ -311,9 +319,27 @@ def render_delta(
 
 
 def _draw_tier_panel(
-    ax: Axes, data: dict, title: str, comparison_modes: list[str]
+    ax: Axes,
+    data: dict,
+    title: str,
+    comparison_modes: list[str],
+    n_panels: int = 2,
 ) -> None:
-    """Grouped vertical bars: Vera vs each comparison language, per model."""
+    """Grouped vertical bars: Vera vs each comparison language, per model.
+
+    Typography scales with `n_panels`. The constants were chosen for two
+    half-width panels; at three the panels are a third of the figure and
+    nothing rescaled, so the rightmost title ran off the canvas and the
+    model labels collided in every panel. Measured, not guessed: the
+    "Sonnet Tier (workhorse)" title spanned to x=2964 on a 2880px figure.
+    """
+    # 2 panels -> 1.0 (unchanged, so the v0.0.7 slides are byte-stable);
+    # 3 panels -> 2/3.
+    scale = min(1.0, 2 / n_panels)
+    title_pt = round((TITLE_PT - 4) * scale)
+    tick_pt = round(TICK_PT_MEDIUM * scale)
+    bar_pt = round(BAR_LABEL_PT_MEDIUM * scale)
+    legend_pt = round(LEGEND_PT * scale)
     models = list(data.keys())
     languages = ["Vera", *comparison_modes]
     x = np.arange(len(models))
@@ -337,29 +363,31 @@ def _draw_tier_panel(
                 f"{val}%",
                 ha="center",
                 va="bottom",
-                fontsize=BAR_LABEL_PT_MEDIUM,
+                fontsize=bar_pt,
                 fontweight="bold",
                 color=BROWN_700,
             )
 
-    ax.set_ylabel("run_correct (%)", fontsize=AXIS_LABEL_PT, color=BROWN_500)
+    ax.set_ylabel(
+        "run_correct (%)", fontsize=round(AXIS_LABEL_PT * scale), color=BROWN_500
+    )
     ax.set_title(
         title,
-        fontsize=TITLE_PT - 4,
+        fontsize=title_pt,
         fontweight="bold",
         pad=16,
         fontfamily=FONT_HEADING,
         color=BROWN_900,
     )
     ax.set_xticks(x + width * (len(languages) - 1) / 2)
-    ax.set_xticklabels(models, fontsize=TICK_PT_MEDIUM)
+    ax.set_xticklabels(models, fontsize=tick_pt)
     ax.set_ylim(0, 118)
     ax.set_yticks([0, 25, 50, 75, 100])
-    ax.tick_params(axis="y", labelsize=TICK_PT_MEDIUM)
+    ax.tick_params(axis="y", labelsize=tick_pt)
     ax.axhline(y=100, color=BROWN_300, linestyle="--", linewidth=0.8, alpha=0.4)
     _style_ax(ax)
     ax.legend(
-        loc="lower right", fontsize=LEGEND_PT, framealpha=0.85, edgecolor=BROWN_300
+        loc="lower right", fontsize=legend_pt, framealpha=0.85, edgecolor=BROWN_300
     )
 
 
@@ -379,7 +407,7 @@ def render_tiers(
     comparison_modes = ["Python", "TypeScript"]
     for ax, (tier_key, tier_data) in zip(axes, tiers.items()):
         title = TIER_TITLES.get(tier_key, tier_key.title())
-        _draw_tier_panel(ax, tier_data, title, comparison_modes)
+        _draw_tier_panel(ax, tier_data, title, comparison_modes, n_panels=n)
 
     fig.suptitle(
         "run_correct by model (Vera vs Python vs TypeScript)",
@@ -597,7 +625,7 @@ def render_ztd(
 
 
 # ----------------------------------------------------------------------
-# Reasoning-budget slide — same model, two effort levels
+# Reasoning-budget slide — same model, two reasoning modes
 # ----------------------------------------------------------------------
 
 # Display names of a (default, pro) pair from plot_results.MODELS. Both
@@ -616,7 +644,7 @@ def render_reasoning(
     """Does a bigger reasoning budget help — and does it help less on Vera?
 
     The controlled comparison no other provider offers: one model, two
-    effort levels, every language. If Vera's delta is ~0 while the
+    reasoning modes, every language. If Vera's delta is ~0 while the
     comparison languages gain from extra deliberation, the language is
     supplying the structure the reasoning budget otherwise has to
     reconstruct.
@@ -653,7 +681,7 @@ def render_reasoning(
     width = 0.36
 
     for offset, row, label, alpha, hatch in (
-        (-width / 2, base, "default effort", 0.95, None),
+        (-width / 2, base, "reasoning: standard", 0.95, None),
         (width / 2, pro, "reasoning: pro", 0.75, "//"),
     ):
         values = [row[m] for m in modes]
@@ -724,11 +752,14 @@ def render_reasoning(
     _style_ax(ax)
 
     # Neutral legend: colour already encodes language, so the legend
-    # only needs to distinguish the two effort levels.
+    # only needs to distinguish the two reasoning modes.
     ax.legend(
         handles=[
             Patch(
-                facecolor="#888888", edgecolor=CREAM, alpha=0.95, label="default effort"
+                facecolor="#888888",
+                edgecolor=CREAM,
+                alpha=0.95,
+                label="reasoning: standard",
             ),
             Patch(
                 facecolor="#888888",

--- a/scripts/plot_slide.py
+++ b/scripts/plot_slide.py
@@ -138,8 +138,8 @@ def _patch_models_for_slide() -> tuple[ModuleType, list[ModelSpec]]:
 
 def _load_data(
     version: str, results_dir: Path, modes: list[str]
-) -> dict[str, dict[str, dict[str, int]]]:
-    """Load slide data as extract_data's tier dict.
+) -> tuple[dict[str, dict[str, dict[str, int]]], set[tuple[str, str]]]:
+    """Load slide data as extract_data's tier dict, plus the missing set.
 
     For version 0.0.7 the historical MODELS_V_0_0_7 lineup is patched
     in (the frozen talk lineup — labels would silently mis-map against
@@ -149,18 +149,18 @@ def _load_data(
     if version == "0.0.7":
         pr, original = _patch_models_for_slide()
         try:
-            tiers, warnings, _used = extract_data(results_dir, version, modes)
+            tiers, warnings, _used, missing = extract_data(results_dir, version, modes)
         finally:
             pr.MODELS = original
     else:
-        tiers, warnings, _used = extract_data(results_dir, version, modes)
+        tiers, warnings, _used, missing = extract_data(results_dir, version, modes)
 
     if warnings:
         print("Warnings:")
         for w in warnings:
             print(w)
 
-    return tiers
+    return tiers, missing
 
 
 def _merge_tiers(tiers: dict[str, dict]) -> dict:
@@ -201,7 +201,10 @@ def _style_ax(ax: Axes) -> None:
 
 
 def render_delta(
-    tiers: dict[str, dict], output: Path, background: str = DEFAULT_BACKGROUND
+    tiers: dict[str, dict],
+    output: Path,
+    background: str = DEFAULT_BACKGROUND,
+    missing: set[tuple[str, str]] | None = None,
 ) -> None:
     """The 'Does Vera beat …?' horizontal-bar chart at 16:9."""
     all_data = _merge_tiers(tiers)
@@ -361,7 +364,10 @@ def _draw_tier_panel(
 
 
 def render_tiers(
-    tiers: dict[str, dict], output: Path, background: str = DEFAULT_BACKGROUND
+    tiers: dict[str, dict],
+    output: Path,
+    background: str = DEFAULT_BACKGROUND,
+    missing: set[tuple[str, str]] | None = None,
 ) -> None:
     """Per-tier comparison panels side-by-side at 16:9 (2 or 3 tiers)."""
     from scripts.plot_results import TIER_TITLES
@@ -394,7 +400,10 @@ def render_tiers(
 
 
 def render_all_modes(
-    tiers: dict[str, dict], output: Path, background: str = DEFAULT_BACKGROUND
+    tiers: dict[str, dict],
+    output: Path,
+    background: str = DEFAULT_BACKGROUND,
+    missing: set[tuple[str, str]] | None = None,
 ) -> None:
     """Single panel showing Vera, Vera NL, Python, TypeScript for every model."""
     all_data = _merge_tiers(tiers)
@@ -495,7 +504,10 @@ ZTD_MODES = ["Vera", "Aver", "AILANG"]
 
 
 def render_ztd(
-    tiers: dict[str, dict], output: Path, background: str = DEFAULT_BACKGROUND
+    tiers: dict[str, dict],
+    output: Path,
+    background: str = DEFAULT_BACKGROUND,
+    missing: set[tuple[str, str]] | None = None,
 ) -> None:
     """Zero-training-data languages: Vera vs Aver vs AILANG at 16:9.
 
@@ -504,13 +516,25 @@ def render_ztd(
     percentage point comes from in-context instruction alone.
     """
     all_data = _merge_tiers(tiers)
-    models = [m for m in ZTD_MODELS if m in all_data]
+    absent = missing or set()
+
+    def ran_all_ztd(model: str) -> bool:
+        """Did this model actually produce every ZTD result file?
+
+        `extract_data` writes 0 for a missing file, so `mode in row` is
+        always true and cannot answer this — an un-run language would
+        otherwise be plotted at 0%, which on this slide reads as "the
+        language failed catastrophically" rather than "no data". This is
+        the ZTD thesis slide; a fabricated zero is the worst possible
+        error on it.
+        """
+        return all((model, mode) not in absent for mode in ZTD_MODES)
+
+    models = [m for m in ZTD_MODELS if m in all_data and ran_all_ztd(m)]
     if not models:
-        # Fall back to every model that has all three ZTD modes — keeps
-        # the renderer usable if the subset lineup changes.
-        models = [
-            m for m, row in all_data.items() if all(md in row for md in ZTD_MODES)
-        ]
+        # Fall back to every model that ran all three — keeps the
+        # renderer usable if the subset lineup changes.
+        models = [m for m in all_data if ran_all_ztd(m)]
     if not models:
         # Both paths empty. Without this the renderer writes a blank but
         # otherwise well-formed 16:9 PNG — which is worse than an error,
@@ -584,7 +608,10 @@ REASONING_MODES = ["Vera", "Vera NL", "Python", "TypeScript"]
 
 
 def render_reasoning(
-    tiers: dict[str, dict], output: Path, background: str = DEFAULT_BACKGROUND
+    tiers: dict[str, dict],
+    output: Path,
+    background: str = DEFAULT_BACKGROUND,
+    missing: set[tuple[str, str]] | None = None,
 ) -> None:
     """Does a bigger reasoning budget help — and does it help less on Vera?
 
@@ -595,14 +622,30 @@ def render_reasoning(
     reconstruct.
     """
     all_data = _merge_tiers(tiers)
+    absent = missing or set()
     base_name, pro_name = REASONING_PAIR
-    missing = [n for n in REASONING_PAIR if n not in all_data]
-    if missing:
-        print(f"  reasoning slide: no data for {missing} — skipping")
+    unknown = [n for n in REASONING_PAIR if n not in all_data]
+    if unknown:
+        print(f"  reasoning slide: no data for {unknown} — skipping")
         return
 
     base, pro = all_data[base_name], all_data[pro_name]
-    modes = [m for m in REASONING_MODES if m in base and m in pro]
+    # Both halves must have a real result file for the mode. `m in base`
+    # cannot express that — extract_data writes 0 for a missing file, so
+    # every mode key is always present. Without this, an unrun mode
+    # contributes a fabricated delta of ±the other half's score, which is
+    # exactly the quantity this slide exists to report.
+    modes = [
+        m
+        for m in REASONING_MODES
+        if (base_name, m) not in absent and (pro_name, m) not in absent
+    ]
+    if not modes:
+        print(
+            f"  reasoning slide: no mode has results for both "
+            f"{base_name!r} and {pro_name!r} — skipping"
+        )
+        return
     deltas = [pro[m] - base[m] for m in modes]
 
     fig, ax = plt.subplots(figsize=(16, 9), dpi=180)
@@ -768,13 +811,13 @@ def main() -> None:
     modes = ["Vera", "Vera NL", "Python", "TypeScript"]
     if "ztd" in types:
         modes += ["Aver", "AILANG"]
-    tiers = _load_data(args.version, Path(args.results_dir), modes)
+    tiers, missing = _load_data(args.version, Path(args.results_dir), modes)
 
     for t in types:
         output = (
             Path(args.output) if args.output else Path(f"/tmp/vera-bench_slide_{t}.png")
         )
-        RENDERERS[t](tiers, output, background=args.background)
+        RENDERERS[t](tiers, output, background=args.background, missing=missing)
 
 
 if __name__ == "__main__":

--- a/scripts/plot_slide.py
+++ b/scripts/plot_slide.py
@@ -1,15 +1,20 @@
 #!/usr/bin/env python3
-"""Render v0.0.7 result panels as 16:9 slides for talk presentation.
+"""Render benchmark result panels as 16:9 slides for talk presentation.
 
-Three slide types are supported:
+Four slide types are supported:
 
 - `delta`     — the "Does Vera beat Python / TypeScript?" horizontal-bar chart
                 (the headline storytelling slide; Vera-wins read as green
                 positive bars).
-- `tiers`     — Flagship and Sonnet tier comparisons side-by-side, mirroring
-                the top row of the documentation chart.
-- `all-modes` — all 6 models × 4 modes (Vera, Vera NL, Python, TypeScript)
-                in a single grouped-bar panel.
+- `tiers`     — per-tier comparison panels side-by-side (2 panels for the
+                historical 2-tier data, 3 for the fable/opus/sonnet matrix),
+                mirroring the top row of the documentation chart.
+- `all-modes` — every model × the 4 core modes (Vera, Vera NL, Python,
+                TypeScript) in a single grouped-bar panel.
+- `ztd`       — the zero-training-data slide: Vera vs Aver vs AILANG on the
+                subset of models that ran the ZTD generation targets. Needs
+                Aver/AILANG result files, so it's opt-in (--type ztd), not
+                part of --type all.
 
 Standalone script — not part of the documentation chart-generation flow in
 `plot_results.py`. Slide rendering has different typography and layout
@@ -18,19 +23,21 @@ side-by-side per figure, landscape aspect) that don't belong in the README
 artefact. Reuses palette + data extraction from `plot_results.py` so the
 slide numbers match the README chart by construction.
 
-The historical v0.0.7 model lineup is hard-coded here because the live
-`plot_results.MODELS` registry now reflects the post-K2.6 lineup (PR #69)
-— slide must match what was actually run in v0.0.7.
+Version handling: `--version 0.0.7` renders against the frozen
+MODELS_V_0_0_7 lineup (what was actually run in v0.0.7 — the live
+registry has moved on); any other version renders against the live
+`plot_results.MODELS` matrix.
 
 Usage:
-    # Render all three by default
-    python scripts/plot_slide.py
-        # -> /tmp/vera-bench_slide_{delta,tiers,all-modes}.png
+    # Render the base trio (delta, tiers, all-modes)
+    python scripts/plot_slide.py --version 0.0.16
 
     # One at a time
-    python scripts/plot_slide.py --type delta
-    python scripts/plot_slide.py --type tiers
-    python scripts/plot_slide.py --type all-modes
+    python scripts/plot_slide.py --version 0.0.16 --type delta
+    python scripts/plot_slide.py --version 0.0.16 --type ztd
+
+    # The historical v0.0.7 talk slides still render identically
+    python scripts/plot_slide.py --version 0.0.7
 
     # Custom output path (only with single --type)
     python scripts/plot_slide.py --type delta --output ~/Desktop/slide-3.png
@@ -122,23 +129,39 @@ def _patch_models_for_slide() -> tuple[ModuleType, list[ModelSpec]]:
     return pr, original
 
 
-def _load_v0_0_7_data(
-    version: str, results_dir: Path
-) -> tuple[dict[str, dict[str, int]], dict[str, dict[str, int]]]:
-    """Load the v0.0.7 data once, patched against the historical lineup."""
-    pr, original = _patch_models_for_slide()
-    try:
-        modes = ["Vera", "Vera NL", "Python", "TypeScript"]
-        flagship, sonnet, warnings, _used = extract_data(results_dir, version, modes)
-    finally:
-        pr.MODELS = original
+def _load_data(
+    version: str, results_dir: Path, modes: list[str]
+) -> dict[str, dict[str, dict[str, int]]]:
+    """Load slide data as extract_data's tier dict.
+
+    For version 0.0.7 the historical MODELS_V_0_0_7 lineup is patched
+    in (the frozen talk lineup — labels would silently mis-map against
+    the live registry). Any other version uses plot_results.MODELS
+    as-is, so slides track the current matrix.
+    """
+    if version == "0.0.7":
+        pr, original = _patch_models_for_slide()
+        try:
+            tiers, warnings, _used = extract_data(results_dir, version, modes)
+        finally:
+            pr.MODELS = original
+    else:
+        tiers, warnings, _used = extract_data(results_dir, version, modes)
 
     if warnings:
         print("Warnings:")
         for w in warnings:
             print(w)
 
-    return flagship, sonnet
+    return tiers
+
+
+def _merge_tiers(tiers: dict[str, dict]) -> dict:
+    """Flatten the tier dict into display_name -> mode rows, tier order."""
+    merged: dict = {}
+    for tier_data in tiers.values():
+        merged.update(tier_data)
+    return merged
 
 
 def _slide_rcparams() -> None:
@@ -171,10 +194,10 @@ def _style_ax(ax: Axes) -> None:
 
 
 def render_delta(
-    flagship: dict, sonnet: dict, output: Path, background: str = DEFAULT_BACKGROUND
+    tiers: dict[str, dict], output: Path, background: str = DEFAULT_BACKGROUND
 ) -> None:
     """The 'Does Vera beat …?' horizontal-bar chart at 16:9."""
-    all_data = {**flagship, **sonnet}
+    all_data = _merge_tiers(tiers)
     models = list(all_data.keys())
     comparison_modes = ["Python", "TypeScript"]
 
@@ -331,13 +354,19 @@ def _draw_tier_panel(
 
 
 def render_tiers(
-    flagship: dict, sonnet: dict, output: Path, background: str = DEFAULT_BACKGROUND
+    tiers: dict[str, dict], output: Path, background: str = DEFAULT_BACKGROUND
 ) -> None:
-    """Flagship + Sonnet tier comparisons side-by-side at 16:9."""
-    fig, (ax_left, ax_right) = plt.subplots(1, 2, figsize=(16, 9), dpi=180)
+    """Per-tier comparison panels side-by-side at 16:9 (2 or 3 tiers)."""
+    from scripts.plot_results import TIER_TITLES
+
+    n = max(len(tiers), 1)
+    fig, axes = plt.subplots(1, n, figsize=(16, 9), dpi=180)
+    if n == 1:
+        axes = [axes]
     comparison_modes = ["Python", "TypeScript"]
-    _draw_tier_panel(ax_left, flagship, "Flagship Tier", comparison_modes)
-    _draw_tier_panel(ax_right, sonnet, "Sonnet Tier", comparison_modes)
+    for ax, (tier_key, tier_data) in zip(axes, tiers.items()):
+        title = TIER_TITLES.get(tier_key, tier_key.title())
+        _draw_tier_panel(ax, tier_data, title, comparison_modes)
 
     fig.suptitle(
         "run_correct by model (Vera vs Python vs TypeScript)",
@@ -358,10 +387,10 @@ def render_tiers(
 
 
 def render_all_modes(
-    flagship: dict, sonnet: dict, output: Path, background: str = DEFAULT_BACKGROUND
+    tiers: dict[str, dict], output: Path, background: str = DEFAULT_BACKGROUND
 ) -> None:
     """Single panel showing Vera, Vera NL, Python, TypeScript for every model."""
-    all_data = {**flagship, **sonnet}
+    all_data = _merge_tiers(tiers)
     models = list(all_data.keys())
     modes = ["Vera", "Vera NL", "Python", "TypeScript"]
 
@@ -442,10 +471,99 @@ def _save(fig, output: Path, background: str = DEFAULT_BACKGROUND) -> None:
     plt.close(fig)
 
 
+# ----------------------------------------------------------------------
+# Zero-training-data slide — Vera vs Aver vs AILANG
+# ----------------------------------------------------------------------
+
+# The Aver/AILANG generation targets run on a subset of the matrix
+# (sweep-scope decision: the opus-tier trio + the Anthropic ceiling).
+# Models listed here render on the ZTD slide when present in the data.
+ZTD_MODELS = [
+    "Claude Fable 5",
+    "Claude Opus 4.8",
+    "GPT-5.6 Sol",
+    "Kimi K3",
+]
+ZTD_MODES = ["Vera", "Aver", "AILANG"]
+
+
+def render_ztd(
+    tiers: dict[str, dict], output: Path, background: str = DEFAULT_BACKGROUND
+) -> None:
+    """Zero-training-data languages: Vera vs Aver vs AILANG at 16:9.
+
+    The strongest single slide for the language-design thesis: none of
+    the three languages appear in any model's training data — every
+    percentage point comes from in-context instruction alone.
+    """
+    all_data = _merge_tiers(tiers)
+    models = [m for m in ZTD_MODELS if m in all_data]
+    if not models:
+        # Fall back to every model that has all three ZTD modes — keeps
+        # the renderer usable if the subset lineup changes.
+        models = [
+            m for m, row in all_data.items() if all(md in row for md in ZTD_MODES)
+        ]
+
+    fig, ax = plt.subplots(figsize=(16, 9), dpi=180)
+    x = np.arange(len(models))
+    width = 0.8 / len(ZTD_MODES)
+
+    for i, mode in enumerate(ZTD_MODES):
+        values = [all_data[m].get(mode, 0) for m in models]
+        bars = ax.bar(
+            x + i * width,
+            values,
+            width,
+            label=mode,
+            color=COLORS[mode],
+            edgecolor=CREAM,
+            linewidth=0.8,
+        )
+        for bar, val in zip(bars, values):
+            ax.text(
+                bar.get_x() + bar.get_width() / 2,
+                bar.get_height() + 1.5,
+                f"{val}",
+                ha="center",
+                va="bottom",
+                fontsize=BAR_LABEL_PT_MEDIUM,
+                fontweight="bold",
+                color=BROWN_700,
+            )
+
+    ax.set_ylabel("run_correct (%)", fontsize=AXIS_LABEL_PT, color=BROWN_500)
+    ax.set_title(
+        "Zero-training-data languages — in-context instruction only",
+        fontsize=TITLE_PT,
+        fontweight="bold",
+        pad=20,
+        fontfamily=FONT_HEADING,
+        color=BROWN_900,
+    )
+    ax.set_xticks(x + width * (len(ZTD_MODES) - 1) / 2)
+    ax.set_xticklabels(models, fontsize=TICK_PT_MEDIUM)
+    ax.set_ylim(0, 118)
+    ax.set_yticks([0, 25, 50, 75, 100])
+    ax.tick_params(axis="y", labelsize=TICK_PT_SMALL)
+    ax.axhline(y=100, color=BROWN_300, linestyle="--", linewidth=0.8, alpha=0.4)
+    _style_ax(ax)
+    ax.legend(
+        loc="lower left",
+        fontsize=LEGEND_PT,
+        framealpha=0.85,
+        edgecolor=BROWN_300,
+    )
+
+    fig.tight_layout(rect=(0.02, 0.02, 0.98, 0.95))
+    _save(fig, output, background)
+
+
 RENDERERS = {
     "delta": render_delta,
     "tiers": render_tiers,
     "all-modes": render_all_modes,
+    "ztd": render_ztd,
 }
 
 
@@ -459,13 +577,11 @@ def main() -> None:
     )
     parser.add_argument(
         "--version",
-        choices=["0.0.7"],
         default="0.0.7",
         help=(
-            "Bench version to plot. Only '0.0.7' is supported — the model "
-            "lineup is hard-coded to MODELS_V_0_0_7 and other versions "
-            "would silently mis-map labels to data. Future versions would "
-            "need their own lineup and dispatch."
+            "Bench version to plot. '0.0.7' renders against the frozen "
+            "MODELS_V_0_0_7 talk lineup; any other version renders "
+            "against the live plot_results.MODELS matrix."
         ),
     )
     parser.add_argument(
@@ -496,14 +612,22 @@ def main() -> None:
         parser.error("--output is only valid when --type is a single slide type")
 
     _slide_rcparams()
-    flagship, sonnet = _load_v0_0_7_data(args.version, Path(args.results_dir))
-
     types = list(RENDERERS) if args.type == "all" else [args.type]
+    # "all" renders the base trio only — the ZTD slide needs Aver/AILANG
+    # result files that historical versions don't have; request it
+    # explicitly with --type ztd.
+    if args.type == "all":
+        types = [t for t in types if t != "ztd"]
+    modes = ["Vera", "Vera NL", "Python", "TypeScript"]
+    if "ztd" in types:
+        modes += ["Aver", "AILANG"]
+    tiers = _load_data(args.version, Path(args.results_dir), modes)
+
     for t in types:
         output = (
             Path(args.output) if args.output else Path(f"/tmp/vera-bench_slide_{t}.png")
         )
-        RENDERERS[t](flagship, sonnet, output, background=args.background)
+        RENDERERS[t](tiers, output, background=args.background)
 
 
 if __name__ == "__main__":

--- a/scripts/plot_slide.py
+++ b/scripts/plot_slide.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Render benchmark result panels as 16:9 slides for talk presentation.
 
-Four slide types are supported:
+Five slide types are supported:
 
 - `delta`     — the "Does Vera beat Python / TypeScript?" horizontal-bar chart
                 (the headline storytelling slide; Vera-wins read as green
@@ -15,6 +15,13 @@ Four slide types are supported:
                 subset of models that ran the ZTD generation targets. Needs
                 Aver/AILANG result files, so it's opt-in (--type ztd), not
                 part of --type all.
+- `reasoning` — one model at two reasoning budgets (REASONING_PAIR) across
+                every core mode, per-language delta annotated. The
+                controlled comparison: both entries are the SAME model, so
+                deliberation is the only variable — if Vera's delta is ~0
+                while comparison languages gain, the language is supplying
+                structure the reasoning budget otherwise reconstructs.
+                Opt-in; needs both halves of the pair.
 
 Standalone script — not part of the documentation chart-generation flow in
 `plot_results.py`. Slide rendering has different typography and layout
@@ -559,11 +566,145 @@ def render_ztd(
     _save(fig, output, background)
 
 
+# ----------------------------------------------------------------------
+# Reasoning-budget slide — same model, two effort levels
+# ----------------------------------------------------------------------
+
+# Display names of a (default, pro) pair from plot_results.MODELS. Both
+# entries are the SAME underlying model at different reasoning budgets,
+# so the only variable between them is deliberation.
+REASONING_PAIR = ("GPT-5.6 Sol", "GPT-5.6 Sol (pro)")
+REASONING_MODES = ["Vera", "Vera NL", "Python", "TypeScript"]
+
+
+def render_reasoning(
+    tiers: dict[str, dict], output: Path, background: str = DEFAULT_BACKGROUND
+) -> None:
+    """Does a bigger reasoning budget help — and does it help less on Vera?
+
+    The controlled comparison no other provider offers: one model, two
+    effort levels, every language. If Vera's delta is ~0 while the
+    comparison languages gain from extra deliberation, the language is
+    supplying the structure the reasoning budget otherwise has to
+    reconstruct.
+    """
+    all_data = _merge_tiers(tiers)
+    base_name, pro_name = REASONING_PAIR
+    missing = [n for n in REASONING_PAIR if n not in all_data]
+    if missing:
+        print(f"  reasoning slide: no data for {missing} — skipping")
+        return
+
+    base, pro = all_data[base_name], all_data[pro_name]
+    modes = [m for m in REASONING_MODES if m in base and m in pro]
+    deltas = [pro[m] - base[m] for m in modes]
+
+    fig, ax = plt.subplots(figsize=(16, 9), dpi=180)
+    x = np.arange(len(modes))
+    width = 0.36
+
+    for offset, row, label, alpha, hatch in (
+        (-width / 2, base, "default effort", 0.95, None),
+        (width / 2, pro, "reasoning: pro", 0.75, "//"),
+    ):
+        values = [row[m] for m in modes]
+        bars = ax.bar(
+            x + offset,
+            values,
+            width,
+            label=label,
+            color=[COLORS[m] for m in modes],
+            edgecolor=CREAM,
+            linewidth=0.8,
+            alpha=alpha,
+            hatch=hatch,
+        )
+        for bar, val in zip(bars, values):
+            ax.text(
+                bar.get_x() + bar.get_width() / 2,
+                bar.get_height() + 1.5,
+                f"{val}",
+                ha="center",
+                va="bottom",
+                fontsize=BAR_LABEL_PT_MEDIUM,
+                fontweight="bold",
+                color=BROWN_700,
+            )
+
+    # The point of the slide: the per-language delta.
+    for xi, d in zip(x, deltas):
+        sign = "+" if d > 0 else ""
+        ax.text(
+            xi,
+            108,
+            f"{sign}{d} pp",
+            ha="center",
+            va="center",
+            fontsize=BAR_LABEL_PT_MEDIUM,
+            fontweight="bold",
+            color=GREEN if d > 0 else (BROWN_500 if d == 0 else RED),
+        )
+
+    ax.set_ylabel("run_correct (%)", fontsize=AXIS_LABEL_PT, color=BROWN_500)
+    # Punchy title + explanatory subtitle: the long single-line form
+    # clips at 16:9 even at TITLE_PT - 2.
+    ax.set_title(
+        "Does more reasoning help?",
+        fontsize=TITLE_PT,
+        fontweight="bold",
+        pad=44,
+        fontfamily=FONT_HEADING,
+        color=BROWN_900,
+    )
+    ax.text(
+        0.5,
+        1.015,
+        f"{base_name} — one model, two reasoning budgets",
+        transform=ax.transAxes,
+        ha="center",
+        va="bottom",
+        fontsize=SUBTITLE_PT,
+        color=BROWN_500,
+    )
+    ax.set_xticks(x)
+    ax.set_xticklabels(modes, fontsize=TICK_PT_LARGE)
+    ax.set_ylim(0, 118)
+    ax.set_yticks([0, 25, 50, 75, 100])
+    ax.tick_params(axis="y", labelsize=TICK_PT_SMALL)
+    ax.axhline(y=100, color=BROWN_300, linestyle="--", linewidth=0.8, alpha=0.4)
+    _style_ax(ax)
+
+    # Neutral legend: colour already encodes language, so the legend
+    # only needs to distinguish the two effort levels.
+    ax.legend(
+        handles=[
+            Patch(
+                facecolor="#888888", edgecolor=CREAM, alpha=0.95, label="default effort"
+            ),
+            Patch(
+                facecolor="#888888",
+                edgecolor=CREAM,
+                alpha=0.75,
+                hatch="//",
+                label="reasoning: pro",
+            ),
+        ],
+        loc="lower left",
+        fontsize=LEGEND_PT,
+        framealpha=0.85,
+        edgecolor=BROWN_300,
+    )
+
+    fig.tight_layout(rect=(0.02, 0.02, 0.98, 0.95))
+    _save(fig, output, background)
+
+
 RENDERERS = {
     "delta": render_delta,
     "tiers": render_tiers,
     "all-modes": render_all_modes,
     "ztd": render_ztd,
+    "reasoning": render_reasoning,
 }
 
 
@@ -617,7 +758,7 @@ def main() -> None:
     # result files that historical versions don't have; request it
     # explicitly with --type ztd.
     if args.type == "all":
-        types = [t for t in types if t != "ztd"]
+        types = [t for t in types if t not in ("ztd", "reasoning")]
     modes = ["Vera", "Vera NL", "Python", "TypeScript"]
     if "ztd" in types:
         modes += ["Aver", "AILANG"]

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
-# v0.0.16 pre-sweep smoke gate (S0-S5).
+# Pre-sweep preflight gate (S0-S5).
+#
+# Run this before committing to a full sweep. A sweep is ~40 target-runs
+# with no resume, so a model id that does not exist, a parameter the API
+# rejects, or a toolchain that is not on PATH costs hours and real money
+# to discover late. Every check here is one problem.
 #
 # Run from the repo root with the three provider keys exported:
 #
 #   export ANTHROPIC_API_KEY=...
 #   export OPENAI_API_KEY=...
 #   export MOONSHOT_API_KEY=...
-#   bash scripts/smoke_v0016.sh              # all stages
-#   bash scripts/smoke_v0016.sh s2 s3        # only these stages
+#   bash scripts/preflight.sh              # all stages
+#   bash scripts/preflight.sh s2 s3        # only these stages
 #
 # Stage selection exists because these calls cost money: a stage that
 # already passed should not be paid for twice on a re-run.
@@ -15,7 +20,12 @@
 # SMOKE_SKIP_MODELS is a space-separated list of S1 models to skip, for
 # the same reason:
 #
-#   SMOKE_SKIP_MODELS="claude-fable-5" bash scripts/smoke_v0016.sh
+#   SMOKE_SKIP_MODELS="claude-fable-5" bash scripts/preflight.sh
+#
+# The model list is NOT duplicated here — it is read from
+# run_full_benchmark.py, so the gate always checks the matrix that is
+# actually configured. Targets bash 3.2 (macOS system bash): no
+# mapfile, no associative arrays.
 #
 # Cost: roughly $1-2. Every LLM call is a SINGLE problem, and most use
 # the Python target (no ~28k-token SKILL.md prefix). Output goes to a
@@ -42,11 +52,23 @@ STAGES="${*:-s0 s1 s2 s3 s5}"
 want() { [[ " $STAGES " == *" $1 "* ]]; }
 SKIP_MODELS="${SMOKE_SKIP_MODELS:-}"
 
+# The reasoning-budget pair (S2) and the canary model (S5). Unlike the
+# S1 list these are roles, not the whole matrix, so they are named here:
+# S2 needs two entries that differ ONLY in reasoning mode, and S5 wants
+# the cheapest model that exercises all six target languages.
+REASON_BASE="${PREFLIGHT_REASON_BASE:-gpt-5.6-sol}"
+REASON_PRO="${PREFLIGHT_REASON_PRO:-openai-pro/gpt-5.6-sol}"
+CANARY="${PREFLIGHT_CANARY:-claude-sonnet-5}"
+
 pass=0; fail=0
 note() { printf '\n\033[1m== %s\033[0m\n' "$1"; }
 ok()   { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
 bad()  { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
 skip() { printf '  --    %s (skipped)\n' "$1"; }
+# Each vera-bench call is redirected to a log, so without this the
+# script looks hung during a slow model — fable thinks, and pro
+# deliberates against a 16000-token budget. Overwritten by the verdict.
+busy() { printf '  ...   %s\r' "$1"; }
 
 # Exit code is NOT success. `vera-bench run` records an API error as a
 # JSONL row and still exits 0 — that is deliberate (a transient error
@@ -93,12 +115,32 @@ oai=$(curl -s https://api.openai.com/v1/models \
         -H "Authorization: Bearer $OPENAI_API_KEY" | jq -r '.data[].id' 2>/dev/null)
 msh=$(curl -s https://api.moonshot.ai/v1/models \
         -H "Authorization: Bearer $MOONSHOT_API_KEY" | jq -r '.data[].id' 2>/dev/null)
-for m in gpt-5.6-sol gpt-5.6-terra; do
-  grep -qx "$m" <<<"$oai" && ok "openai: $m" || bad "openai: $m NOT LISTED"
-done
-for m in kimi-k3 kimi-k2.6; do
-  grep -qx "$m" <<<"$msh" && ok "moonshot: $m" || bad "moonshot: $m NOT LISTED"
-done
+# Derived from the same MODELS table as S1, via run_full_benchmark's own
+# _detect_provider, so a model added to the sweep is gated here too.
+# Routing prefixes are stripped: the provider lists bare ids, and both
+# Sol entries collapse to the same one. Anthropic has no equivalent
+# public /v1/models listing, so those ids are checked in S1 instead.
+while IFS='|' read -r provider bare; do
+  [ -z "$bare" ] && continue
+  case "$provider" in
+    openai)   grep -qx "$bare" <<<"$oai" && ok "openai: $bare" \
+                || bad "openai: $bare NOT LISTED" ;;
+    moonshot) grep -qx "$bare" <<<"$msh" && ok "moonshot: $bare" \
+                || bad "moonshot: $bare NOT LISTED" ;;
+  esac
+done < <($PY -c "
+import sys; sys.path.insert(0, 'scripts')
+from run_full_benchmark import MODELS, _detect_provider
+seen = set()
+for group in MODELS.values():
+    for _label, model_id in group:
+        provider = _detect_provider(model_id)
+        bare = model_id.split('/')[-1]
+        if (provider, bare) in seen:
+            continue
+        seen.add((provider, bare))
+        print(f'{provider}|{bare}')
+")
 echo "  --- OpenAI ids matching 5.6 (substitution candidates) ---"
 grep -i "5\.6" <<<"$oai" | sed 's/^/      /'
 echo "  --- Moonshot ids matching k3/k2 ---"
@@ -111,15 +153,29 @@ fi
 # real calls that still exercise the whole client path.
 if want s1; then
 note "S1  one problem per model (python target)"
-MODELS=(
-  claude-fable-5 claude-opus-4-8 claude-sonnet-5
-  gpt-5.6-sol gpt-5.6-terra openai-pro/gpt-5.6-sol
-  moonshot/kimi-k3 moonshot/kimi-k2.6
-)
+# Single source of truth: whatever the sweep is configured to run is
+# what gets gated. A hardcoded copy here would drift and quietly stop
+# checking a model that the sweep still uses.
+MODELS=()
+while IFS= read -r m; do
+  [ -n "$m" ] && MODELS+=("$m")
+done < <($PY -c "
+import sys; sys.path.insert(0, 'scripts')
+from run_full_benchmark import MODELS
+for group in MODELS.values():
+    for _label, model_id in group:
+        print(model_id)
+")
+if [ "${#MODELS[@]}" -eq 0 ]; then
+  bad "could not read MODELS from scripts/run_full_benchmark.py"
+else
+  echo "  (${#MODELS[@]} models from run_full_benchmark.py)"
+fi
 for m in "${MODELS[@]}"; do
   if [[ " $SKIP_MODELS " == *" $m "* ]]; then skip "$m"; continue; fi
   slug="${m//\//-}"
   log="$SMOKE/log-s1-$slug.txt"
+  busy "$m"
   # Per-model dir so verdict() judges only this model's rows.
   $VB run --model "$m" --problem VB-T1-001 --language python \
      --output-dir "$SMOKE/s1/$slug" >"$log" 2>&1
@@ -135,10 +191,13 @@ fi
 # Separate dirs: both calls produce the same filename otherwise.
 if want s2; then
 note "S2  reasoning budget actually engages"
-$VB run --model gpt-5.6-sol --problem VB-T1-001 \
+busy "$REASON_BASE (standard)"
+$VB run --model "$REASON_BASE" --problem VB-T1-001 \
    --output-dir "$SMOKE/s2/default" >"$SMOKE/log-s2-default.txt" 2>&1
-$VB run --model openai-pro/gpt-5.6-sol --problem VB-T1-001 \
+busy "$REASON_PRO — deliberating"
+$VB run --model "$REASON_PRO" --problem VB-T1-001 \
    --output-dir "$SMOKE/s2/pro" >"$SMOKE/log-s2-pro.txt" 2>&1
+printf '%-60s\r' " "
 $PY - "$SMOKE/s2" <<'PY'
 import json, pathlib, sys
 d = pathlib.Path(sys.argv[1])
@@ -184,7 +243,7 @@ fi
 # should report cached_tokens > 0 here and 0 there.
 if want s3; then
 note "S3  cache accounting (2nd call on the same 28k prefix)"
-$VB run --model gpt-5.6-sol --problem VB-T1-002 \
+$VB run --model "$REASON_BASE" --problem VB-T1-002 \
    --output-dir "$SMOKE/s3" >"$SMOKE/log-s3.txt" 2>&1
 $PY - "$SMOKE" <<'PY'
 import json, pathlib, sys
@@ -216,7 +275,8 @@ note "S5  all six targets, one problem, one model"
 run_target () {  # label, extra args...
   local lbl=$1; shift
   local log="$SMOKE/log-s5-$lbl.txt"
-  $VB run --model claude-sonnet-5 --problem VB-T1-001 "$@" \
+  busy "canary $lbl"
+  $VB run --model "$CANARY" --problem VB-T1-001 "$@" \
      --output-dir "$SMOKE/s5/$lbl" >"$log" 2>&1
   verdict "canary $lbl" "$SMOKE/s5/$lbl" "$log"
 }

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -208,7 +208,7 @@ busy "$REASON_PRO — deliberating"
 $VB run --model "$REASON_PRO" --problem VB-T1-001 \
    --output-dir "$SMOKE/s2/pro" >"$SMOKE/log-s2-pro.txt" 2>&1
 printf '%-60s\r' " "
-$PY - "$SMOKE/s2" <<'PY'
+if $PY - "$SMOKE/s2" <<'PY'
 import json, pathlib, sys
 d = pathlib.Path(sys.argv[1])
 def row(sub):
@@ -230,21 +230,26 @@ for lbl, r in (("default", base), ("pro", pro)):
         failed = True
 if failed:
     print("  VERDICT : inconclusive — fix the error above, then re-run s2")
-    raise SystemExit
+    raise SystemExit(1)
 for lbl, r in (("default", base), ("pro", pro)):
     print(f"  {lbl:<8}: model={r['model']!r} wall={r['wall_time_s']:.1f}s "
           f"out_tok={r['output_tokens']} check={r['check_pass']}")
 w = pro["wall_time_s"] / max(base["wall_time_s"], 0.01)
 t = pro["output_tokens"] / max(base["output_tokens"], 1)
 print(f"  ratio   : wall x{w:.1f}   out_tok x{t:.1f}")
+engaged = w > 1.4 or t > 1.4
 print("  VERDICT : " + ("pro ENGAGED — distinct cost/latency signature"
-      if w > 1.4 or t > 1.4 else
+      if engaged else
       "*** pro may be SILENTLY IGNORED — indistinguishable from default ***"))
 print(f"  model field distinguishable in JSONL: "
       f"{'yes' if pro['model'] != base['model'] else 'NO — charts cannot tell them apart'}")
 if pro["wall_time_s"] > 100:
     print(f"  WARNING : {pro['wall_time_s']:.0f}s is near the 120s client timeout")
+raise SystemExit(0 if engaged else 1)
 PY
+then ok "S2 reasoning budget engages"
+else bad "S2 — pro indistinguishable from default (see verdict above)"
+fi
 fi
 
 # ---------------------------------------------------------------- S3
@@ -320,3 +325,9 @@ printf '\n\033[1m== SMOKE COMPLETE — %d ok, %d failed\033[0m\n' "$pass" "$fail
 echo "Logs + JSONL: $SMOKE"
 echo
 echo "Paste from '== S0' downwards. It contains no credentials."
+
+# Exit status must reflect the verdict. Without this the gate could
+# print "pro may be SILENTLY IGNORED" — the one finding that
+# invalidates the headline slide — and still exit 0, so a chained
+# `preflight.sh && run_full_benchmark.py` would sail straight past it.
+exit $([ "$fail" -eq 0 ] && echo 0 || echo 1)

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -32,8 +32,9 @@
 # scratch dir, never results/, so it cannot pollute a real sweep.
 #
 # Each stage writes to its own subdirectory. This is load-bearing, not
-# tidiness: result filenames carry no timestamp (cli.py:258-270) and
-# `run` UNLINKS an existing file (cli.py:273-274), so two stages that
+# tidiness: result filenames carry no timestamp (the `parts`/`_ver_slug`
+# block in vera_bench/cli.py) and `run` UNLINKS an existing file (the
+# "Truncate stale results" step), so two stages that
 # run the same model+language+mode would silently overwrite each other.
 #
 # Nothing here prints a key. The report at the end is safe to paste.
@@ -78,14 +79,23 @@ busy() { printf '  ...   %s\r' "$1"; }
 verdict () {  # label, results-dir, logfile
   local lbl=$1 dir=$2 log=$3
   local err
-  err=$($PY - "$dir" <<'PY'
+  # 2>&1: without it a traceback goes to stderr, $err is empty, and the
+  # verdict falls through to "ok" — the judge failing silently is exactly
+  # the failure mode this function was written to eliminate. A truncated
+  # JSONL line (the signature of a killed run) reaches here as a
+  # JSONDecodeError, and must read as FAIL rather than pass.
+  err=$($PY - "$dir" 2>&1 <<'PY'
 import json, pathlib, sys
 for f in sorted(pathlib.Path(sys.argv[1]).rglob("*.jsonl")):
-    for line in f.read_text().splitlines():
-        if line.strip():
+    for n, line in enumerate(f.read_text().splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
             r = json.loads(line)
-            if r.get("error_message"):
-                print(r["error_message"][:150]); raise SystemExit
+        except json.JSONDecodeError as e:
+            print(f"corrupt row {f.name}:{n} — {e}"); raise SystemExit
+        if r.get("error_message"):
+            print(r["error_message"][:150]); raise SystemExit
 PY
 )
   if [ -n "$err" ]; then bad "$lbl — $err"
@@ -123,9 +133,9 @@ msh=$(curl -s https://api.moonshot.ai/v1/models \
 while IFS='|' read -r provider bare; do
   [ -z "$bare" ] && continue
   case "$provider" in
-    openai)   grep -qx "$bare" <<<"$oai" && ok "openai: $bare" \
+    openai)   grep -qxF "$bare" <<<"$oai" && ok "openai: $bare" \
                 || bad "openai: $bare NOT LISTED" ;;
-    moonshot) grep -qx "$bare" <<<"$msh" && ok "moonshot: $bare" \
+    moonshot) grep -qxF "$bare" <<<"$msh" && ok "moonshot: $bare" \
                 || bad "moonshot: $bare NOT LISTED" ;;
   esac
 done < <($PY -c "
@@ -171,7 +181,7 @@ if [ "${#MODELS[@]}" -eq 0 ]; then
 else
   echo "  (${#MODELS[@]} models from run_full_benchmark.py)"
 fi
-for m in "${MODELS[@]}"; do
+for m in ${MODELS[@]+"${MODELS[@]}"}; do
   if [[ " $SKIP_MODELS " == *" $m "* ]]; then skip "$m"; continue; fi
   slug="${m//\//-}"
   log="$SMOKE/log-s1-$slug.txt"

--- a/scripts/run_full_benchmark.py
+++ b/scripts/run_full_benchmark.py
@@ -38,18 +38,23 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+# v0.0.16 matrix, grouped by provider for the interactive menu. Tier
+# assignment lives in scripts/plot_results.py MODELS (it drives chart
+# layout); this dict only populates the picker.
 MODELS = {
     "anthropic": [
-        ("Claude Sonnet 4.6", "claude-sonnet-4-6"),
-        ("Claude Opus 4.8", "claude-opus-4-8"),
+        ("Claude Sonnet 5 (sonnet tier)", "claude-sonnet-5"),
+        ("Claude Opus 4.8 (opus tier)", "claude-opus-4-8"),
+        ("Claude Fable 5 (fable tier)", "claude-fable-5"),
     ],
     "openai": [
-        ("GPT-4o", "gpt-4o"),
-        ("GPT-4.1", "gpt-4.1-2025-04-14"),
+        ("GPT-5.6 Terra (sonnet tier)", "gpt-5.6-terra"),
+        ("GPT-5.6 Sol (opus tier)", "gpt-5.6-sol"),
+        ("GPT-5.6 Sol @ pro (fable tier)", "openai-pro/gpt-5.6-sol"),
     ],
     "moonshot": [
-        ("Kimi K2.5", "moonshot/kimi-k2.5"),
-        ("Kimi K2.6", "moonshot/kimi-k2.6"),
+        ("Kimi K2.6 (sonnet tier)", "moonshot/kimi-k2.6"),
+        ("Kimi K3 (opus tier)", "moonshot/kimi-k3"),
     ],
 }
 

--- a/scripts/run_full_benchmark.py
+++ b/scripts/run_full_benchmark.py
@@ -7,11 +7,11 @@ Usage:
 
   # Autonomous mode
   python scripts/run_full_benchmark.py \
-    --model claude-sonnet-4-6 --api-key sk-ant-...
+    --model claude-sonnet-5 --api-key sk-ant-...
 
   # Autonomous with env var
   ANTHROPIC_API_KEY=sk-ant-... \
-    python scripts/run_full_benchmark.py --model claude-sonnet-4-6
+    python scripts/run_full_benchmark.py --model claude-sonnet-5
 
 Runs all 10 targets:
   1. Vera full-spec

--- a/scripts/smoke_v0016.sh
+++ b/scripts/smoke_v0016.sh
@@ -48,6 +48,30 @@ ok()   { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
 bad()  { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
 skip() { printf '  --    %s (skipped)\n' "$1"; }
 
+# Exit code is NOT success. `vera-bench run` records an API error as a
+# JSONL row and still exits 0 — that is deliberate (a transient error
+# costs one problem, not the whole sweep), but it means a smoke check
+# that reads $? reports "ok" for a model that never answered. Both
+# fable-tier models passed that way on 2026-07-23. Judge the rows.
+verdict () {  # label, results-dir, logfile
+  local lbl=$1 dir=$2 log=$3
+  local err
+  err=$($PY - "$dir" <<'PY'
+import json, pathlib, sys
+for f in sorted(pathlib.Path(sys.argv[1]).rglob("*.jsonl")):
+    for line in f.read_text().splitlines():
+        if line.strip():
+            r = json.loads(line)
+            if r.get("error_message"):
+                print(r["error_message"][:150]); raise SystemExit
+PY
+)
+  if [ -n "$err" ]; then bad "$lbl — $err"
+  elif [ ! -d "$dir" ] || [ -z "$(find "$dir" -name '*.jsonl' 2>/dev/null)" ]; then
+    bad "$lbl — no result row ($(grep -iE 'error|Traceback' "$log" | head -1 | cut -c1-100))"
+  else ok "$lbl"; fi
+}
+
 note "keys present (values never printed)"
 for k in ANTHROPIC_API_KEY OPENAI_API_KEY MOONSHOT_API_KEY; do
   if [ -n "${!k:-}" ]; then ok "$k set"; else bad "$k MISSING — export it and re-run"; fi
@@ -94,13 +118,12 @@ MODELS=(
 )
 for m in "${MODELS[@]}"; do
   if [[ " $SKIP_MODELS " == *" $m "* ]]; then skip "$m"; continue; fi
-  log="$SMOKE/log-s1-${m//\//-}.txt"
-  if $VB run --model "$m" --problem VB-T1-001 --language python \
-        --output-dir "$SMOKE/s1" >"$log" 2>&1; then
-    ok "$m"
-  else
-    bad "$m — $(grep -iE 'error|Traceback|unsupported|invalid' "$log" | head -1 | cut -c1-140)"
-  fi
+  slug="${m//\//-}"
+  log="$SMOKE/log-s1-$slug.txt"
+  # Per-model dir so verdict() judges only this model's rows.
+  $VB run --model "$m" --problem VB-T1-001 --language python \
+     --output-dir "$SMOKE/s1/$slug" >"$log" 2>&1
+  verdict "$m" "$SMOKE/s1/$slug" "$log"
 done
 fi
 
@@ -180,12 +203,10 @@ if want s5; then
 note "S5  all six targets, one problem, one model"
 run_target () {  # label, extra args...
   local lbl=$1; shift
-  if $VB run --model claude-sonnet-5 --problem VB-T1-001 "$@" \
-        --output-dir "$SMOKE/s5" >"$SMOKE/log-s5-$lbl.txt" 2>&1; then
-    ok "canary $lbl"
-  else
-    bad "canary $lbl — $(grep -iE 'error' "$SMOKE/log-s5-$lbl.txt" | head -1 | cut -c1-120)"
-  fi
+  local log="$SMOKE/log-s5-$lbl.txt"
+  $VB run --model claude-sonnet-5 --problem VB-T1-001 "$@" \
+     --output-dir "$SMOKE/s5/$lbl" >"$log" 2>&1
+  verdict "canary $lbl" "$SMOKE/s5/$lbl" "$log"
 }
 run_target vera-full
 run_target vera-nl      --mode spec-from-nl

--- a/scripts/smoke_v0016.sh
+++ b/scripts/smoke_v0016.sh
@@ -150,6 +150,18 @@ def row(sub):
 base, pro = row("default"), row("pro")
 if not base or not pro:
     print("  FAIL  missing one half of the pair — see log-s2-*.txt"); raise SystemExit
+# An errored call reports wall=0.0 and out_tok=0, which the ratio test
+# below would read as "pro looks identical to default" — the exact
+# wrong conclusion. It said that on 2026-07-23 when pro was in fact
+# 400-ing. Check for errors first.
+failed = False
+for lbl, r in (("default", base), ("pro", pro)):
+    if r.get("error_message"):
+        print(f"  FAIL  {lbl} errored: {r['error_message'][:200]}")
+        failed = True
+if failed:
+    print("  VERDICT : inconclusive — fix the error above, then re-run s2")
+    raise SystemExit
 for lbl, r in (("default", base), ("pro", pro)):
     print(f"  {lbl:<8}: model={r['model']!r} wall={r['wall_time_s']:.1f}s "
           f"out_tok={r['output_tokens']} check={r['check_pass']}")

--- a/scripts/smoke_v0016.sh
+++ b/scripts/smoke_v0016.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# v0.0.16 pre-sweep smoke gate (S0-S5).
+#
+# Run from the repo root with the three provider keys exported:
+#
+#   export ANTHROPIC_API_KEY=...
+#   export OPENAI_API_KEY=...
+#   export MOONSHOT_API_KEY=...
+#   bash scripts/smoke_v0016.sh              # all stages
+#   bash scripts/smoke_v0016.sh s2 s3        # only these stages
+#
+# Stage selection exists because these calls cost money: a stage that
+# already passed should not be paid for twice on a re-run.
+#
+# SMOKE_SKIP_MODELS is a space-separated list of S1 models to skip, for
+# the same reason:
+#
+#   SMOKE_SKIP_MODELS="claude-fable-5" bash scripts/smoke_v0016.sh
+#
+# Cost: roughly $1-2. Every LLM call is a SINGLE problem, and most use
+# the Python target (no ~28k-token SKILL.md prefix). Output goes to a
+# scratch dir, never results/, so it cannot pollute a real sweep.
+#
+# Each stage writes to its own subdirectory. This is load-bearing, not
+# tidiness: result filenames carry no timestamp (cli.py:258-270) and
+# `run` UNLINKS an existing file (cli.py:273-274), so two stages that
+# run the same model+language+mode would silently overwrite each other.
+#
+# Nothing here prints a key. The report at the end is safe to paste.
+
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+
+SMOKE="/tmp/vb-smoke-$(date +%F-%H%M)"
+mkdir -p "$SMOKE"/{s1,s2,s3,s5}
+VB=".venv/bin/vera-bench"
+PY=".venv/bin/python"
+export VERA_PATH="$PWD/.venv/bin/vera"
+export PATH="$PWD/.venv/bin:$PATH"
+
+STAGES="${*:-s0 s1 s2 s3 s5}"
+want() { [[ " $STAGES " == *" $1 "* ]]; }
+SKIP_MODELS="${SMOKE_SKIP_MODELS:-}"
+
+pass=0; fail=0
+note() { printf '\n\033[1m== %s\033[0m\n' "$1"; }
+ok()   { printf '  ok    %s\n' "$1"; pass=$((pass+1)); }
+bad()  { printf '  FAIL  %s\n' "$1"; fail=$((fail+1)); }
+skip() { printf '  --    %s (skipped)\n' "$1"; }
+
+note "keys present (values never printed)"
+for k in ANTHROPIC_API_KEY OPENAI_API_KEY MOONSHOT_API_KEY; do
+  if [ -n "${!k:-}" ]; then ok "$k set"; else bad "$k MISSING — export it and re-run"; fi
+done
+[ "$fail" -gt 0 ] && { echo; echo "Stopping: export the missing key(s) first."; exit 1; }
+
+note "toolchain"
+echo "  vera-bench $($VB --version 2>&1 | tail -1)"
+echo "  vera       $(vera version 2>&1 | head -1)"
+echo "  aver       $(aver --version 2>&1 | head -1)"
+echo "  ailang     $(ailang --version 2>&1 | head -1)"   # 7-line banner
+
+# ---------------------------------------------------------------- S0
+# Do the IDs exist? Free — no tokens spent. This is the cheapest place
+# to discover that a planned model ID is wrong.
+if want s0; then
+note "S0  model IDs exist (provider /v1/models)"
+oai=$(curl -s https://api.openai.com/v1/models \
+        -H "Authorization: Bearer $OPENAI_API_KEY" | jq -r '.data[].id' 2>/dev/null)
+msh=$(curl -s https://api.moonshot.ai/v1/models \
+        -H "Authorization: Bearer $MOONSHOT_API_KEY" | jq -r '.data[].id' 2>/dev/null)
+for m in gpt-5.6-sol gpt-5.6-terra; do
+  grep -qx "$m" <<<"$oai" && ok "openai: $m" || bad "openai: $m NOT LISTED"
+done
+for m in kimi-k3 kimi-k2.6; do
+  grep -qx "$m" <<<"$msh" && ok "moonshot: $m" || bad "moonshot: $m NOT LISTED"
+done
+echo "  --- OpenAI ids matching 5.6 (substitution candidates) ---"
+grep -i "5\.6" <<<"$oai" | sed 's/^/      /'
+echo "  --- Moonshot ids matching k3/k2 ---"
+grep -iE "k3|k2" <<<"$msh" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------- S1
+# Auth + ID acceptance + the max_tokens vs max_completion_tokens
+# question. Python target = no big prefix, so these are the cheapest
+# real calls that still exercise the whole client path.
+if want s1; then
+note "S1  one problem per model (python target)"
+MODELS=(
+  claude-fable-5 claude-opus-4-8 claude-sonnet-5
+  gpt-5.6-sol gpt-5.6-terra openai-pro/gpt-5.6-sol
+  moonshot/kimi-k3 moonshot/kimi-k2.6
+)
+for m in "${MODELS[@]}"; do
+  if [[ " $SKIP_MODELS " == *" $m "* ]]; then skip "$m"; continue; fi
+  log="$SMOKE/log-s1-${m//\//-}.txt"
+  if $VB run --model "$m" --problem VB-T1-001 --language python \
+        --output-dir "$SMOKE/s1" >"$log" 2>&1; then
+    ok "$m"
+  else
+    bad "$m — $(grep -iE 'error|Traceback|unsupported|invalid' "$log" | head -1 | cut -c1-140)"
+  fi
+done
+fi
+
+# ---------------------------------------------------------------- S2
+# Does pro mode actually ENGAGE, or is the parameter silently accepted
+# and ignored? Same model, same problem, same prompt — the only
+# variable is the reasoning budget, so a null result here means the
+# Responses-API migration becomes the verified fix.
+# Separate dirs: both calls produce the same filename otherwise.
+if want s2; then
+note "S2  reasoning budget actually engages"
+$VB run --model gpt-5.6-sol --problem VB-T1-001 \
+   --output-dir "$SMOKE/s2/default" >"$SMOKE/log-s2-default.txt" 2>&1
+$VB run --model openai-pro/gpt-5.6-sol --problem VB-T1-001 \
+   --output-dir "$SMOKE/s2/pro" >"$SMOKE/log-s2-pro.txt" 2>&1
+$PY - "$SMOKE/s2" <<'PY'
+import json, pathlib, sys
+d = pathlib.Path(sys.argv[1])
+def row(sub):
+    fs = sorted((d / sub).glob("*.jsonl"))
+    if not fs: return None
+    ls = [json.loads(x) for x in fs[0].read_text().splitlines() if x.strip()]
+    return ls[0] if ls else None
+base, pro = row("default"), row("pro")
+if not base or not pro:
+    print("  FAIL  missing one half of the pair — see log-s2-*.txt"); raise SystemExit
+for lbl, r in (("default", base), ("pro", pro)):
+    print(f"  {lbl:<8}: model={r['model']!r} wall={r['wall_time_s']:.1f}s "
+          f"out_tok={r['output_tokens']} check={r['check_pass']}")
+w = pro["wall_time_s"] / max(base["wall_time_s"], 0.01)
+t = pro["output_tokens"] / max(base["output_tokens"], 1)
+print(f"  ratio   : wall x{w:.1f}   out_tok x{t:.1f}")
+print("  VERDICT : " + ("pro ENGAGED — distinct cost/latency signature"
+      if w > 1.4 or t > 1.4 else
+      "*** pro may be SILENTLY IGNORED — indistinguishable from default ***"))
+print(f"  model field distinguishable in JSONL: "
+      f"{'yes' if pro['model'] != base['model'] else 'NO — charts cannot tell them apart'}")
+if pro["wall_time_s"] > 100:
+    print(f"  WARNING : {pro['wall_time_s']:.0f}s is near the 120s client timeout")
+PY
+fi
+
+# ---------------------------------------------------------------- S3
+# Prompt caching. This is the SECOND call sharing the ~28k SKILL.md
+# system prefix (S2's default run was the first), so a working cache
+# should report cached_tokens > 0 here and 0 there.
+if want s3; then
+note "S3  cache accounting (2nd call on the same 28k prefix)"
+$VB run --model gpt-5.6-sol --problem VB-T1-002 \
+   --output-dir "$SMOKE/s3" >"$SMOKE/log-s3.txt" 2>&1
+$PY - "$SMOKE" <<'PY'
+import json, pathlib, sys
+d = pathlib.Path(sys.argv[1])
+def show(label, sub):
+    for f in sorted((d / sub).rglob("*.jsonl")):
+        for line in f.read_text().splitlines():
+            if not line.strip(): continue
+            r = json.loads(line)
+            i, c = r.get("input_tokens", 0), r.get("cached_tokens", 0)
+            pct = (100 * c / i) if i else 0
+            print(f"  {label:<12} {r['model'][:26]:<26} input={i:>6} "
+                  f"cached={c:>6} ({pct:.0f}%)")
+show("S2 1st call", "s2/default")
+show("S3 2nd call", "s3")
+print("  (OpenAI auto-caches prompts >=1024 tokens; a 0 on the 2nd call means")
+print("   either the prefix differs per problem or cached_tokens isn't plumbed)")
+print("\n  --- all providers, S1 rows ---")
+show("S1", "s1")
+PY
+fi
+
+# ---------------------------------------------------------------- S5
+# Canary: every target path end-to-end on one cheap model. Proves the
+# vera-HEAD / aver-0.27 / ailang toolchains all work through the
+# harness before 40 target-runs depend on them.
+if want s5; then
+note "S5  all six targets, one problem, one model"
+run_target () {  # label, extra args...
+  local lbl=$1; shift
+  if $VB run --model claude-sonnet-5 --problem VB-T1-001 "$@" \
+        --output-dir "$SMOKE/s5" >"$SMOKE/log-s5-$lbl.txt" 2>&1; then
+    ok "canary $lbl"
+  else
+    bad "canary $lbl — $(grep -iE 'error' "$SMOKE/log-s5-$lbl.txt" | head -1 | cut -c1-120)"
+  fi
+}
+run_target vera-full
+run_target vera-nl      --mode spec-from-nl
+run_target python       --language python
+run_target typescript   --language typescript
+run_target aver         --language aver
+run_target ailang       --language ailang
+fi
+
+# ------------------------------------------------------------- REPORT
+note "RESULT FILENAMES  (verify plot_results file_prefix values against these)"
+find "$SMOKE" -name '*.jsonl' | sed "s|$SMOKE/||" | sort | sed 's/^/  /'
+
+note "PER-ROW SUMMARY"
+$PY - "$SMOKE" <<'PY'
+import json, pathlib, sys
+for f in sorted(pathlib.Path(sys.argv[1]).rglob("*.jsonl")):
+    for line in f.read_text().splitlines():
+        if not line.strip(): continue
+        r = json.loads(line)
+        err = (r.get("error_message") or "")[:64]
+        print(f"  {r['problem_id']} {r['language']:<11} "
+              f"chk={'Y' if r['check_pass'] else 'n'} "
+              f"run={str(r.get('run_correct')):<5} "
+              f"{r['model'][:32]:<32} {err}")
+PY
+
+printf '\n\033[1m== SMOKE COMPLETE — %d ok, %d failed\033[0m\n' "$pass" "$fail"
+echo "Logs + JSONL: $SMOKE"
+echo
+echo "Paste from '== S0' downwards. It contains no credentials."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,47 @@ import shutil
 import pytest
 from click.testing import CliRunner
 
-from vera_bench.cli import main
+from vera_bench.cli import _parse_version_banner, main
+
+
+class TestParseVersionBanner:
+    """Compiler version fragments are hyphen-joined into result filenames,
+    so anything but a bare version number corrupts the name."""
+
+    def test_single_line_banner(self):
+        assert _parse_version_banner("aver 0.27.1\n") == "0.27.1"
+
+    def test_multi_line_banner_takes_first_line_only(self):
+        # ailang --version prints seven lines. Before the fix the whole
+        # blob — newlines, colons and all — landed in the filename.
+        banner = (
+            "AILANG v0.30.0\n"
+            "Commit: e37b370\n"
+            "Full:   e37b370d1d7a9c4e7136b319e38bec4d5f2bd9a0\n"
+            "Built:  2026-07-19T09:27:00Z\n"
+            "\n"
+            "The AI-First Programming Language\n"
+            "Copyright (c) 2025-2026"
+        )
+        assert _parse_version_banner(banner) == "0.30.0"
+
+    def test_v_prefix_stripped(self):
+        assert _parse_version_banner("AILANG v0.30.0") == "0.30.0"
+
+    def test_two_component_version(self):
+        assert _parse_version_banner("vera 0.1.6") == "0.1.6"
+        assert _parse_version_banner("toolchain 1.2") == "1.2"
+
+    @pytest.mark.parametrize("raw", ["", "   \n\n  ", "no digits here"])
+    def test_unparseable_yields_unknown(self, raw):
+        # Callers special-case "unknown" by omitting the version from the
+        # filename, which is the correct degradation.
+        assert _parse_version_banner(raw) == "unknown"
+
+    def test_result_is_filename_safe(self):
+        banner = "AILANG v0.30.0\nCommit: e37b370\nCopyright (c) 2025-2026"
+        parsed = _parse_version_banner(banner)
+        assert not set(parsed) & set("\n\r\t /:")
 
 
 class TestValidateCommand:

--- a/tests/test_metrics_errored.py
+++ b/tests/test_metrics_errored.py
@@ -68,3 +68,49 @@ class TestErroredAccounting:
         assert m.errored == 0
         assert m.run_eligible == 60
         assert m.run_correct_rate == 0.0
+
+
+class TestVeraRunDiagnostics:
+    """`vera run` failures must be attributable (#72 reached Aver and
+    AILANG but never the Vera path, which is the headline number).
+
+    A compiler crash previously arrived as `error_message=None,
+    check_pass=True, run_correct=False` — byte-identical to a model
+    writing a wrong program. vera SIGBUS'd repeatedly on 2026-07-23
+    (aallan/vera#1145), so this is observed, not hypothetical.
+    """
+
+    def test_signal_death_is_named(self):
+        from vera_bench.runner import _vera_run_error
+        from vera_bench.vera_runner import RunResult
+
+        # subprocess reports a signal death as a negative returncode;
+        # SIGBUS is 10. Without naming it this reads as an ordinary
+        # non-zero exit — which is to say, as the model's fault.
+        msg = _vera_run_error(0, RunResult(exit_code=-10, stdout="", stderr=""))
+        assert "killed by signal 10" in msg
+
+    def test_signal_death_includes_stderr_when_present(self):
+        from vera_bench.runner import _vera_run_error
+        from vera_bench.vera_runner import RunResult
+
+        msg = _vera_run_error(
+            3, RunResult(exit_code=-11, stdout="", stderr="memory fault at 0x0")
+        )
+        assert "signal 11" in msg and "memory fault" in msg
+
+    def test_ordinary_failure_surfaces_stderr(self):
+        from vera_bench.runner import _vera_run_error
+        from vera_bench.vera_runner import RunResult
+
+        msg = _vera_run_error(
+            1, RunResult(exit_code=1, stdout="", stderr="type error: expected Int")
+        )
+        assert "type error: expected Int" in msg
+
+    def test_silent_nonzero_exit_still_reports_something(self):
+        from vera_bench.runner import _vera_run_error
+        from vera_bench.vera_runner import RunResult
+
+        msg = _vera_run_error(2, RunResult(exit_code=1, stdout="", stderr=""))
+        assert "exit 1" in msg

--- a/tests/test_metrics_errored.py
+++ b/tests/test_metrics_errored.py
@@ -1,0 +1,70 @@
+"""Error accounting: the shrinking run_correct denominator (#95)."""
+
+from __future__ import annotations
+
+from vera_bench.metrics import compute_metrics
+
+
+def _row(pid: str, *, check: bool, run, err: str | None):
+    return {
+        "problem_id": pid,
+        "tier": 1,
+        "attempt": 1,
+        "check_pass": check,
+        "run_correct": run,
+        "error_message": err,
+    }
+
+
+class TestErroredAccounting:
+    """`run_correct_rate` is measured over problems that compiled, so
+    API-error rows leave the denominator entirely. The rate itself is
+    unchanged (historical comparability), but the shrinkage must be
+    visible in the metrics object."""
+
+    def test_partial_api_failure_is_counted(self):
+        rows = [
+            _row(f"VB-T1-{i:03d}", check=False, run=None, err="API error: 401")
+            for i in range(40)
+        ]
+        rows += [
+            _row(f"VB-T1-{i:03d}", check=True, run=True, err=None)
+            for i in range(40, 60)
+        ]
+        m = compute_metrics(rows)
+
+        # The headline number is still 100% — that is the hazard.
+        assert m.run_correct_rate == 1.0
+        assert m.total_problems == 60
+        # ...but the denominator and the failures are now reportable.
+        assert m.run_eligible == 20
+        assert m.errored == 40
+
+    def test_total_api_failure(self):
+        rows = [
+            _row(f"VB-T1-{i:03d}", check=False, run=None, err="API error: 401")
+            for i in range(60)
+        ]
+        m = compute_metrics(rows)
+        assert m.run_correct_rate is None  # no measurement exists
+        assert m.run_eligible == 0
+        assert m.errored == 60
+
+    def test_clean_run_reports_no_errors(self):
+        rows = [
+            _row(f"VB-T1-{i:03d}", check=True, run=True, err=None) for i in range(60)
+        ]
+        m = compute_metrics(rows)
+        assert m.errored == 0
+        assert m.run_eligible == m.total_problems == 60
+
+    def test_compiled_but_wrong_is_not_an_error(self):
+        """A model that compiles and gets the answer wrong is a real
+        result, not a harness failure — it must stay in the denominator."""
+        rows = [
+            _row(f"VB-T1-{i:03d}", check=True, run=False, err=None) for i in range(60)
+        ]
+        m = compute_metrics(rows)
+        assert m.errored == 0
+        assert m.run_eligible == 60
+        assert m.run_correct_rate == 0.0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -797,8 +797,11 @@ class TestOpenAIProRouting:
 
         from vera_bench.models import REASONING_MODES
 
-        mode_type = get_type_hints(Reasoning)["mode"]
-        literal = next(a for a in get_args(mode_type) if get_args(a))
+        hints = get_type_hints(Reasoning)
+        # No skip guard: pyproject floors openai at >=2.45, the first
+        # release declaring this field. If it is absent, the environment
+        # violates the declared floor and that should fail loudly.
+        literal = next(a for a in get_args(hints["mode"]) if get_args(a))
         assert REASONING_MODES <= set(get_args(literal))
 
     def test_unknown_reasoning_mode_raises(self, monkeypatch):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -688,7 +688,22 @@ class TestOpenAIProRouting:
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")
         return create_client(model)
 
-    def _ok_response(self) -> MagicMock:
+    def _ok_response(self, mode: str = "pro", text: str = "code") -> MagicMock:
+        """A Responses-API response. `reasoning.mode` is set explicitly —
+        a bare MagicMock would return an auto-attribute that silently
+        satisfies nothing, which is how the earlier reasoning bug got
+        past this suite."""
+        resp = MagicMock()
+        resp.output_text = text
+        resp.model = "gpt-5.6-sol"
+        resp.reasoning.mode = mode
+        resp.usage.input_tokens = 100
+        resp.usage.output_tokens = 5000
+        resp.usage.input_tokens_details.cached_tokens = 0
+        return resp
+
+    def _chat_response(self) -> MagicMock:
+        """A Chat Completions response, for the default (non-pro) path."""
         resp = MagicMock()
         choice = MagicMock()
         choice.message.content = "code"
@@ -722,58 +737,115 @@ class TestOpenAIProRouting:
         with pytest.raises(ValueError, match="Unknown model"):
             create_client("mystery/some-model")
 
-    def test_pro_sends_reasoning_effort_kwarg(self, monkeypatch):
-        """Chat Completions takes `reasoning_effort`, not a nested
-        `reasoning` object — the latter is the Responses-API shape and
-        is rejected with 400 "Unknown parameter: 'reasoning'" (smoke
-        S2, 2026-07-23). "pro" is our name; the API ceiling is "max"."""
+    def test_pro_routes_to_responses_api(self, monkeypatch):
+        """`reasoning.mode` exists only on the Responses API. Chat
+        Completions rejects it (400 "Unknown parameter: 'reasoning'"),
+        and it is NOT expressible as reasoning_effort — mode and effort
+        are independent axes, and gpt-5.6-sol rejects effort="max" on
+        Chat Completions anyway. Both verified live 2026-07-23."""
         client = self._client(monkeypatch)
         mock_inner = MagicMock()
-        mock_inner.chat.completions.create.return_value = self._ok_response()
+        mock_inner.responses.create.return_value = self._ok_response()
         self._wire(client, mock_inner)
         client.complete("sys", "user")
-        kwargs = mock_inner.chat.completions.create.call_args.kwargs
-        assert kwargs["reasoning_effort"] == "max"
-        assert "reasoning" not in kwargs
-        assert "reasoning" not in kwargs["extra_body"]
-        # Cache key still rides alongside (#61)
-        assert "prompt_cache_key" in kwargs["extra_body"]
 
-    def test_default_mode_sends_no_reasoning(self, monkeypatch):
+        mock_inner.chat.completions.create.assert_not_called()
+        kwargs = mock_inner.responses.create.call_args.kwargs
+        assert kwargs["reasoning"] == {"mode": "pro"}
+        assert kwargs["instructions"] == "sys"
+        assert kwargs["input"] == "user"
+        # Responses names the budget differently from Chat Completions.
+        assert "max_output_tokens" in kwargs
+        assert "max_completion_tokens" not in kwargs
+        # Cache key still rides along (#61), as a typed kwarg here.
+        assert "prompt_cache_key" in kwargs
+
+    def test_default_mode_uses_chat_completions(self, monkeypatch):
         client = self._client(monkeypatch, model="gpt-5.6-sol")
         mock_inner = MagicMock()
-        mock_inner.chat.completions.create.return_value = self._ok_response()
+        mock_inner.chat.completions.create.return_value = self._chat_response()
         self._wire(client, mock_inner)
         client.complete("sys", "user")
+
+        mock_inner.responses.create.assert_not_called()
         kwargs = mock_inner.chat.completions.create.call_args.kwargs
+        assert "reasoning" not in kwargs
         assert "reasoning_effort" not in kwargs
         assert "reasoning" not in kwargs["extra_body"]
 
-    def test_reasoning_effort_is_a_value_the_api_accepts(self, monkeypatch):
-        """Guard against inventing a value the SDK's Literal rejects."""
-        from typing import get_args
+    def test_mode_is_one_the_api_defines(self):
+        """Guard against inventing a mode the SDK does not define.
 
-        from openai.types.shared.reasoning_effort import ReasoningEffort
+        `Reasoning` uses `from __future__ import annotations`, so its
+        raw __annotations__ are ForwardRef strings — get_type_hints is
+        needed to resolve them. The field is
+        `Union[str, Literal["standard", "pro"]]`; the str arm makes the
+        API permissive, which is exactly why we validate ourselves."""
+        from typing import get_args, get_type_hints
 
-        from vera_bench.models import REASONING_MODE_EFFORT
+        from openai.types.shared_params.reasoning import Reasoning
 
-        valid = {v for v in get_args(get_args(ReasoningEffort)[0]) if v}
-        assert set(REASONING_MODE_EFFORT.values()) <= valid
+        from vera_bench.models import REASONING_MODES
 
-    def test_unmapped_reasoning_mode_raises(self, monkeypatch):
+        mode_type = get_type_hints(Reasoning)["mode"]
+        literal = next(a for a in get_args(mode_type) if get_args(a))
+        assert REASONING_MODES <= set(get_args(literal))
+
+    def test_unknown_reasoning_mode_raises(self, monkeypatch):
         """Silently dropping the parameter would make the 'pro' entry run
-        at default effort — a comparison of a model against itself."""
+        in standard mode — a comparison of a model against itself."""
         from vera_bench.models import OpenAIClient
 
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")
         with pytest.raises(ValueError, match="Unknown reasoning mode"):
             OpenAIClient("gpt-5.6-sol", reasoning_mode="ultra")
 
+    def test_silent_downgrade_to_standard_raises(self, monkeypatch):
+        """The response echoes the *effective* mode. If OpenAI quietly
+        served standard, that must not be recorded as a pro result."""
+        client = self._client(monkeypatch)
+        mock_inner = MagicMock()
+        mock_inner.responses.create.return_value = self._ok_response(mode="standard")
+        self._wire(client, mock_inner)
+        with pytest.raises(RuntimeError, match="not the requested 'pro'"):
+            client.complete("sys", "user")
+
+    def test_empty_output_reports_budget_exhaustion(self, monkeypatch):
+        """Reasoning bills against the output budget; an all-deliberation
+        response yields empty text and must say why."""
+        client = self._client(monkeypatch)
+        resp = self._ok_response(text="")
+        resp.incomplete_details.reason = "max_output_tokens"
+        mock_inner = MagicMock()
+        mock_inner.responses.create.return_value = resp
+        self._wire(client, mock_inner)
+        with pytest.raises(ValueError, match="max_output_tokens"):
+            client.complete("sys", "user")
+
+    def test_responses_usage_accounting(self, monkeypatch):
+        """Responses names its usage fields differently from Chat
+        Completions (input_tokens vs prompt_tokens, and cached_tokens
+        under input_tokens_details)."""
+        client = self._client(monkeypatch)
+        resp = self._ok_response()
+        resp.usage.input_tokens = 29000
+        resp.usage.output_tokens = 12000
+        resp.usage.input_tokens_details.cached_tokens = 28000
+        mock_inner = MagicMock()
+        mock_inner.responses.create.return_value = resp
+        self._wire(client, mock_inner)
+
+        result = client.complete("sys", "user")
+        assert result.input_tokens == 29000
+        assert result.output_tokens == 12000
+        assert result.cached_tokens == 28000
+        assert result.model == "gpt-5.6-sol#pro"
+
     def test_max_completion_tokens_sent_not_max_tokens(self, monkeypatch):
         """GPT-5.x reasoning families reject the legacy max_tokens kwarg."""
         client = self._client(monkeypatch, model="gpt-5.6-sol")
         mock_inner = MagicMock()
-        mock_inner.chat.completions.create.return_value = self._ok_response()
+        mock_inner.chat.completions.create.return_value = self._chat_response()
         self._wire(client, mock_inner)
         client.complete("sys", "user", max_tokens=4096)
         kwargs = mock_inner.chat.completions.create.call_args.kwargs
@@ -781,22 +853,22 @@ class TestOpenAIProRouting:
         assert "max_tokens" not in kwargs
 
     def test_pro_mode_floors_completion_budget(self, monkeypatch):
-        """Reasoning eats completion budget — pro floors to 16000 so
-        deliberation can't starve the output (validated live in S2)."""
+        """Reasoning eats output budget — pro floors to 16000 so
+        deliberation can't starve the answer."""
         client = self._client(monkeypatch)
         mock_inner = MagicMock()
-        mock_inner.chat.completions.create.return_value = self._ok_response()
+        mock_inner.responses.create.return_value = self._ok_response()
         self._wire(client, mock_inner)
         client.complete("sys", "user", max_tokens=4096)
-        kwargs = mock_inner.chat.completions.create.call_args.kwargs
-        assert kwargs["max_completion_tokens"] == 16000
+        kwargs = mock_inner.responses.create.call_args.kwargs
+        assert kwargs["max_output_tokens"] == 16000
 
     def test_pro_response_model_gets_mode_suffix(self, monkeypatch):
         """Both Sol variants report the same API id — the suffix makes
         JSONL rows self-describing."""
         client = self._client(monkeypatch)
         mock_inner = MagicMock()
-        mock_inner.chat.completions.create.return_value = self._ok_response()
+        mock_inner.responses.create.return_value = self._ok_response()
         self._wire(client, mock_inner)
         result = client.complete("sys", "user")
         assert result.model == "gpt-5.6-sol#pro"
@@ -804,7 +876,7 @@ class TestOpenAIProRouting:
     def test_default_response_model_unsuffixed(self, monkeypatch):
         client = self._client(monkeypatch, model="gpt-5.6-sol")
         mock_inner = MagicMock()
-        mock_inner.chat.completions.create.return_value = self._ok_response()
+        mock_inner.chat.completions.create.return_value = self._chat_response()
         self._wire(client, mock_inner)
         result = client.complete("sys", "user")
         assert result.model == "gpt-5.6-sol"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -86,7 +86,84 @@ class TestOpenAIClient:
             pytest.skip("openai package not installed")
 
 
+def _text_block(text: str):
+    """A TextBlock stand-in. `.type` matters — the real SDK discriminates
+    content blocks on it, and MagicMock's auto-attributes would hide a
+    bug that only shows up against the live API."""
+    block = MagicMock()
+    block.type = "text"
+    block.text = text
+    return block
+
+
+class _ThinkingBlock:
+    """A ThinkingBlock stand-in with **no** `.text` attribute, which is
+    what makes this faithful: the live failure was
+    "'ThinkingBlock' object has no attribute 'text'". A MagicMock would
+    have silently supplied one and reproduced nothing."""
+
+    type = "thinking"
+    thinking = "let me work through this"
+
+
+class TestAnthropicTextExtraction:
+    """Claude Fable 5 returns extended-thinking blocks ahead of the text,
+    so content[0] is not the answer (smoke S1, 2026-07-23)."""
+
+    def test_skips_leading_thinking_block(self):
+        from vera_bench.models import _anthropic_text
+
+        assert _anthropic_text([_ThinkingBlock(), _text_block("answer")]) == "answer"
+
+    def test_plain_text_response(self):
+        from vera_bench.models import _anthropic_text
+
+        assert _anthropic_text([_text_block("answer")]) == "answer"
+
+    def test_joins_multiple_text_blocks(self):
+        from vera_bench.models import _anthropic_text
+
+        blocks = [_ThinkingBlock(), _text_block("part one "), _text_block("part two")]
+        assert _anthropic_text(blocks) == "part one part two"
+
+    def test_unknown_block_types_ignored(self):
+        from vera_bench.models import _anthropic_text
+
+        redacted = MagicMock()
+        redacted.type = "redacted_thinking"
+        assert _anthropic_text([redacted, _text_block("answer")]) == "answer"
+
+    @pytest.mark.parametrize("content", [[], None, [_ThinkingBlock()]])
+    def test_no_text_block_yields_empty_string(self, content):
+        from vera_bench.models import _anthropic_text
+
+        assert _anthropic_text(content) == ""
+
+
 class TestAnthropicComplete:
+    def test_thinking_response_does_not_crash(self, monkeypatch):
+        """End-to-end regression for the Fable 5 failure."""
+        try:
+            import anthropic  # noqa: F401
+
+            from vera_bench.models import AnthropicClient
+        except ImportError:
+            pytest.skip("anthropic not installed")
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        client = AnthropicClient("claude-fable-5")
+
+        mock_resp = MagicMock()
+        mock_resp.content = [_ThinkingBlock(), _text_block("def f(): pass")]
+        mock_resp.usage.input_tokens = 100
+        mock_resp.usage.output_tokens = 50
+        mock_resp.usage.cache_creation_input_tokens = 0
+        mock_resp.usage.cache_read_input_tokens = 0
+        mock_resp.model = "claude-fable-5"
+        client._client.messages.create = MagicMock(return_value=mock_resp)
+
+        assert client.complete("system", "user").text == "def f(): pass"
+
     def test_complete_mock(self, monkeypatch):
         """Test Anthropic complete with a mocked SDK."""
         try:
@@ -101,7 +178,7 @@ class TestAnthropicComplete:
         client = AnthropicClient("claude-test")
 
         mock_resp = MagicMock()
-        mock_resp.content = [MagicMock(text="hello")]
+        mock_resp.content = [_text_block("hello")]
         mock_resp.usage.input_tokens = 100
         mock_resp.usage.output_tokens = 50
         mock_resp.usage.cache_creation_input_tokens = 0
@@ -645,14 +722,20 @@ class TestOpenAIProRouting:
         with pytest.raises(ValueError, match="Unknown model"):
             create_client("mystery/some-model")
 
-    def test_reasoning_mode_sent_in_extra_body(self, monkeypatch):
+    def test_pro_sends_reasoning_effort_kwarg(self, monkeypatch):
+        """Chat Completions takes `reasoning_effort`, not a nested
+        `reasoning` object — the latter is the Responses-API shape and
+        is rejected with 400 "Unknown parameter: 'reasoning'" (smoke
+        S2, 2026-07-23). "pro" is our name; the API ceiling is "max"."""
         client = self._client(monkeypatch)
         mock_inner = MagicMock()
         mock_inner.chat.completions.create.return_value = self._ok_response()
         self._wire(client, mock_inner)
         client.complete("sys", "user")
         kwargs = mock_inner.chat.completions.create.call_args.kwargs
-        assert kwargs["extra_body"]["reasoning"] == {"mode": "pro"}
+        assert kwargs["reasoning_effort"] == "max"
+        assert "reasoning" not in kwargs
+        assert "reasoning" not in kwargs["extra_body"]
         # Cache key still rides alongside (#61)
         assert "prompt_cache_key" in kwargs["extra_body"]
 
@@ -663,7 +746,28 @@ class TestOpenAIProRouting:
         self._wire(client, mock_inner)
         client.complete("sys", "user")
         kwargs = mock_inner.chat.completions.create.call_args.kwargs
+        assert "reasoning_effort" not in kwargs
         assert "reasoning" not in kwargs["extra_body"]
+
+    def test_reasoning_effort_is_a_value_the_api_accepts(self, monkeypatch):
+        """Guard against inventing a value the SDK's Literal rejects."""
+        from typing import get_args
+
+        from openai.types.shared.reasoning_effort import ReasoningEffort
+
+        from vera_bench.models import REASONING_MODE_EFFORT
+
+        valid = {v for v in get_args(get_args(ReasoningEffort)[0]) if v}
+        assert set(REASONING_MODE_EFFORT.values()) <= valid
+
+    def test_unmapped_reasoning_mode_raises(self, monkeypatch):
+        """Silently dropping the parameter would make the 'pro' entry run
+        at default effort — a comparison of a model against itself."""
+        from vera_bench.models import OpenAIClient
+
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        with pytest.raises(ValueError, match="Unknown reasoning mode"):
+            OpenAIClient("gpt-5.6-sol", reasoning_mode="ultra")
 
     def test_max_completion_tokens_sent_not_max_tokens(self, monkeypatch):
         """GPT-5.x reasoning families reject the legacy max_tokens kwarg."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -135,6 +135,13 @@ class TestAnthropicTextExtraction:
 
     @pytest.mark.parametrize("content", [[], None, [_ThinkingBlock()]])
     def test_no_text_block_yields_empty_string(self, content):
+        """The helper reports absence; `complete` decides what it means.
+
+        See TestAnthropicComplete.test_thinking_only_response_raises —
+        returning "" here is correct, but letting "" reach the harness
+        is not: it would be scored as the model failing to define an
+        entry point when the fault is API-side.
+        """
         from vera_bench.models import _anthropic_text
 
         assert _anthropic_text(content) == ""
@@ -163,6 +170,33 @@ class TestAnthropicComplete:
         client._client.messages.create = MagicMock(return_value=mock_resp)
 
         assert client.complete("system", "user").text == "def f(): pass"
+
+    def test_thinking_only_response_raises(self, monkeypatch):
+        """A response with no TextBlock must not be scored as a model failure.
+
+        Realistic for the thinking models this release adds: truncate at
+        max_tokens while still inside a thinking block and the content
+        list holds no text at all. Returning "" would reach extract_code
+        and be recorded as "did not define entry point" — blaming the
+        model for an API-side non-answer. Mirrors the OpenAI guard.
+        """
+        try:
+            import anthropic  # noqa: F401
+
+            from vera_bench.models import AnthropicClient
+        except ImportError:
+            pytest.skip("anthropic not installed")
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        client = AnthropicClient("claude-fable-5")
+
+        mock_resp = MagicMock()
+        mock_resp.content = [_ThinkingBlock()]
+        mock_resp.stop_reason = "max_tokens"
+        client._client.messages.create = MagicMock(return_value=mock_resp)
+
+        with pytest.raises(RuntimeError, match="no text block"):
+            client.complete("system", "user")
 
     def test_complete_mock(self, monkeypatch):
         """Test Anthropic complete with a mocked SDK."""
@@ -747,6 +781,46 @@ class TestOpenAIProRouting:
         with pytest.raises(ValueError, match="Unknown model"):
             create_client("mystery/some-model")
 
+    @pytest.mark.parametrize(
+        ("model_id", "mode"),
+        [("openai-pro/gpt-5.6-sol", "pro"), ("gpt-5.6-sol", "standard")],
+    )
+    def test_both_arms_drive_their_own_mode(self, monkeypatch, model_id, mode):
+        """Drive BOTH halves of the controlled pair through complete().
+
+        Only the pro arm was exercised end-to-end, so hardcoding
+        `reasoning={"mode": "pro"}` passed the suite green — and that
+        would run *both* arms at pro, making the reasoning slide a
+        comparison of a model against itself. Same failure the
+        downgrade guard exists to catch, arriving from our side of the
+        wire instead of OpenAI's. The shared 16000 ceiling is asserted
+        for both arms too: an unequal budget is a second confound.
+        """
+        client = self._client(monkeypatch, model=model_id)
+        mock_inner = MagicMock()
+        mock_inner.responses.create.return_value = self._ok_response(mode=mode)
+        self._wire(client, mock_inner)
+
+        result = client.complete("sys", "user", max_tokens=4096)
+
+        mock_inner.chat.completions.create.assert_not_called()
+        kwargs = mock_inner.responses.create.call_args.kwargs
+        assert kwargs["reasoning"] == {"mode": mode}
+        assert kwargs["max_output_tokens"] == 16000
+        assert result.model == f"gpt-5.6-sol#{mode}"
+
+    def test_budget_floor_does_not_cap_a_larger_request(self, monkeypatch):
+        """`max(max_tokens, 16000)` — not a bare 16000, which would
+        silently cap an explicit --max-tokens above the floor."""
+        client = self._client(monkeypatch)
+        mock_inner = MagicMock()
+        mock_inner.responses.create.return_value = self._ok_response()
+        self._wire(client, mock_inner)
+        client.complete("sys", "user", max_tokens=32000)
+        assert (
+            mock_inner.responses.create.call_args.kwargs["max_output_tokens"] == 32000
+        )
+
     def test_pro_routes_to_responses_api(self, monkeypatch):
         """`reasoning.mode` exists only on the Responses API. Chat
         Completions rejects it (400 "Unknown parameter: 'reasoning'"),
@@ -813,6 +887,27 @@ class TestOpenAIProRouting:
         with pytest.raises(ValueError, match="Unknown reasoning mode"):
             OpenAIClient("gpt-5.6-sol", reasoning_mode="ultra")
 
+    @pytest.mark.parametrize("shape", ["mode_none", "reasoning_none"])
+    def test_unconfirmed_mode_raises(self, monkeypatch, shape):
+        """A server that ignored the parameter most likely does not echo it.
+
+        `reasoning` and `mode` are both Optional with None defaults, so
+        the likeliest wire signature of a silent downgrade is absence,
+        not a mismatched value — an `if effective and ...` guard would
+        short-circuit past exactly the case it exists to catch.
+        """
+        client = self._client(monkeypatch)
+        resp = self._ok_response()
+        if shape == "mode_none":
+            resp.reasoning.mode = None
+        else:
+            resp.reasoning = None
+        mock_inner = MagicMock()
+        mock_inner.responses.create.return_value = resp
+        self._wire(client, mock_inner)
+        with pytest.raises(RuntimeError, match="did not confirm"):
+            client.complete("sys", "user")
+
     def test_silent_downgrade_to_standard_raises(self, monkeypatch):
         """The response echoes the *effective* mode. If OpenAI quietly
         served standard, that must not be recorded as a pro result."""
@@ -820,7 +915,7 @@ class TestOpenAIProRouting:
         mock_inner = MagicMock()
         mock_inner.responses.create.return_value = self._ok_response(mode="standard")
         self._wire(client, mock_inner)
-        with pytest.raises(RuntimeError, match="not the requested 'pro'"):
+        with pytest.raises(RuntimeError, match="reported 'standard'"):
             client.complete("sys", "user")
 
     def test_empty_output_reports_budget_exhaustion(self, monkeypatch):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -809,6 +809,21 @@ class TestOpenAIProRouting:
         assert kwargs["max_output_tokens"] == 16000
         assert result.model == f"gpt-5.6-sol#{mode}"
 
+    def test_responses_opts_out_of_server_side_storage(self, monkeypatch):
+        """Responses defaults store=True; Chat Completions does not persist.
+
+        Retained prompts and completions could feed cross-run caching or
+        personalisation, which would make a second sweep not independent
+        of the first — a benchmark informed by its own previous run is
+        not measuring what it claims to.
+        """
+        client = self._client(monkeypatch)
+        mock_inner = MagicMock()
+        mock_inner.responses.create.return_value = self._ok_response()
+        self._wire(client, mock_inner)
+        client.complete("sys", "user")
+        assert mock_inner.responses.create.call_args.kwargs["store"] is False
+
     def test_budget_floor_does_not_cap_a_larger_request(self, monkeypatch):
         """`max(max_tokens, 16000)` — not a bare 16000, which would
         silently cap an explicit --max-tokens above the floor."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -708,7 +708,7 @@ class TestOpenAIProRouting:
         choice = MagicMock()
         choice.message.content = "code"
         resp.choices = [choice]
-        resp.model = "gpt-5.6-sol"
+        resp.model = "gpt-5.6-terra"
         resp.usage.prompt_tokens = 100
         resp.usage.completion_tokens = 5000
         resp.usage.prompt_tokens_details.cached_tokens = 0
@@ -726,8 +726,18 @@ class TestOpenAIProRouting:
         assert client._model == "gpt-5.6-sol"
         assert client._reasoning_mode == "pro"
 
-    def test_default_openai_has_no_reasoning_mode(self, monkeypatch):
+    def test_default_sol_pinned_to_standard_mode(self, monkeypatch):
+        """Sol's default entry is the other arm of the reasoning-budget
+        comparison, so it runs on the same endpoint as pro with an
+        explicit standard mode. Otherwise the two bars on the slide
+        differ by endpoint as well as by deliberation."""
         client = self._client(monkeypatch, model="gpt-5.6-sol")
+        assert client._reasoning_mode == "standard"
+
+    def test_non_paired_model_has_no_reasoning_mode(self, monkeypatch):
+        """Terra is a separate tier row, not half of a controlled pair —
+        it stays on Chat Completions."""
+        client = self._client(monkeypatch, model="gpt-5.6-terra")
         assert client._reasoning_mode is None
 
     def test_unknown_prefix_still_rejected(self, monkeypatch):
@@ -761,7 +771,7 @@ class TestOpenAIProRouting:
         assert "prompt_cache_key" in kwargs
 
     def test_default_mode_uses_chat_completions(self, monkeypatch):
-        client = self._client(monkeypatch, model="gpt-5.6-sol")
+        client = self._client(monkeypatch, model="gpt-5.6-terra")
         mock_inner = MagicMock()
         mock_inner.chat.completions.create.return_value = self._chat_response()
         self._wire(client, mock_inner)
@@ -843,7 +853,7 @@ class TestOpenAIProRouting:
 
     def test_max_completion_tokens_sent_not_max_tokens(self, monkeypatch):
         """GPT-5.x reasoning families reject the legacy max_tokens kwarg."""
-        client = self._client(monkeypatch, model="gpt-5.6-sol")
+        client = self._client(monkeypatch, model="gpt-5.6-terra")
         mock_inner = MagicMock()
         mock_inner.chat.completions.create.return_value = self._chat_response()
         self._wire(client, mock_inner)
@@ -874,12 +884,12 @@ class TestOpenAIProRouting:
         assert result.model == "gpt-5.6-sol#pro"
 
     def test_default_response_model_unsuffixed(self, monkeypatch):
-        client = self._client(monkeypatch, model="gpt-5.6-sol")
+        client = self._client(monkeypatch, model="gpt-5.6-terra")
         mock_inner = MagicMock()
         mock_inner.chat.completions.create.return_value = self._chat_response()
         self._wire(client, mock_inner)
         result = client.complete("sys", "user")
-        assert result.model == "gpt-5.6-sol"
+        assert result.model == "gpt-5.6-terra"
 
     def test_bare_openai_pro_prefix_rejected(self, monkeypatch):
         from vera_bench.models import create_client

--- a/vera_bench/__init__.py
+++ b/vera_bench/__init__.py
@@ -8,4 +8,4 @@ except PackageNotFoundError:
     # Fallback for development checkouts without `pip install -e .`.
     # Kept in sync with pyproject.toml `version`; the canonical source
     # is the installed package metadata above.
-    __version__ = "0.0.15"
+    __version__ = "0.0.16"

--- a/vera_bench/cli.py
+++ b/vera_bench/cli.py
@@ -359,7 +359,25 @@ def _print_metrics(model: str, metrics, language: str = "vera") -> None:
     if language in ("vera", "aver"):
         table.add_row("verify@1", _fmt_rate(metrics.verify_rate))
         table.add_row("fix@1", _fmt_rate(metrics.fix_rate))
-    table.add_row("run_correct", _fmt_rate(metrics.run_correct_rate))
+    # run_correct is measured over the problems that compiled, not over
+    # all of them, so state the denominator rather than leaving the
+    # reader to assume it is total_problems.
+    eligible = getattr(metrics, "run_eligible", 0)
+    run_cell = _fmt_rate(metrics.run_correct_rate)
+    if eligible and eligible != metrics.total_problems:
+        run_cell = f"{run_cell} ({eligible}/{metrics.total_problems} graded)"
+    table.add_row("run_correct", run_cell)
+
+    # Printed unconditionally when non-zero. A run where most calls died
+    # at the API otherwise looks entirely healthy: check@1 drops, which
+    # is a normal result for a model struggling with Vera, while
+    # run_correct rises because the failures left its denominator.
+    errored = getattr(metrics, "errored", 0)
+    if errored:
+        table.add_row(
+            "[red]errored[/red]",
+            f"[red]{errored}/{metrics.total_problems}[/red]",
+        )
 
     if metrics.by_tier:
         table.add_section()

--- a/vera_bench/cli.py
+++ b/vera_bench/cli.py
@@ -227,7 +227,13 @@ def run(
                 )
                 raise SystemExit(1)
             aver_ver = _parse_version_banner(_av_proc.stdout)
-        except (FileNotFoundError, _sp.TimeoutExpired):
+        except _sp.TimeoutExpired:
+            console.print(
+                "[red]Error: aver --version timed out after 5s. "
+                "Check your aver installation.[/red]"
+            )
+            raise SystemExit(1)
+        except FileNotFoundError:
             console.print(
                 "[red]Error: aver not found on PATH. "
                 "Install with: cargo install aver-lang[/red]"
@@ -255,7 +261,16 @@ def run(
                 )
                 raise SystemExit(1)
             ailang_ver = _parse_version_banner(_al_proc.stdout)
-        except (FileNotFoundError, _sp.TimeoutExpired):
+        except _sp.TimeoutExpired:
+            # Distinct from not-found: the binary exists but is wedged.
+            # Reporting "not on PATH" here sends you to reinstall
+            # something that is already installed.
+            console.print(
+                "[red]Error: ailang --version timed out after 5s. "
+                "Check your ailang installation.[/red]"
+            )
+            raise SystemExit(1)
+        except FileNotFoundError:
             console.print(
                 "[red]Error: ailang not found on PATH. "
                 "Install from https://github.com/sunholo-data/ailang[/red]"
@@ -303,7 +318,11 @@ def run(
         console.print(f"Vera:     v{vera_ver}")
     if ailang_ver:
         console.print(f"AILANG:   v{ailang_ver}")
-    console.print(f"Output:   {output_path}\n")
+    # soft_wrap: rich wraps at the console width (80 when not a tty, as
+    # in CI and when piping a sweep log to a file), which breaks a long
+    # result path across lines mid-token. The path is meant to be
+    # copy-pasteable and greppable, so let it overflow instead.
+    console.print(f"Output:   {output_path}\n", soft_wrap=True)
 
     # Run benchmark
     results = run_benchmark(
@@ -440,7 +459,11 @@ def baselines(language: str, output_dir: Path | None):
             raise SystemExit(1)
 
     console.print(f"Language: {language}")
-    console.print(f"Output:   {output_path}\n")
+    # soft_wrap: rich wraps at the console width (80 when not a tty, as
+    # in CI and when piping a sweep log to a file), which breaks a long
+    # result path across lines mid-token. The path is meant to be
+    # copy-pasteable and greppable, so let it overflow instead.
+    console.print(f"Output:   {output_path}\n", soft_wrap=True)
 
     # Run baselines
     results = run_all_baselines(

--- a/vera_bench/cli.py
+++ b/vera_bench/cli.py
@@ -276,12 +276,6 @@ def run(
                 "Install from https://github.com/sunholo-data/ailang[/red]"
             )
             raise SystemExit(1)
-        except _sp.TimeoutExpired:
-            console.print(
-                "[red]Error: `ailang --version` timed out after 5s. "
-                "Check for a hung ailang process or slow startup.[/red]"
-            )
-            raise SystemExit(1)
 
     # Set up output — dots to hyphens in versions for clean filenames
     def _ver_slug(v: str) -> str:

--- a/vera_bench/cli.py
+++ b/vera_bench/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import click
@@ -11,9 +12,28 @@ from rich.table import Table
 
 console = Console()
 
+_VERSION_RE = re.compile(r"\d+\.\d+(?:\.\d+)?")
+
 
 def _repo_root() -> Path:
     return Path(__file__).parent.parent
+
+
+def _parse_version_banner(raw: str) -> str:
+    """Pull a bare version number out of a compiler's --version output.
+
+    Banners vary in shape: `aver --version` prints a single line
+    (`aver 0.27.1`), while `ailang --version` prints seven — commit hash,
+    build stamp and copyright included. Only the first line carries the
+    version, and only the numeric token belongs in a result filename,
+    which is built by hyphen-joining these fragments. Returning the raw
+    banner puts newlines and spaces into that filename; callers treat
+    "unknown" as "omit the version from the name" instead.
+    """
+    stripped = raw.strip()
+    first_line = stripped.splitlines()[0] if stripped else ""
+    match = _VERSION_RE.search(first_line)
+    return match.group(0) if match else "unknown"
 
 
 @click.group()
@@ -206,7 +226,7 @@ def run(
                     "Check your aver installation.[/red]"
                 )
                 raise SystemExit(1)
-            aver_ver = _av_proc.stdout.strip().replace("aver ", "")
+            aver_ver = _parse_version_banner(_av_proc.stdout)
         except (FileNotFoundError, _sp.TimeoutExpired):
             console.print(
                 "[red]Error: aver not found on PATH. "
@@ -234,8 +254,8 @@ def run(
                     "Check your ailang installation.[/red]"
                 )
                 raise SystemExit(1)
-            ailang_ver = _al_proc.stdout.strip().replace("ailang ", "")
-        except FileNotFoundError:
+            ailang_ver = _parse_version_banner(_al_proc.stdout)
+        except (FileNotFoundError, _sp.TimeoutExpired):
             console.print(
                 "[red]Error: ailang not found on PATH. "
                 "Install from https://github.com/sunholo-data/ailang[/red]"

--- a/vera_bench/metrics.py
+++ b/vera_bench/metrics.py
@@ -25,6 +25,21 @@ class BenchmarkMetrics:
     fix_rate: float | None
     run_correct_rate: float | None
     by_tier: dict[int, TierMetrics]
+    # `run_correct_rate` is measured over `run_eligible`, not over
+    # `total_problems`: a problem whose attempt never compiled cannot be
+    # graded on output. That is defensible, but it means the denominator
+    # moves — and nothing else in this dataclass said so, so a run where
+    # most calls died at the API reported an excellent rate over the
+    # handful that survived. 40 API failures plus 20 successes read as
+    # run_correct 100%.
+    #
+    # These two fields exist to make that visible without changing the
+    # rate, which would break comparability with published results.
+    run_eligible: int = 0
+    errored: int = 0
+    """Problems whose best attempt carries an `error_message` — API
+    failures, auth rejections, timeouts. Counted separately from
+    "compiled but wrong", which is a real result."""
 
 
 def load_results(path: Path) -> list[dict]:
@@ -81,6 +96,7 @@ def compute_metrics(
     fix_eligible = 0
     run_correct_count = 0
     run_eligible = 0
+    errored = 0
 
     for pid, attempts in by_problem.items():
         attempt_1 = next((a for a in attempts if a.get("attempt") == 1), None)
@@ -108,6 +124,12 @@ def compute_metrics(
                 if vp:
                     verify_pass_count += 1
 
+        # An error_message on the best attempt means the problem never
+        # reached a verdict — it is absent from run_eligible below, so
+        # without this tally the shrinking denominator is invisible.
+        if best and best.get("error_message"):
+            errored += 1
+
         # run_correct (on best passing attempt)
         if best and best.get("check_pass"):
             rc = best.get("run_correct")
@@ -123,6 +145,8 @@ def compute_metrics(
         fix_rate=_rate(fix_success, fix_eligible),
         run_correct_rate=_rate(run_correct_count, run_eligible),
         by_tier=_compute_by_tier(by_problem),
+        run_eligible=run_eligible,
+        errored=errored,
     )
     return overall
 

--- a/vera_bench/models.py
+++ b/vera_bench/models.py
@@ -285,6 +285,20 @@ class AnthropicClient:
 
         elapsed = time.monotonic() - start
         text = _anthropic_text(response.content)
+        if not text:
+            # Mirrors _validate_openai_response_text. Without this, an
+            # empty string reaches extract_code and the row is recorded as
+            # "did not define entry point" — the model blamed for an
+            # API-side non-answer. Realistic for the thinking models this
+            # release adds: a response truncated mid-deliberation contains
+            # ThinkingBlocks and no TextBlock at all.
+            kinds = [getattr(b, "type", "?") for b in (response.content or [])]
+            raise RuntimeError(
+                f"Anthropic returned no text block for model={self._model!r} "
+                f"(stop_reason={getattr(response, 'stop_reason', 'unknown')}, "
+                f"blocks={kinds}). Extended thinking may have consumed the "
+                f"entire {max_tokens}-token budget — try raising --max-tokens."
+            )
         usage = response.usage
         cache_creation = getattr(usage, "cache_creation_input_tokens", 0) or 0
         cache_read = getattr(usage, "cache_read_input_tokens", 0) or 0
@@ -420,11 +434,20 @@ class OpenAIClient:
         # later from suspiciously-similar wall times. A pro entry that
         # actually ran standard would make the headline comparison a
         # model against itself, so it must not pass quietly.
+        # Absence must be as loud as mismatch. Both `reasoning` and `mode`
+        # are Optional with None defaults, so a server that did NOT apply
+        # the parameter most likely does not echo it either — and an
+        # `if effective and ...` guard short-circuits past precisely the
+        # case this exists to catch. The row is stamped "#pro" on the
+        # strength of this check, and the reasoning slide's entire claim
+        # rests on that suffix meaning something.
         effective = getattr(getattr(response, "reasoning", None), "mode", None)
-        if effective and effective != self._reasoning_mode:
+        if effective != self._reasoning_mode:
             raise RuntimeError(
-                f"OpenAI ran model={self._model!r} in reasoning mode "
-                f"{effective!r}, not the requested {self._reasoning_mode!r}"
+                f"OpenAI did not confirm the reasoning mode for "
+                f"model={self._model!r}: requested {self._reasoning_mode!r}, "
+                f"response reported {effective!r}. An unconfirmed mode must "
+                f"not be recorded as '#{self._reasoning_mode}'."
             )
 
         text = (response.output_text or "").strip()

--- a/vera_bench/models.py
+++ b/vera_bench/models.py
@@ -200,6 +200,33 @@ def create_client(model: str) -> LLMClient:
     )
 
 
+# Maps our user-facing reasoning-mode names onto the values the OpenAI
+# Chat Completions `reasoning_effort` parameter actually accepts
+# (none/minimal/low/medium/high/xhigh/max as of openai-python 2.47).
+# "pro" is our name for the ceiling tier; the API calls it "max".
+REASONING_MODE_EFFORT: dict[str, str] = {"pro": "max"}
+
+
+def _anthropic_text(content: object) -> str:
+    """Join the text blocks of an Anthropic response, skipping the rest.
+
+    Models with extended thinking return ThinkingBlock (and possibly
+    RedactedThinkingBlock) entries *ahead of* the TextBlock, so
+    `content[0]` is not the answer — Claude Fable 5 fails outright on a
+    blind `content[0].text` with "'ThinkingBlock' object has no
+    attribute 'text'". Blocks are matched on `.type` rather than
+    isinstance so a future SDK can add block kinds without breaking
+    this, and every text block is joined rather than just the first,
+    since nothing guarantees there is exactly one.
+    """
+    parts = [
+        getattr(block, "text", "") or ""
+        for block in (content or [])
+        if getattr(block, "type", None) == "text"
+    ]
+    return "".join(parts)
+
+
 class AnthropicClient:
     def __init__(self, model: str) -> None:
         try:
@@ -244,7 +271,7 @@ class AnthropicClient:
             raise TimeoutError(f"Anthropic API timed out: {e}") from e
 
         elapsed = time.monotonic() - start
-        text = response.content[0].text if response.content else ""
+        text = _anthropic_text(response.content)
         usage = response.usage
         cache_creation = getattr(usage, "cache_creation_input_tokens", 0) or 0
         cache_read = getattr(usage, "cache_read_input_tokens", 0) or 0
@@ -277,11 +304,27 @@ class OpenAIClient:
 
         self._client = openai.OpenAI(api_key=api_key)
         self._model = model.removeprefix("openai/")
-        # Reasoning mode (e.g. "pro" for gpt-5.6-sol's ceiling tier).
-        # Set by the openai-pro/ routing prefix in create_client; never
-        # via the runner (the complete() Protocol carries no per-call
-        # config — see the openai-pro design notes in the v0.0.16 plan).
+        # Reasoning tier for the ceiling ("pro") benchmark entry. Set by
+        # the openai-pro/ routing prefix in create_client; never via the
+        # runner (the complete() Protocol carries no per-call config —
+        # see the openai-pro design notes in the v0.0.16 plan).
+        #
+        # The user-facing name stays "pro" — it is baked into the model
+        # string, the result filenames and the talk slides — but the API
+        # has no such value. Chat Completions takes `reasoning_effort`
+        # from a fixed set (none/minimal/low/medium/high/xhigh/max), so
+        # "pro" maps to the ceiling, "max".
         self._reasoning_mode = reasoning_mode
+        self._reasoning_effort = REASONING_MODE_EFFORT.get(reasoning_mode or "")
+        if reasoning_mode and self._reasoning_effort is None:
+            # Failing loudly matters here: an unmapped mode would send no
+            # reasoning parameter at all, so the "pro" entry would quietly
+            # run at default effort and the pro-vs-default comparison would
+            # be a comparison of a model against itself.
+            raise ValueError(
+                f"Unknown reasoning mode {reasoning_mode!r}. "
+                f"Known modes: {sorted(REASONING_MODE_EFFORT)}"
+            )
 
     def complete(
         self,
@@ -300,13 +343,16 @@ class OpenAIClient:
 
         # Cache-shard routing for the shared system prefix, passed via
         # extra_body so it works on any 1.x SDK regardless of
-        # typed-kwarg support (#61). The reasoning mode rides the same
-        # channel ("reasoning.mode" per OpenAI's gpt-5.5-pro
-        # deprecation notice); smoke S2 verifies the exact accepted
-        # shape before the sweep.
+        # typed-kwarg support (#61).
         extra_body: dict = {"prompt_cache_key": _prompt_cache_key(system)}
-        if self._reasoning_mode:
-            extra_body["reasoning"] = {"mode": self._reasoning_mode}
+
+        # Reasoning goes in as the typed `reasoning_effort` kwarg. The
+        # nested `reasoning={"mode": ...}` shape belongs to the Responses
+        # API; Chat Completions rejects it outright with
+        # 400 "Unknown parameter: 'reasoning'" (smoke S2, 2026-07-23).
+        kwargs: dict = {}
+        if self._reasoning_effort:
+            kwargs["reasoning_effort"] = self._reasoning_effort
 
         start = time.monotonic()
         response = _call_openai_compatible(
@@ -322,6 +368,7 @@ class OpenAIClient:
                     {"role": "user", "content": user},
                 ],
                 extra_body=extra_body,
+                **kwargs,
             ),
             label="OpenAI",
             key_hint="OPENAI_API_KEY",

--- a/vera_bench/models.py
+++ b/vera_bench/models.py
@@ -200,11 +200,10 @@ def create_client(model: str) -> LLMClient:
     )
 
 
-# Maps our user-facing reasoning-mode names onto the values the OpenAI
-# Chat Completions `reasoning_effort` parameter actually accepts
-# (none/minimal/low/medium/high/xhigh/max as of openai-python 2.47).
-# "pro" is our name for the ceiling tier; the API calls it "max".
-REASONING_MODE_EFFORT: dict[str, str] = {"pro": "max"}
+# Reasoning execution modes, per the OpenAI Responses API `reasoning.mode`
+# field (Literal["standard", "pro"] in openai-python 2.47). This is a
+# different axis from `reasoning.effort` — see OpenAIClient.__init__.
+REASONING_MODES: frozenset[str] = frozenset({"standard", "pro"})
 
 
 def _anthropic_text(content: object) -> str:
@@ -304,27 +303,26 @@ class OpenAIClient:
 
         self._client = openai.OpenAI(api_key=api_key)
         self._model = model.removeprefix("openai/")
-        # Reasoning tier for the ceiling ("pro") benchmark entry. Set by
-        # the openai-pro/ routing prefix in create_client; never via the
-        # runner (the complete() Protocol carries no per-call config —
-        # see the openai-pro design notes in the v0.0.16 plan).
+        # Reasoning execution mode for the ceiling ("pro") benchmark
+        # entry. Set by the openai-pro/ routing prefix in create_client;
+        # never via the runner (the complete() Protocol carries no
+        # per-call config — see the v0.0.16 plan).
         #
-        # The user-facing name stays "pro" — it is baked into the model
-        # string, the result filenames and the talk slides — but the API
-        # has no such value. Chat Completions takes `reasoning_effort`
-        # from a fixed set (none/minimal/low/medium/high/xhigh/max), so
-        # "pro" maps to the ceiling, "max".
-        self._reasoning_mode = reasoning_mode
-        self._reasoning_effort = REASONING_MODE_EFFORT.get(reasoning_mode or "")
-        if reasoning_mode and self._reasoning_effort is None:
-            # Failing loudly matters here: an unmapped mode would send no
-            # reasoning parameter at all, so the "pro" entry would quietly
-            # run at default effort and the pro-vs-default comparison would
-            # be a comparison of a model against itself.
+        # `mode` and `effort` are INDEPENDENT axes: mode selects standard
+        # vs pro execution, effort controls how much reasoning happens
+        # within it. Pro mode exists only on the Responses API, so a
+        # client with a mode set routes there instead of Chat
+        # Completions. Chat Completions rejects the parameter outright
+        # (400 "Unknown parameter: 'reasoning'"), and mapping pro onto
+        # reasoning_effort="max" does not work either — gpt-5.6-sol
+        # rejects "max" on Chat Completions, and effort is the wrong axis
+        # regardless. Both verified live, 2026-07-23.
+        if reasoning_mode is not None and reasoning_mode not in REASONING_MODES:
             raise ValueError(
                 f"Unknown reasoning mode {reasoning_mode!r}. "
-                f"Known modes: {sorted(REASONING_MODE_EFFORT)}"
+                f"Known modes: {sorted(REASONING_MODES)}"
             )
+        self._reasoning_mode = reasoning_mode
 
     def complete(
         self,
@@ -340,19 +338,12 @@ class OpenAIClient:
         effective_max = max_tokens
         if self._reasoning_mode:
             effective_max = max(max_tokens, 16000)
+            return self._complete_responses(system, user, effective_max, timeout)
 
         # Cache-shard routing for the shared system prefix, passed via
         # extra_body so it works on any 1.x SDK regardless of
         # typed-kwarg support (#61).
         extra_body: dict = {"prompt_cache_key": _prompt_cache_key(system)}
-
-        # Reasoning goes in as the typed `reasoning_effort` kwarg. The
-        # nested `reasoning={"mode": ...}` shape belongs to the Responses
-        # API; Chat Completions rejects it outright with
-        # 400 "Unknown parameter: 'reasoning'" (smoke S2, 2026-07-23).
-        kwargs: dict = {}
-        if self._reasoning_effort:
-            kwargs["reasoning_effort"] = self._reasoning_effort
 
         start = time.monotonic()
         response = _call_openai_compatible(
@@ -368,7 +359,6 @@ class OpenAIClient:
                     {"role": "user", "content": user},
                 ],
                 extra_body=extra_body,
-                **kwargs,
             ),
             label="OpenAI",
             key_hint="OPENAI_API_KEY",
@@ -377,19 +367,73 @@ class OpenAIClient:
         elapsed = time.monotonic() - start
         text = _validate_openai_response_text(response, "OpenAI", self._model)
         usage = response.usage
-        # Both Sol variants report the same API model id — suffix the
-        # reasoning mode so JSONL rows are self-describing (filenames
-        # are already distinct via the CLI model string).
-        reported_model = response.model or self._model
-        if self._reasoning_mode:
-            reported_model = f"{reported_model}#{self._reasoning_mode}"
         return LLMResponse(
             text=text,
             input_tokens=_as_count(usage.prompt_tokens) if usage else 0,
             output_tokens=_as_count(usage.completion_tokens) if usage else 0,
             wall_time_s=round(elapsed, 2),
-            model=reported_model,
+            model=response.model or self._model,
             cached_tokens=_openai_cached_tokens(usage) if usage else 0,
+        )
+
+    def _complete_responses(
+        self, system: str, user: str, max_output: int, timeout: float
+    ) -> LLMResponse:
+        """Run through the Responses API, the only endpoint carrying
+        `reasoning.mode`. Chat Completions rejects the parameter."""
+        start = time.monotonic()
+        response = _call_openai_compatible(
+            lambda: self._client.with_options(timeout=timeout).responses.create(
+                model=self._model,
+                instructions=system,
+                input=user,
+                reasoning={"mode": self._reasoning_mode},
+                max_output_tokens=max_output,
+                prompt_cache_key=_prompt_cache_key(system),
+            ),
+            label="OpenAI",
+            key_hint="OPENAI_API_KEY",
+            model=self._model,
+        )
+        elapsed = time.monotonic() - start
+
+        # The response echoes the *effective* execution mode, so a silent
+        # downgrade to standard is detectable here rather than inferred
+        # later from suspiciously-similar wall times. A pro entry that
+        # actually ran standard would make the headline comparison a
+        # model against itself, so it must not pass quietly.
+        effective = getattr(getattr(response, "reasoning", None), "mode", None)
+        if effective and effective != self._reasoning_mode:
+            raise RuntimeError(
+                f"OpenAI ran model={self._model!r} in reasoning mode "
+                f"{effective!r}, not the requested {self._reasoning_mode!r}"
+            )
+
+        text = (response.output_text or "").strip()
+        if not text:
+            detail = getattr(response, "incomplete_details", None)
+            reason = getattr(detail, "reason", None) or getattr(
+                response, "status", "unknown"
+            )
+            raise ValueError(
+                f"OpenAI returned no output text for model={self._model!r} "
+                f"(status/reason: {reason}). Reasoning may have consumed the "
+                f"entire {max_output}-token budget."
+            )
+
+        usage = response.usage
+        details = getattr(usage, "input_tokens_details", None) if usage else None
+        # Both Sol variants report the same API model id — suffix the
+        # reasoning mode so JSONL rows are self-describing (filenames
+        # are already distinct via the CLI model string).
+        reported = f"{response.model or self._model}#{self._reasoning_mode}"
+        return LLMResponse(
+            text=text,
+            input_tokens=_as_count(getattr(usage, "input_tokens", 0)) if usage else 0,
+            output_tokens=_as_count(getattr(usage, "output_tokens", 0)) if usage else 0,
+            wall_time_s=round(elapsed, 2),
+            model=reported,
+            cached_tokens=_as_count(getattr(details, "cached_tokens", 0)),
         )
 
 

--- a/vera_bench/models.py
+++ b/vera_bench/models.py
@@ -205,6 +205,20 @@ def create_client(model: str) -> LLMClient:
 # different axis from `reasoning.effort` — see OpenAIClient.__init__.
 REASONING_MODES: frozenset[str] = frozenset({"standard", "pro"})
 
+# Models routed to the Responses API even without an explicit mode.
+#
+# This exists to keep the reasoning-budget comparison controlled.
+# `openai-pro/gpt-5.6-sol` can ONLY run on Responses (pro mode is
+# Responses-only), so if its default-mode counterpart ran on Chat
+# Completions the two arms would differ by endpoint as well as by mode —
+# and the slide claims the difference is deliberation. Pinning both Sol
+# entries here makes mode the only variable.
+#
+# Deliberately not every OpenAI model: gpt-5.6-terra is a separate tier
+# row, not half of a controlled pair, and leaving it on Chat Completions
+# avoids re-verifying a path that already works.
+RESPONSES_API_MODELS: frozenset[str] = frozenset({"gpt-5.6-sol"})
+
 
 def _anthropic_text(content: object) -> str:
     """Join the text blocks of an Anthropic response, skipping the rest.
@@ -322,6 +336,8 @@ class OpenAIClient:
                 f"Unknown reasoning mode {reasoning_mode!r}. "
                 f"Known modes: {sorted(REASONING_MODES)}"
             )
+        if reasoning_mode is None and self._model in RESPONSES_API_MODELS:
+            reasoning_mode = "standard"
         self._reasoning_mode = reasoning_mode
 
     def complete(
@@ -331,10 +347,12 @@ class OpenAIClient:
         max_tokens: int = 4096,
         timeout: float = 120.0,
     ) -> LLMResponse:
-        # Reasoning consumes completion budget on reasoning models —
-        # a 4096 default can be all deliberation and no output at the
-        # pro tier. Floor the budget when a reasoning mode is active;
-        # smoke test S2 validates against truncation.
+        # Reasoning consumes output budget on reasoning models — a 4096
+        # default can be all deliberation and no answer at the pro tier.
+        # The floor applies to standard mode too, not just pro: both arms
+        # of the reasoning-budget comparison must get the same ceiling,
+        # or the delta measures the budget as well as the mode. Smoke S2
+        # validates against truncation.
         effective_max = max_tokens
         if self._reasoning_mode:
             effective_max = max(max_tokens, 16000)

--- a/vera_bench/models.py
+++ b/vera_bench/models.py
@@ -422,6 +422,14 @@ class OpenAIClient:
                 reasoning={"mode": self._reasoning_mode},
                 max_output_tokens=max_output,
                 prompt_cache_key=_prompt_cache_key(system),
+                # Responses defaults store=True; Chat Completions does not
+                # persist at all. Opting out keeps repeat sweeps mutually
+                # independent — retained prompts and completions could feed
+                # cross-run caching or personalisation, and a benchmark whose
+                # second run is informed by its first is not measuring what
+                # it claims to. (It also keeps 60 problems' worth of prompts
+                # and generated code off the provider's servers.)
+                store=False,
             ),
             label="OpenAI",
             key_hint="OPENAI_API_KEY",

--- a/vera_bench/prompts.py
+++ b/vera_bench/prompts.py
@@ -23,7 +23,7 @@ AVER_LLMS_TXT_URL = "https://averlang.dev/llms.txt"
 # to retrieve the canonical, version-locked prompt content for the
 # installed AILANG version. No URL fetching required.
 
-_USER_AGENT = "vera-bench/0.0.15"
+_USER_AGENT = "vera-bench/0.0.16"
 
 
 def _fetch_url(url: str, *, timeout: int = 10) -> str:

--- a/vera_bench/runner.py
+++ b/vera_bench/runner.py
@@ -137,8 +137,16 @@ def _evaluate_code(
         result["run_correct"] = None
         return result
 
+    # The Aver and AILANG evaluators capture the first run failure's
+    # diagnostic (issue #72); the Vera path — the headline number — did
+    # not, so a compiler crash was indistinguishable in JSONL from a
+    # model writing a wrong program: error_message=None, check_pass=True,
+    # run_correct=False. That is not hypothetical here. vera SIGBUS'd
+    # repeatedly on 2026-07-23 (aallan/vera#1145) and every one of those
+    # would have been recorded as the model's fault.
     all_pass = True
-    for tc in test_cases:
+    last_run_error: str | None = None
+    for i, tc in enumerate(test_cases):
         if not isinstance(tc, dict):
             continue
         args = tc.get("args", [])
@@ -146,18 +154,44 @@ def _evaluate_code(
         result["tests_total"] += 1
         try:
             run = vera.run_fn(file_path, entry_point, args if args else None)
-            if run.exit_code != 0:
-                all_pass = False
-                continue
+        except subprocess.TimeoutExpired:
+            all_pass = False
+            if last_run_error is None:
+                last_run_error = _first_run_error(i, None, "vera")
+            continue
+        except Exception as e:  # noqa: BLE001 - recorded, not swallowed
+            # Bare-except-with-no-message was the original defect: an
+            # OSError spawning the subprocess, a UnicodeDecodeError on
+            # stdout, a TypeError in normalize_output — all scored as
+            # "the model wrote a wrong program".
+            all_pass = False
+            if last_run_error is None:
+                last_run_error = f"test {i}: {type(e).__name__}: {e}"
+            continue
+
+        if run.exit_code != 0:
+            all_pass = False
+            if last_run_error is None:
+                last_run_error = _vera_run_error(i, run)
+            continue
+
+        try:
             actual, expected_str = normalize_output(run.stdout, expected)
-            if actual == expected_str:
-                result["tests_passed"] += 1
-            else:
-                all_pass = False
-        except Exception:
+        except Exception as e:  # noqa: BLE001 - recorded, not swallowed
+            all_pass = False
+            if last_run_error is None:
+                last_run_error = f"test {i}: output comparison failed: {e}"
+            continue
+
+        if actual == expected_str:
+            result["tests_passed"] += 1
+        else:
             all_pass = False
 
     result["run_correct"] = all_pass
+    # Don't clobber a check/verify diagnostic already recorded above.
+    if last_run_error and not result.get("error_message"):
+        result["error_message"] = last_run_error
     return result
 
 
@@ -429,6 +463,29 @@ def _first_run_error(
     if err:
         return f"test {i}: {err}"
     return f"test {i}: exit {proc.returncode} (no output)"
+
+
+def _vera_run_error(i: int, run) -> str:
+    """Format a failed `vera run` for `error_message`.
+
+    Sibling of :func:`_first_run_error` for `VeraRunner.RunResult`, which
+    carries `exit_code` rather than `returncode`.
+
+    The negative-exit_code branch is the one that matters: `subprocess`
+    reports a signal death as `-N`, so a compiler SIGBUS (signal 10)
+    arrives as `exit_code == -10`. Without naming it, that reads as an
+    ordinary non-zero exit — which is to say, as the model's fault.
+    """
+    if run.exit_code < 0:
+        detail = (run.stderr or run.stdout or "").strip()[:300]
+        return (
+            f"test {i}: vera run killed by signal {-run.exit_code}"
+            f"{' — ' + detail if detail else ''}"
+        )
+    err = (run.stderr or run.stdout or "").strip()[:400]
+    if err:
+        return f"test {i}: {err}"
+    return f"test {i}: vera run exit {run.exit_code} (no output)"
 
 
 def _evaluate_aver_code(


### PR DESCRIPTION
## Summary

The last PR of the v0.0.16 batch: the 8-model / 3-tier chart work, plus the version bump and CHANGELOG promotion. **Merges last.**

It also carries four harness fixes that the preflight gate turned up — three of which would have silently corrupted the sweep rather than failing it.

## What preflight found

The gate was meant to confirm five model ids. It did that (all present, plus `gpt-5.6-luna` as an unplanned substitution candidate), and then found real bugs:

### 1. Claude Fable 5 returned no code at all

`AnthropicClient.complete` read `response.content[0].text`. Models with extended thinking return `ThinkingBlock` entries *ahead of* the `TextBlock`, so every Fable 5 call died with `'ThinkingBlock' object has no attribute 'text'`. **The entire fable tier would have come back empty.**

The existing unit test missed it because `mock_resp.content = [MagicMock(text="hello")]` — a `MagicMock` invents the very attribute whose absence is the bug. The new double is a plain class with no `.text`.

### 2. `openai-pro/` went to the wrong endpoint

Sol@pro was sending `extra_body={"reasoning": {"mode": "pro"}}` to Chat Completions, which rejects it: `400 Unknown parameter: 'reasoning'`.

Per OpenAI's reasoning guide, **mode and effort are independent axes** — mode selects standard vs pro *execution*, effort controls how much reasoning happens — and `reasoning.mode` exists only on the Responses API. Pro is not expressible on Chat Completions at all; `reasoning_effort="max"` is rejected too (`gpt-5.6-sol` takes only `none`/`low`/`medium`/`high`/`xhigh` there).

This confirms the CodeRabbit finding on #92 that was declined pending evidence. The evidence arrived.

**Both Sol entries are now pinned to the Responses API**, the default one sending an explicit `reasoning.mode: "standard"`, with the same 16000-token output floor. Pro mode is Responses-only, so leaving the default arm on Chat Completions would have varied endpoint *and* mode together — and the reasoning-budget slide claims its delta is deliberation. Terra is a separate tier row rather than half of a controlled pair, and stays on Chat Completions.

Verified live: `wall ×1.3, output tokens ×3.2`, `VERDICT: pro ENGAGED`, rows self-describing as `gpt-5.6-sol#standard` / `gpt-5.6-sol#pro`.

### 3. AILANG version parsing corrupted result filenames

`ailang --version` prints a **seven-line** banner. The old `.strip().replace("ailang ", "")` matched nothing in it (the binary prints `AILANG v0.30.0`, capitalised), so the whole banner flowed into the result filename — 216 characters with embedded newlines. macOS creates that file happily, so every `results/*bench-0-0-16*` glob, the `file_prefix` matching here, and the release tarball would have silently missed the AILANG results.

Never caught because `baselines --language ailang` uses a separate path that doesn't embed versions; `run --language ailang` had never been exercised end-to-end.

### 4. Long paths wrapped mid-token in console output

`Output: <path>` went through rich, which wraps at width 80 when stdout isn't a tty — CI, and any sweep log piped to a file. This was already failing `test_run_ailang_full_path_success` **on `main`**.

## WS8 — charts

`ModelSpec.tier` was a **strict binary**: `extract_data` did `(flagship if tier == "flagship" else sonnet)`. With `fable`/`opus`/`sonnet`, all 8 models would have piled into `sonnet` and the top-left panel would have rendered blank — a wrong chart, not a crash.

- `extract_data` returns `dict[tier_key, dict]`, ordered by `TIER_TITLES`, skipping unpopulated tiers.
- Row 1 renders one panel per populated tier — 3 for the new matrix, 2 for historical data.
- `plot_slide.py` updated in lockstep; the frozen `MODELS_V_0_0_7` path is preserved.
- **AILANG is now plottable** — it had zero references in either plot script.

**All 8 `file_prefix` values verified against real result filenames** (the README's own rule), by running the chart's actual `_find_result_file` globs over the preflight output: 15 of 15 discovered, none missed, no prefix unmatched. The one that mattered is `gpt-5.6-sol` vs `openai-pro-gpt-5.6-sol` — one prefix is a proper substring of the other, and they resolve to their correct distinct files.

### Two new talk slides

- **`ztd`** — zero-training-data: Vera vs Aver vs AILANG.
- **`reasoning`** — Sol@default vs Sol@pro across every mode. This exists because the comparison the matrix was *designed around* had nowhere to be seen: in the doc chart the two Sol entries sit in **different tier panels**.

## WS7 — config, and `preflight.sh`

- `run_full_benchmark.py` MODELS → the 8-model lineup.
- `smoke_v0016.sh` → **`scripts/preflight.sh`**, promoted from one-off to documented tooling. The model list is no longer duplicated: `s0` and `s1` read it from `run_full_benchmark.py` (including `_detect_provider`), so a model added to the sweep is gated automatically instead of silently skipped.
- **Corrected a dangerous doc bug**: `scripts/README.md` claimed "the harness auto-resumes: rerunning the same invocation skips problems that already have a passing attempt". It does not — `run` *unlinks* the output file at startup. Anyone trusting that during a crashed sweep would have silently lost a target.

## WS9 — release artifacts

Version bumped in all three locations; CHANGELOG `[Unreleased]` → `[0.0.16]` with compare links. Reinstalled and confirmed `vera-bench --version` = `0.0.16` with no stale `0-0-16` files.

No ROADMAP change: all 18 unticked items checked, none completed by this release. The near miss is "Expand provider coverage", which names Mistral, xAI Grok, DeepSeek and Gemini — we added models from providers already supported. #72 was ticked by #90; #61 has no ROADMAP line.

## Validation

- ✅ 654 tests, ruff clean
- ✅ preflight S0/S1/S2/S5 green against live APIs
- ✅ chart globs verified against real filenames
- ✅ regression: `--version 0.0.7` and `0.0.9` renders unchanged
- ✅ synthetic 40-file v0.0.16 dataset renders all charts, including the deliberately-incomplete fable row

## Closes

Closes #95 — `run_correct` silently rebasing its denominator. Fixed here rather than deferred: the fix is additive (the rate is unchanged; `run_eligible` and `errored` make the shrinkage visible), and the sweep it endangers is the next step.

## Known, not blocking

`cached_tokens` read 0 on a 29k-token second call. The accessor matches the SDK exactly (`usage.prompt_tokens_details.cached_tokens`) and the system prompt is problem-independent, so the prefix is genuinely cacheable — most likely the cache hadn't warmed between two calls ~30 s apart. One data point; the canary (60 problems back-to-back) is the real test, and I'll check it before trusting any cost estimate that assumes cache discounts.

Separately, [aallan/vera#1145](https://github.com/aallan/vera/issues/1145) — `vera` can `SIGBUS` on an unchecked ctypes read of WASM memory. Not triggered by the benchmark path (validate over 60 problems and four preflight runs were clean; it's the unit tests that hit it), but worth landing before the overnight sweep since a crash arrives as a plausible data row rather than an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenAI reasoning-mode support with Responses API routing and pro-mode validation.
  * Added AILANG as a selectable comparison mode, including tier-based charts and new ZTD/reasoning slide types.
  * Introduced a preflight gate workflow for safer large benchmark runs.
* **Bug Fixes**
  * Fixed Anthropic “thinking” block handling and improved multi-block text extraction.
  * Improved output-path display wrapping and made version-banner parsing filename-safe.
* **Documentation**
  * Updated version/model guidance and clarified “no resume” behaviour.
* **Tests**
  * Expanded CLI parsing and model-routing/usage test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
