### PR TITLE
docs: correct the attribution of the Vera deficit closing

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ started or below.
 
 Only the second step is controlled. The first spans a compiler, a standard
 library and a revision of the teaching document, so it measures the Vera
-ecosystem improving as much as the models. The controlled step moves the same
-way, which is suggestive rather than conclusive on a sample of one transition.
+ecosystem improving alongside the models, in unknown proportion. The controlled
+step moves the same way, which is suggestive rather than conclusive on a sample
+of one transition.
 
 ### Reasoning mode
 

--- a/assets/README.md
+++ b/assets/README.md
@@ -43,7 +43,7 @@ problems in Vera than in Python; Claude Opus 5 reverses that. Both Vera modes
 rise at every step, while Python and TypeScript end where they started or
 below. Only the last step is controlled; the earlier one spans a compiler, a
 standard library and a revision of the teaching document, so it measures the
-ecosystem improving as much as the models.
+ecosystem improving alongside the models, in unknown proportion.
 
 ### `fig-reasoning.png`: reasoning mode
 


### PR DESCRIPTION
The Results section claimed the early Vera deficit closed because the models
improved while the language stood still. That is not what happened.

Between the two benchmark runs the Vera changelog records:

| | |
|---|--:|
| releases, 0.0.108 to 0.1.7 | **96** |
| changelog entries | **661** |
| ...fixes | ~300 |
| ...stdlib / built-ins | 57 |
| ...SKILL.md revisions | 32 |

`v0.0.7` ran on 10 April 2026 against Vera 0.0.108; this sweep ran on 23 July
against 0.1.7. That is 104 days, and since Vera's first commit is 22 February
2026 it covers about 69% of the language's life to date. The language could not
be held fixed, because it was still being built.

So the honest position is that two things moved and the benchmark cannot
separate them. A plausible reading is that many of the early failures were
models reaching for built-in functions that did not exist yet, in which case
the deficit closed because the standard library caught up with what models
expect, rather than because models got better at Vera.

## Changes

**README.md** and **assets/README.md**: "so it measures the Vera ecosystem
improving **as much as** the models" implied parity, which nothing supports in
either direction. Now "**alongside** the models, in unknown proportion".

The longer version, with the changelog figures and the cart-and-horse framing,
lives in the untracked `assets/GRAPHS.md` talk notes rather than here. The
README's generation section already flags the confound and does not need to
argue it at length.

No code changes, and no version bump: this corrects wording in shipped
documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark descriptions to clarify that ecosystem improvements occurred alongside model advances, with the relative contribution unspecified.
  * Applied consistent wording across the main and assets documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->