### PR TITLE
errored counts grading gaps, not model runtime-failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`errored` counted model runtime-failures as harness errors.** The
+  metric added in [#95](https://github.com/aallan/vera-bench/issues/95)
+  tallied every row carrying an `error_message`. But the Vera evaluator
+  now records the runtime diagnostic for a contract violation, a
+  division by zero, a stack overflow — code that *compiled and ran* and
+  was graded `run_correct=False`. Those are model failures already in
+  the denominator, not the grading gaps `errored` exists to surface. It
+  now counts only rows that produced no run verdict
+  (`run_correct is None`). The v0.1.7 canary showed the bug directly:
+  `errored 1/60` and `3/60` on healthy runs whose only "errors" were the
+  model failing hard problems at runtime — after the fix, both are 0,
+  with `run_correct` unchanged. `errored` is a derived metric, so
+  re-running `vera-bench report` corrects already-swept files.
 - **Moonshot cache hits were always recorded as zero.** `_openai_cached_tokens`
   read only `usage.prompt_tokens_details.cached_tokens` — the OpenAI *nested*
   location — but Moonshot reports it at the **top level**, `usage.cached_tokens`

--- a/tests/test_metrics_errored.py
+++ b/tests/test_metrics_errored.py
@@ -69,6 +69,37 @@ class TestErroredAccounting:
         assert m.run_eligible == 60
         assert m.run_correct_rate == 0.0
 
+    def test_runtime_exception_is_a_model_failure_not_an_error(self):
+        """The canary case (2026-07-24). The Vera evaluator records the
+        runtime diagnostic for a contract violation / div-by-zero / stack
+        overflow, so these rows carry an error_message — but the code
+        compiled (check=True), ran, and was graded run_correct=False. That
+        is a model failure counted in run_correct, not a grading gap.
+        Counting it as `errored` conflated a legitimate failure with a
+        harness problem and put an alarming non-zero on a healthy run."""
+        rows = [
+            _row(
+                "VB-T5-009",
+                check=True,
+                run=False,
+                err="test 0: Precondition violation in state_max$where$loop ...",
+            ),
+            _row(
+                "VB-T3-011",
+                check=True,
+                run=False,
+                err="test 2: Integer division by zero in safe_divide ...",
+            ),
+        ]
+        # ...alongside genuine grading gaps, which MUST still count.
+        rows += [
+            _row("VB-T1-001", check=False, run=None, err="API error: 401"),
+        ]
+        m = compute_metrics(rows)
+        assert m.errored == 1  # only the API failure, not the two runtime fails
+        assert m.run_eligible == 2  # the two that compiled and ran
+        assert m.run_correct_rate == 0.0  # both ran and failed
+
 
 class TestVeraRunDiagnostics:
     """`vera run` failures must be attributable (#72 reached Aver and

--- a/vera_bench/metrics.py
+++ b/vera_bench/metrics.py
@@ -124,10 +124,17 @@ def compute_metrics(
                 if vp:
                     verify_pass_count += 1
 
-        # An error_message on the best attempt means the problem never
-        # reached a verdict — it is absent from run_eligible below, so
-        # without this tally the shrinking denominator is invisible.
-        if best and best.get("error_message"):
+        # `errored` counts the grading GAP — problems that carried an
+        # error and produced no run verdict, so they silently dropped out
+        # of run_eligible (API failure, timeout, compile failure). It must
+        # NOT count a problem that got a verdict: the Vera evaluator now
+        # records the runtime diagnostic for a contract violation, a
+        # division by zero, a stack overflow — but that code compiled and
+        # ran and was graded run_correct=False. That is a model failure,
+        # already in the denominator, not a gap. `run_correct is None`
+        # (never reached a verdict) is the discriminator, not the mere
+        # presence of an error_message.
+        if best and best.get("error_message") and best.get("run_correct") is None:
             errored += 1
 
         # run_correct (on best passing attempt)


### PR DESCRIPTION
## Summary

The v0.1.7 canary caught this — exactly what a canary is for.

`claude-sonnet-5` reported `errored 1/60` (full-spec) and `errored 3/60` (spec-from-nl) on runs that were otherwise healthy: `run_correct` 97% / 89%, all files written, SKILL.md hash consistent. Reading the rows, **every "error" was the model's own code failing at runtime**:

| problem | mode | what the model did wrong |
|---|---|---|
| VB-T5-009 | full-spec | precondition violation in a `where` loop |
| VB-T3-011 | spec-from-nl | integer division by zero — no `requires(divisor != 0)` |
| VB-T4-002 | spec-from-nl | WASM stack exhausted — non-terminating `gcd` |
| VB-T5-003 | spec-from-nl | postcondition violation |

`check=True, run=False` for all four. The code compiled, ran, and was graded `run_correct=False`. **These are model failures, already in the denominator** — in spec-from-nl especially, writing an unsafe contract is precisely the failure that mode measures.

## The bug

An interaction between two of my own recent changes:

1. The Vera runtime-diagnostics work (the #72 pattern finally reaching the Vera path) now records the runtime diagnostic into `error_message`.
2. [#95](https://github.com/aallan/vera-bench/issues/95)'s `errored` counter tallies **any** row with an `error_message`.

So a runtime failure — which #95 never meant to count — now shows up as `errored`. Its own comment gives the intent away: *"never reached a verdict — absent from run_eligible"*. A `run=False` row **did** reach a verdict and **is** in `run_eligible`.

## Fix

`errored` now counts only rows that produced **no run verdict** (`run_correct is None`) — the genuine grading gap: API failure, timeout, compile failure. A row with a verdict, however it went, is not a gap.

Verified over the real canary JSONL:

```
claude-sonnet-5               run_correct=0.9722  errored: 1 -> 0
claude-sonnet-5-spec-from-nl  run_correct=0.8889  errored: 3 -> 0
```

`run_correct` is **unchanged** — the fix touches only the `errored` label, never the score.

## Not a version bump, and it self-heals

`errored` is a *derived* metric (`compute_metrics` over stored rows), so re-running `vera-bench report` recomputes it — **files already on disk get the corrected count for free**, including the canary and anything swept before this merges. `run_correct` / `check@1` / `verify@1` are untouched. Lands under `[Unreleased]`.

## Tests

Adds the case my #95 tests missed: a runtime-exception row (`error_message` set, `check=True`, `run=False`) must **not** be `errored`, while a genuine `API error` row in the same batch still is. 673 green, ruff clean.

## Why this matters before the full sweep

The sweep is unattended and overnight. Without this, every healthy run where a model fails a few hard problems at runtime shows a non-zero `errored` — a false alarm at 2am, and a misleading number on a talk slide. The sweep *data* is valid either way (this is derived), but the live displays should tell the truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected error metrics so model runtime failures are graded as incorrect runs rather than harness errors.
  * Updated `errored` counts to include only cases without a run verdict.
  * Ensured run eligibility and correctness rates accurately reflect runtime failures.
  * Existing reports can be corrected by re-running the reporting command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->