### PR TITLE
matrix: add Claude Opus 5 (head-to-head vs Opus 4.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Claude Opus 5 in the model matrix.** Added alongside `claude-opus-4-8`
+  (same `opus` tier, same zero-training-data targets) for a same-day
+  head-to-head — Opus 5 shipped 2026-07-24. `vera_bench/matrix.py` grows to
+  nine models; the sweep, the preflight gate and the charts pick it up from
+  the registry with no other change.
 - **`scripts/sweep_status.py` / `scripts/rerun_failed.py` — sweep
   visibility and surgical repair.** `vera-bench run`'s `rich` progress
   blanks itself off-TTY, so `run_sweep.sh`'s tee'd logs hold only a banner

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -6,8 +6,8 @@ from vera_bench.matrix import MODELS, PROVIDER_ENV_KEYS, detect_provider
 
 
 class TestMatrix:
-    def test_eight_models_three_providers(self):
-        assert len(MODELS) == 8
+    def test_nine_models_three_providers(self):
+        assert len(MODELS) == 9
         assert {m.provider for m in MODELS} == {"anthropic", "openai", "moonshot"}
 
     def test_display_names_unique(self):
@@ -33,6 +33,7 @@ class TestMatrix:
         assert ztd == {
             "claude-fable-5",
             "claude-opus-4-8",
+            "claude-opus-5",
             "gpt-5.6-sol",
             "moonshot/kimi-k3",
         }

--- a/tests/test_sweep_status.py
+++ b/tests/test_sweep_status.py
@@ -83,14 +83,18 @@ def test_expected_problems_matches_repo():
 
 
 class TestExpectedTargets:
-    """The sweep-file denominator must match the default sweep, not a hardcoded
-    40: with pro opt-out (the default) run_sweep produces 36 targets, so a
-    complete pro-off sweep should read as 36/36, not 36/40."""
+    """The sweep-file denominator is derived from the matrix, not hardcoded: it
+    tracks 4 core targets per model plus 2 (aver, ailang) per ztd model, with
+    the pro tier honoured via SWEEP_INCLUDE_PRO. As the matrix grows this count
+    moves with it — the point is that it is derived, so a complete sweep reads
+    as N/N rather than N/<stale-constant>."""
 
-    def test_pro_off_default_is_36(self, monkeypatch):
+    def test_pro_off_default(self, monkeypatch):
+        # 8 models pro-off (5 of them ztd): 8*4 core + 5*2 ztd = 42.
         monkeypatch.delenv("SWEEP_INCLUDE_PRO", raising=False)
-        assert ss._expected_targets() == 36
+        assert ss._expected_targets() == 42
 
-    def test_pro_on_is_40(self, monkeypatch):
+    def test_pro_on_adds_the_pro_tier(self, monkeypatch):
+        # 9 models pro-on: 9*4 + 5*2 = 46.
         monkeypatch.setenv("SWEEP_INCLUDE_PRO", "1")
-        assert ss._expected_targets() == 40
+        assert ss._expected_targets() == 46

--- a/vera_bench/matrix.py
+++ b/vera_bench/matrix.py
@@ -41,6 +41,7 @@ MODELS: list[Model] = [
     Model("claude-fable-5", "anthropic", "fable", "Claude Fable 5", ztd=True),
     Model("openai-pro/gpt-5.6-sol", "openai", "fable", "GPT-5.6 Sol (pro)"),
     Model("claude-opus-4-8", "anthropic", "opus", "Claude Opus 4.8", ztd=True),
+    Model("claude-opus-5", "anthropic", "opus", "Claude Opus 5", ztd=True),
     Model("gpt-5.6-sol", "openai", "opus", "GPT-5.6 Sol", ztd=True),
     Model("moonshot/kimi-k3", "moonshot", "opus", "Kimi K3", ztd=True),
     Model("claude-sonnet-5", "anthropic", "sonnet", "Claude Sonnet 5"),


### PR DESCRIPTION
Claude Opus 5 shipped **today (2026-07-24)**. This adds it to the model matrix for a same-day head-to-head against Opus 4.8.

## What
- `vera_bench/matrix.py`: `Model("claude-opus-5", "anthropic", "opus", "Claude Opus 5", ztd=True)`, right after `claude-opus-4-8`.
- Same **`opus` tier** → the two land on the same chart panel for direct comparison.
- **`ztd=True`** → runs the identical six targets as 4.8 (Vera full-spec + spec-from-NL, Python, TypeScript, Aver, AILANG), so it's a fair comparison, not just the core four.

## Fallout (all mechanical, registry-driven)
- 9 models, 5 ztd → **42 targets pro-off / 46 pro-on**. `sweep_status._expected_targets()` derives this, so the census denominator moves with it; `TestExpectedTargets` updated.
- `plot_results.MODELS` derives from the matrix, so the opus panel now renders four bars (Opus 4.8, Opus 5, GPT-5.6 Sol, Kimi K3) with no code change.
- `preflight.sh` gates it from the registry.

## Not touched
- **No `models.py` change.** Opus 5 is a standard Messages-API Claude model; `AnthropicClient` handles it as-is. Verify with `preflight.sh` before committing to the sweep.
- **No version bump.** Adding a model to the sweep lineup doesn't change how any existing model is evaluated — the mechanism is unchanged (`[Unreleased]`).

## After merge
`preflight.sh` (now gates Opus 5) → `SWEEP_INCLUDE_PRO=1 bash scripts/run_sweep.sh` runs **only** Opus 5's six targets; the other 40 are already on disk and clean, so they're skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Opus 5 to the supported model matrix.
  * Included Claude Opus 5 in benchmark sweeps, coverage checks and charts.
  * Added the model to the zero-training-data target set.
  * Documented the planned shipment date of 24 July 2026.

* **Tests**
  * Updated benchmark coverage and model-count checks for the expanded model matrix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->