### PR TITLE
chore: gitignore results/logs/ for co-located sweep console logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ assets/vera-bench_slide_*.png
 
 # AILANG runtime cache (created by `ailang run` in solutions/ailang/)
 solutions/ailang/.ailang/
+
+# Sweep console logs (SKILL.md hash provenance, timing, errors) —
+# co-located with the results they describe, never committed.
+results/logs/


### PR DESCRIPTION
Sweep console logs carry the per-run SKILL.md hash — the provenance the live-fetch methodology depends on — plus timing and any errors that never reach the JSONL. Co-locating them under `results/logs/` keeps each sweep self-contained.

But `.gitignore` only covered `results/*.jsonl`, `results/summary.md` and `results/timing.json` — **not** the directory — so a `.log` dropped in `results/logs/` was trackable, and a `git add -A` mid-sweep would have committed it. This adds the one rule that closes that.

No code, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ignore rules to exclude generated result logs and related console artefacts from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->