### PR TITLE
Fix the deferred adversarial findings (#113): shape validation and legal idioms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A legal-but-unconventional declaration was graded wrong instead of
+  declining.** `resolve_names` — serving Python, TypeScript, Aver and
+  AILANG — matched constructors by name and never checked the declared
+  shape, so a solution writing `Cons(List, Int)` (a swap, internally
+  consistent and permitted by the problem statement) had canonical-order
+  arguments rendered into it and failed at runtime as the model's wrong
+  answer. The Vera path has declined that since v0.0.18's first cut;
+  the other four now read declared argument types where the language
+  shows them (Aver, AILANG, annotated Python) and decline on mismatch.
+  Unannotated Python stays permissive — unreadable is not the same as
+  wrong.
+- **Idioms each language's own documentation teaches were declined.**
+  TypeScript `readonly` members and declarations whose discriminant is
+  not the first field were invisible to field inference; AILANG's
+  generic `type MyList[a] = …` never matched, and its auto-imported
+  prelude `Option`/`Some`/`None` has no declaration to match at all;
+  `@dataclass(kw_only=True)` was constructed positionally and raised
+  `TypeError`. Each ungraded or failed a correct solution.
+- **A test-case string containing `{…}` or `${…}` was silently
+  re-evaluated** by Aver's and AILANG's string interpolation, calling
+  the function with a different value than the case specifies. Those
+  decline now rather than grade against an argument we did not send.
+- **`rerun_failed.py` lost re-run code under version drift** — it looked
+  for the canonical file's stem in the scratch tree, which names its
+  output with current versions, so a repaired row kept pointing at the
+  original failed attempt's stored code.
+
 - **Comments could silently flip a grading outcome, in all five
   languages.** Every declaration scanner was a regex over raw source, so
   comment text was indistinguishable from code: a comment inside a Vera

--- a/scripts/rerun_failed.py
+++ b/scripts/rerun_failed.py
@@ -139,10 +139,21 @@ def copy_code(scratch: str, canonical: str, pid: str) -> None:
     fresh rows, stale code, under identical names. Runs inside the
     per-pid scratch's lifetime; splice() happens after it is deleted.
     """
+    # The scratch run names its output with the CURRENT bench and
+    # compiler versions, which need not match the canonical file being
+    # repaired. Deriving the stem from the canonical name silently found
+    # nothing and left the spliced row pointing at the original failed
+    # attempt's code, so read whatever stem the scratch actually wrote.
     stem = os.path.splitext(os.path.basename(canonical))[0]
-    src = os.path.join(scratch, "code", stem)
-    if not os.path.isdir(src):
+    code_root = os.path.join(scratch, "code")
+    if not os.path.isdir(code_root):
         return
+    scratch_stems = os.listdir(code_root)
+    src = os.path.join(code_root, stem)
+    if not os.path.isdir(src):
+        if len(scratch_stems) != 1:
+            return
+        src = os.path.join(code_root, scratch_stems[0])
     dest = os.path.join(os.path.dirname(canonical), "code", stem)
     os.makedirs(dest, exist_ok=True)
     for name in os.listdir(src):

--- a/tests/test_adt_render.py
+++ b/tests/test_adt_render.py
@@ -493,6 +493,64 @@ class TestIdiomsThatUsedToDecline:
         )
         assert python_kwonly_fields(aliased)["Cons"] == ["head", "tail"]
 
+    def test_dataclass_alias_resolution_is_module_scoped(self):
+        # A nested import must not authorise a module-level decorator of
+        # the same name, and a module-level rebinding must revoke one
+        # (CR on #114). Getting it wrong builds a positional constructor
+        # by keyword.
+        from vera_bench.adt_render import python_kwonly_fields
+
+        nested = (
+            "def helper():\n"
+            "    from dataclasses import dataclass as dc\n"
+            "    return dc\n"
+            "def dc(kw_only=True):\n    return lambda c: c\n"
+            "class List: pass\n"
+            "@dc(kw_only=True)\nclass Cons(List):\n"
+            "    head: int\n    tail: List\n"
+        )
+        assert python_kwonly_fields(nested) == {}
+
+        shadowed = (
+            "from dataclasses import dataclass as dc\n"
+            "def dc(kw_only=True):\n    return lambda c: c\n"
+            "class List: pass\n"
+            "@dc(kw_only=True)\nclass Cons(List):\n"
+            "    head: int\n    tail: List\n"
+        )
+        assert python_kwonly_fields(shadowed) == {}
+
+        dotted = (
+            "import dataclasses\n"
+            "class List: pass\n"
+            "@dataclasses.dataclass(kw_only=True)\nclass Cons(List):\n"
+            "    head: int\n    tail: List\n"
+        )
+        assert python_kwonly_fields(dotted)["Cons"] == ["head", "tail"]
+
+    def test_a_declaration_outranks_a_literal_for_the_discriminant(self):
+        # A seed constant written before the type would otherwise pick
+        # the discriminant, and the wrapper would build `{ kind: … }`
+        # against a `tag` union — the solution's own switch then reads
+        # undefined and a correct answer grades 0 (CR on #114).
+        src = (
+            'const seed = { kind: "Nil" };\n'
+            'type List = { tag: "Nil" } | '
+            '{ tag: "Cons"; head: number; tail: List };'
+        )
+        assert infer_ts_discriminant(src) == "tag"
+        out = render(
+            [1],
+            LIST,
+            "typescript",
+            ts_fields=infer_ts_fields(src),
+            ts_disc=infer_ts_discriminant(src),
+        )
+        assert out == '{ tag: "Cons", head: 1, tail: { tag: "Nil" } }'
+        # A genuine kind-discriminated union is still honoured.
+        kind = "type List = { kind: 'Nil' } | { kind: 'Cons'; head: number };"
+        assert infer_ts_discriminant(kind) == "kind"
+
     def test_kw_only_dataclass_is_constructed_by_keyword(self):
         from vera_bench.adt_render import python_kwonly_fields
 

--- a/tests/test_adt_render.py
+++ b/tests/test_adt_render.py
@@ -452,6 +452,47 @@ class TestIdiomsThatUsedToDecline:
         with pytest.raises(Unsupported):
             resolve_names(extra, LIST, "python")
 
+    def test_reordered_kw_only_binds_values_to_the_right_fields(self):
+        # Accepting a reordered declaration is only half of it: the
+        # rendered VALUES are in canonical order while the names come
+        # from the declaration, so zipping them produced
+        # `Cons(tail=1, head=Nil())` — a mis-grade, strictly worse than
+        # the false decline it replaced (CR on #114).
+        from vera_bench.adt_render import align_kwonly, python_kwonly_fields
+
+        src = (
+            "from dataclasses import dataclass\n"
+            "class List: pass\n"
+            "@dataclass(kw_only=True)\nclass Nil(List): pass\n"
+            "@dataclass(kw_only=True)\nclass Cons(List):\n"
+            "    tail: List\n    head: int\n"
+        )
+        aligned = align_kwonly(python_kwonly_fields(src), src, LIST)
+        assert aligned["Cons"] == ["head", "tail"]
+        out = render([1], LIST, "python", py_kwonly=aligned)
+        assert out == "Cons(head=1, tail=Nil())"
+
+    def test_only_a_real_dataclass_decorator_means_kw_only(self):
+        # An unrelated decorator taking a kw_only keyword would
+        # otherwise have its class built by keyword against a positional
+        # signature (CR on #114).
+        from vera_bench.adt_render import python_kwonly_fields
+
+        bogus = (
+            "def register(kw_only=True):\n    return lambda c: c\n"
+            "class List: pass\n"
+            "@register(kw_only=True)\nclass Cons(List):\n"
+            "    head: int\n    tail: List\n"
+        )
+        assert python_kwonly_fields(bogus) == {}
+        aliased = (
+            "from dataclasses import dataclass as dc\n"
+            "class List: pass\n"
+            "@dc(kw_only=True)\nclass Cons(List):\n"
+            "    head: int\n    tail: List\n"
+        )
+        assert python_kwonly_fields(aliased)["Cons"] == ["head", "tail"]
+
     def test_kw_only_dataclass_is_constructed_by_keyword(self):
         from vera_bench.adt_render import python_kwonly_fields
 

--- a/tests/test_adt_render.py
+++ b/tests/test_adt_render.py
@@ -34,6 +34,14 @@ LIST = {
         {"name": "Cons", "args": ["Int", "List"], "fields": ["head", "tail"]},
     ],
 }
+TREE = {
+    "type": "Tree",
+    "form": "tagged",
+    "constructors": [
+        {"name": "Leaf", "args": ["Int"], "fields": ["value"]},
+        {"name": "Branch", "args": ["Tree", "Tree"], "fields": ["left", "right"]},
+    ],
+}
 OPTION = {
     "type": "Option",
     "form": "tagged",
@@ -583,6 +591,71 @@ class TestIdiomsThatUsedToDecline:
         # leaving the constructor an argument short (CR on #114).
         src = 'type T = { tag: "Item"; kind: number; label: string };'
         assert [n for n, _ in infer_ts_fields(src)["Item"]] == ["kind", "label"]
+
+    def test_duplicate_type_fields_resolve_by_name_or_decline(self):
+        # Branch(Tree, Tree): types cannot say which declared field is
+        # which, and declaration order is not a proxy for semantic order
+        # once reordering is accepted — guessing silently reverses the
+        # children (CR on #114). Canonical names resolve it; anything
+        # else must decline rather than guess.
+        from vera_bench.adt_render import align_kwonly, python_kwonly_fields
+
+        def src(order, left="left", right="right"):
+            fields = "".join(f"    {n}\n" for n in order)
+            return (
+                "from dataclasses import dataclass\nclass Tree: pass\n"
+                "@dataclass(kw_only=True)\nclass Leaf(Tree):\n    value: int\n"
+                f"@dataclass(kw_only=True)\nclass Branch(Tree):\n{fields}"
+            )
+
+        canonical = src(["right: Tree", "left: Tree"])
+        aligned = align_kwonly(python_kwonly_fields(canonical), canonical, TREE)
+        assert aligned["Branch"] == ["left", "right"]
+
+        ambiguous = src(["b: Tree", "a: Tree"])
+        with pytest.raises(Unsupported):
+            align_kwonly(python_kwonly_fields(ambiguous), ambiguous, TREE)
+
+    def test_scalar_shape_mismatch_is_caught(self):
+        # `(String, Self)` against a canonical `(Int, Self)` used to pass
+        # because neither side was SELF, and the wrapper then rendered an
+        # integer into a string field (CR on #114).
+        with pytest.raises(Unsupported):
+            resolve_names(
+                "type MyList = MyNil | MyCons(string, MyList)", LIST, "ailang"
+            )
+        assert resolve_names(
+            "type MyList = MyNil | MyCons(int, MyList)", LIST, "ailang"
+        )
+
+    def test_a_languages_own_scalar_spelling_is_not_a_mismatch(self):
+        # Enforcing equality must not false-decline Python's `str`
+        # against a canonical `String`.
+        spec = {
+            "type": "L",
+            "form": "list",
+            "empty": "Nil",
+            "cons": "Cons",
+            "constructors": [
+                {"name": "Nil", "args": []},
+                {"name": "Cons", "args": ["String", "L"]},
+            ],
+        }
+        src = (
+            "class L: pass\nclass Nil(L): pass\n"
+            "class Cons(L):\n    def __init__(self, head: str, tail: L): pass\n"
+        )
+        assert resolve_names(src, spec, "python") == {"Nil": "Nil", "Cons": "Cons"}
+
+    def test_a_nested_constructor_argument_is_unverifiable(self):
+        # The `[^)]*` parser cannot see a nested application; flattening
+        # it would invent an arity. Absent means unverifiable, which the
+        # shape guard skips (CR on #114).
+        from vera_bench.adt_render import declared_shape
+
+        shapes = declared_shape("type E = Lit(int) | Add(Pair(E, E))", "ailang")
+        assert shapes.get("Lit") == ("int",)
+        assert "Add" not in shapes
 
     def test_kw_only_dataclass_is_constructed_by_keyword(self):
         from vera_bench.adt_render import python_kwonly_fields

--- a/tests/test_adt_render.py
+++ b/tests/test_adt_render.py
@@ -794,6 +794,52 @@ class TestIdiomsThatUsedToDecline:
         )
         assert aligned == {"NoneOpt": [], "Some": ["value"]}
 
+    def test_positional_only_self_is_not_an_argument(self):
+        # `def __init__(self, /, *, head, tail)` is legal: `self` lands
+        # in posonlyargs, and slicing only `args` left it in the shape as
+        # an extra SELF — declining a correct solution (CR on #114).
+        from vera_bench.adt_render import declared_shape
+
+        src = (
+            "class List: pass\nclass Nil(List): pass\n"
+            "class Cons(List):\n"
+            '    def __init__(self: "Cons", /, *, head: int, tail: List):\n'
+            "        pass\n"
+        )
+        assert declared_shape(src, "python")["Cons"] == ("int", "SELF")
+        assert resolve_names(src, LIST, "python") == {"Nil": "Nil", "Cons": "Cons"}
+
+    def test_kwonly_alignment_uses_the_same_scalar_equivalence(self):
+        # resolve_names accepted `head: str` against a canonical String
+        # through the equivalence table, then the alignment loop's raw
+        # `==` rejected it and the problem declined anyway. One rule now
+        # serves both (CR on #114).
+        from vera_bench.adt_render import align_kwonly, python_kwonly_fields
+
+        spec = {
+            "type": "L",
+            "form": "list",
+            "empty": "Nil",
+            "cons": "Cons",
+            "constructors": [
+                {"name": "Nil", "args": [], "fields": []},
+                {"name": "Cons", "args": ["String", "L"], "fields": ["head", "tail"]},
+            ],
+        }
+        src = (
+            "from dataclasses import dataclass\nclass L: pass\n"
+            "@dataclass(kw_only=True)\nclass Nil(L): pass\n"
+            "@dataclass(kw_only=True)\nclass Cons(L):\n"
+            "    head: str\n    tail: L\n"
+        )
+        aligned = align_kwonly(
+            python_kwonly_fields(src), src, spec, {"Nil": "Nil", "Cons": "Cons"}
+        )
+        assert aligned["Cons"] == ["head", "tail"]
+        assert render(["a"], spec, "python", py_kwonly=aligned) == (
+            'Cons(head="a", tail=Nil())'
+        )
+
     def test_kw_only_dataclass_is_constructed_by_keyword(self):
         from vera_bench.adt_render import python_kwonly_fields
 

--- a/tests/test_adt_render.py
+++ b/tests/test_adt_render.py
@@ -755,6 +755,45 @@ class TestIdiomsThatUsedToDecline:
         assert shapes.get("Lit") == ("int",)
         assert "Add" not in shapes
 
+    def test_a_fieldless_kwonly_class_declines_against_a_non_nullary_ctor(self):
+        # `[]` is only alignable against a NULLARY canonical
+        # constructor. Accepting it for `Branch(Tree, Tree)` produced an
+        # empty kwargs list, which falls back to positional rendering —
+        # rejected by a keyword-only class with TypeError and published
+        # as the model's wrong answer (CR on #114).
+        from vera_bench.adt_render import align_kwonly, python_kwonly_fields
+
+        src = (
+            "from dataclasses import dataclass\nclass Tree: pass\n"
+            "@dataclass(kw_only=True)\nclass Leaf(Tree):\n    value: int\n"
+            "@dataclass(kw_only=True)\nclass Branch(Tree): pass\n"
+        )
+        with pytest.raises(Unsupported):
+            align_kwonly(
+                python_kwonly_fields(src),
+                src,
+                TREE,
+                {"Leaf": "Leaf", "Branch": "Branch"},
+            )
+
+    def test_a_genuinely_nullary_constructor_still_aligns_to_empty(self):
+        # The guard must not break the case it looks like: a nullary
+        # canonical constructor legitimately has no fields.
+        from vera_bench.adt_render import align_kwonly, python_kwonly_fields
+
+        src = (
+            "from dataclasses import dataclass\nclass Option: pass\n"
+            "@dataclass(kw_only=True)\nclass NoneOpt(Option): pass\n"
+            "@dataclass(kw_only=True)\nclass Some(Option):\n    value: int\n"
+        )
+        aligned = align_kwonly(
+            python_kwonly_fields(src),
+            src,
+            OPTION,
+            {"None": "NoneOpt", "Some": "Some"},
+        )
+        assert aligned == {"NoneOpt": [], "Some": ["value"]}
+
     def test_kw_only_dataclass_is_constructed_by_keyword(self):
         from vera_bench.adt_render import python_kwonly_fields
 

--- a/tests/test_adt_render.py
+++ b/tests/test_adt_render.py
@@ -239,7 +239,11 @@ class TestResolveNamesWidening:
     """The declaration forms the first regexes missed (review of #112)."""
 
     def test_bare_and_dataclass_python_classes_resolve(self):
-        src = "class Nil:\n    pass\n\n@dataclass\nclass Cons:\n    head: int\n"
+        src = (
+            "class List: pass\n"
+            "class Nil(List):\n    pass\n\n"
+            "@dataclass\nclass Cons(List):\n    head: int\n    tail: List\n"
+        )
         assert resolve_names(src, LIST, "python") == {"Nil": "Nil", "Cons": "Cons"}
 
     def test_multiline_ailang_type_resolves(self):
@@ -352,3 +356,110 @@ class TestCommentBlindness:
         from vera_bench.adt_render import strip_comments
 
         assert '"a -- b"' in strip_comments('let x = "a -- b"  -- gone', "vera")
+
+
+class TestDeclaredShapeGuard:
+    """A swapped-but-legal declaration declines instead of grading wrong.
+
+    The Vera path has validated declared shape since #112; the other four
+    matched by name alone, so a spec-compliant `Cons(List, Int)` was
+    rendered in canonical order and failed at runtime — the model's
+    "wrong answer". Adversarial review of #112, filed as #113.
+    """
+
+    def test_swapped_shape_declines_in_every_readable_language(self):
+        cases = [
+            ("ailang", "type MyList = MyNil | MyCons(MyList, int)"),
+            ("aver", "type MyList\n    Nil\n    Cons(MyList, Int)\n"),
+            (
+                "python",
+                "class List: pass\nclass Nil(List): pass\n"
+                "class Cons(List):\n"
+                "    def __init__(self, tail: List, head: int): pass\n",
+            ),
+        ]
+        for language, src in cases:
+            with pytest.raises(Unsupported):
+                resolve_names(src, LIST, language)
+
+    def test_correct_shapes_still_map(self):
+        cases = [
+            ("ailang", "type MyList = MyNil | MyCons(int, MyList)"),
+            ("aver", "type MyList\n    Nil\n    Cons(Int, MyList)\n"),
+            (
+                "python",
+                "class List: pass\nclass Nil(List): pass\n"
+                "class Cons(List):\n"
+                "    def __init__(self, head: int, tail: List): pass\n",
+            ),
+        ]
+        for language, src in cases:
+            assert resolve_names(src, LIST, language)
+
+    def test_unannotated_python_is_unverifiable_not_a_mismatch(self):
+        # No annotations means we cannot read the shape; declining would
+        # ungrade correct solutions wholesale.
+        src = (
+            "class List: pass\nclass Nil(List): pass\n"
+            "class Cons(List):\n    def __init__(self, head, tail): pass\n"
+        )
+        assert resolve_names(src, LIST, "python") == {"Nil": "Nil", "Cons": "Cons"}
+
+
+class TestIdiomsThatUsedToDecline:
+    """Legal idioms each language's own docs teach (#113)."""
+
+    def test_readonly_typescript_declaration(self):
+        src = (
+            'type List = { readonly tag: "Nil" } | '
+            '{ readonly tag: "Cons"; readonly head: number; '
+            "readonly tail: List };"
+        )
+        fields = infer_ts_fields(src)
+        assert [n for n, _ in fields["Cons"]] == ["head", "tail"]
+        # types survive, so order alignment still works
+        assert all(t is not None for _, t in fields["Cons"])
+
+    def test_discriminant_need_not_come_first(self):
+        src = 'type List = { head: number; tail: List; tag: "Cons" };'
+        assert [n for n, _ in infer_ts_fields(src)["Cons"]] == ["head", "tail"]
+
+    def test_ailang_generic_type_parameters(self):
+        src = "type MyList[a] = MyNil | MyCons(a, MyList[a])"
+        assert resolve_names(src, LIST, "ailang") == {
+            "Nil": "MyNil",
+            "Cons": "MyCons",
+        }
+
+    def test_ailang_prelude_type_needs_no_declaration(self):
+        # Option/Some/None are auto-imported; there is nothing to match.
+        src = "export func f(x: int) -> Option[int] = Some(x)\nlet y = None"
+        assert resolve_names(src, OPTION, "ailang") == {}
+
+    def test_kw_only_dataclass_is_constructed_by_keyword(self):
+        from vera_bench.adt_render import python_kwonly_fields
+
+        src = (
+            "from dataclasses import dataclass\n"
+            "class List: pass\n"
+            "@dataclass(kw_only=True)\nclass Nil(List): pass\n"
+            "@dataclass(kw_only=True)\nclass Cons(List):\n"
+            "    head: int\n    tail: List\n"
+        )
+        assert python_kwonly_fields(src)["Cons"] == ["head", "tail"]
+        out = render([1], LIST, "python", py_kwonly=python_kwonly_fields(src))
+        assert out == "Cons(head=1, tail=Nil())"
+
+
+class TestInterpolationSafety:
+    """A test-case string the target language would re-evaluate declines."""
+
+    def test_aver_braces_and_ailang_dollar_brace(self):
+        from vera_bench.runner import _interpolation_safe
+
+        with pytest.raises(Unsupported):
+            _interpolation_safe("a{b}", "aver")
+        with pytest.raises(Unsupported):
+            _interpolation_safe("x${y}", "ailang")
+        _interpolation_safe("plain", "aver")  # must not raise
+        _interpolation_safe("a{b}", "python")  # not interpolated there

--- a/tests/test_adt_render.py
+++ b/tests/test_adt_render.py
@@ -551,6 +551,39 @@ class TestIdiomsThatUsedToDecline:
         kind = "type List = { kind: 'Nil' } | { kind: 'Cons'; head: number };"
         assert infer_ts_discriminant(kind) == "kind"
 
+    def test_declaration_region_spans_semicolons_inside_braces(self):
+        # `;` is also the field separator INSIDE a union member, so a
+        # pattern ending at the first semicolon truncated the region,
+        # left no complete block in it, and fell through to the
+        # whole-source scan — where a literal could pick the
+        # discriminant again, defeating the declaration-first rule
+        # (CR on #114).
+        src = (
+            'const seed = { kind: "Nil" };\n'
+            'type List = { tag: "Cons"; head: number; tail: List } '
+            '| { tag: "Nil" };'
+        )
+        assert infer_ts_discriminant(src) == "tag"
+        out = render(
+            [1],
+            LIST,
+            "typescript",
+            ts_fields=infer_ts_fields(src),
+            ts_disc=infer_ts_discriminant(src),
+        )
+        assert out == '{ tag: "Cons", head: 1, tail: { tag: "Nil" } }'
+
+    def test_declaration_without_a_trailing_semicolon(self):
+        assert (
+            infer_ts_discriminant('type List = { tag: "Cons"; head: number }') == "tag"
+        )
+
+    def test_a_payload_field_named_kind_survives_a_tag_union(self):
+        # Excluding both spellings deleted a legitimate payload field,
+        # leaving the constructor an argument short (CR on #114).
+        src = 'type T = { tag: "Item"; kind: number; label: string };'
+        assert [n for n, _ in infer_ts_fields(src)["Item"]] == ["kind", "label"]
+
     def test_kw_only_dataclass_is_constructed_by_keyword(self):
         from vera_bench.adt_render import python_kwonly_fields
 

--- a/tests/test_adt_render.py
+++ b/tests/test_adt_render.py
@@ -436,6 +436,22 @@ class TestIdiomsThatUsedToDecline:
         src = "export func f(x: int) -> Option[int] = Some(x)\nlet y = None"
         assert resolve_names(src, OPTION, "ailang") == {}
 
+    def test_kw_only_dataclass_may_declare_fields_in_any_order(self):
+        # Built by name, so declaration order carries no meaning;
+        # comparing positionally declined a correct solution (CR on
+        # #114). A genuine arity mismatch must still decline.
+        src = (
+            "from dataclasses import dataclass\n"
+            "class List: pass\n"
+            "@dataclass(kw_only=True)\nclass Nil(List): pass\n"
+            "@dataclass(kw_only=True)\nclass Cons(List):\n"
+            "    tail: List\n    head: int\n"
+        )
+        assert resolve_names(src, LIST, "python") == {"Nil": "Nil", "Cons": "Cons"}
+        extra = src.replace("    head: int\n", "    head: int\n    x: int\n")
+        with pytest.raises(Unsupported):
+            resolve_names(extra, LIST, "python")
+
     def test_kw_only_dataclass_is_constructed_by_keyword(self):
         from vera_bench.adt_render import python_kwonly_fields
 
@@ -453,6 +469,18 @@ class TestIdiomsThatUsedToDecline:
 
 class TestInterpolationSafety:
     """A test-case string the target language would re-evaluate declines."""
+
+    def test_nested_strings_are_checked_too(self):
+        # Arguments are compound — VB-T2-006 passes a list of strings —
+        # so a top-level-only check missed the values that actually
+        # reach the interpolator (CR on #114).
+        from vera_bench.runner import _interpolation_safe
+
+        with pytest.raises(Unsupported):
+            _interpolation_safe(["a{b}"], "aver")
+        with pytest.raises(Unsupported):
+            _interpolation_safe({"Some": ["x${y}"]}, "ailang")
+        _interpolation_safe([["a", "b"], "-"], "aver")  # legal, must pass
 
     def test_aver_braces_and_ailang_dollar_brace(self):
         from vera_bench.runner import _interpolation_safe

--- a/tests/test_adt_render.py
+++ b/tests/test_adt_render.py
@@ -662,6 +662,58 @@ class TestIdiomsThatUsedToDecline:
         )
         assert resolve_names(src, spec, "python") == {"Node": "Node"}
 
+    def test_kwonly_scalar_disagreement_declines(self):
+        # The keyword-only branch normalises through the equivalence
+        # table and then compares; this pins that a REAL scalar
+        # disagreement is still caught there (mirroring the positional
+        # test), and that normalising twice does not accidentally make
+        # str and Int compare equal (CR on #114).
+        src = (
+            "from dataclasses import dataclass\nclass List: pass\n"
+            "@dataclass(kw_only=True)\nclass Nil(List): pass\n"
+            "@dataclass(kw_only=True)\nclass Cons(List):\n"
+            "    head: str\n    tail: List\n"
+        )
+        with pytest.raises(Unsupported):
+            resolve_names(src, LIST, "python")
+        # The same shape with the right scalar still maps.
+        ok = src.replace("head: str", "head: int")
+        assert resolve_names(ok, LIST, "python") == {"Nil": "Nil", "Cons": "Cons"}
+
+    def test_a_keyword_only_constructor_never_falls_back_to_positional(self):
+        # An unannotated keyword-only __init__ has readable NAMES but no
+        # types, so alignment used to drop it — and dropping means
+        # positional rendering, which a keyword-only class rejects with
+        # TypeError, published as the model's wrong answer (CR on #114).
+        from vera_bench.adt_render import align_kwonly, python_kwonly_fields
+
+        def src(params):
+            return (
+                "class List: pass\nclass Nil(List): pass\n"
+                "class Cons(List):\n"
+                f"    def __init__(self, *, {params}):\n        pass\n"
+            )
+
+        canonical = src("head, tail")
+        aligned = align_kwonly(
+            python_kwonly_fields(canonical),
+            canonical,
+            LIST,
+            {"Nil": "Nil", "Cons": "Cons"},
+        )
+        assert aligned["Cons"] == ["head", "tail"]
+
+        # Names that do not match the canonical ones cannot be ordered
+        # without types: decline rather than render positionally.
+        other = src("a, b")
+        with pytest.raises(Unsupported):
+            align_kwonly(
+                python_kwonly_fields(other),
+                other,
+                LIST,
+                {"Nil": "Nil", "Cons": "Cons"},
+            )
+
     def test_scalar_shape_mismatch_is_caught(self):
         # `(String, Self)` against a canonical `(Int, Self)` used to pass
         # because neither side was SELF, and the wrapper then rendered an

--- a/tests/test_adt_render.py
+++ b/tests/test_adt_render.py
@@ -600,7 +600,7 @@ class TestIdiomsThatUsedToDecline:
         # else must decline rather than guess.
         from vera_bench.adt_render import align_kwonly, python_kwonly_fields
 
-        def src(order, left="left", right="right"):
+        def src(order):
             fields = "".join(f"    {n}\n" for n in order)
             return (
                 "from dataclasses import dataclass\nclass Tree: pass\n"
@@ -616,6 +616,52 @@ class TestIdiomsThatUsedToDecline:
         with pytest.raises(Unsupported):
             align_kwonly(python_kwonly_fields(ambiguous), ambiguous, TREE)
 
+    def test_an_unrelated_kwonly_helper_does_not_decline_the_problem(self):
+        # align_kwonly scanned every keyword-only class, so a helper
+        # dataclass of the same arity hit the ambiguity branch and
+        # declined the whole problem (CR on #114).
+        from vera_bench.adt_render import align_kwonly, python_kwonly_fields
+
+        src = (
+            "from dataclasses import dataclass\nclass Tree: pass\n"
+            "@dataclass(kw_only=True)\nclass Leaf(Tree):\n    value: int\n"
+            "@dataclass(kw_only=True)\nclass Branch(Tree):\n"
+            "    left: Tree\n    right: Tree\n"
+            "@dataclass(kw_only=True)\nclass Span:\n    lo: int\n    hi: int\n"
+        )
+        aligned = align_kwonly(python_kwonly_fields(src), src, TREE)
+        assert aligned["Branch"] == ["left", "right"]
+
+    def test_an_attribute_annotation_does_not_crash(self):
+        # `obj.attr: int` is a legal AnnAssign whose target is an
+        # Attribute; reading .id raised AttributeError (CR on #114).
+        from vera_bench.adt_render import python_kwonly_fields
+
+        src = (
+            "from dataclasses import dataclass\nclass C: pass\n"
+            "@dataclass(kw_only=True)\nclass D(C):\n"
+            "    x: int\n    obj.attr: int\n"
+        )
+        assert python_kwonly_fields(src)["D"] == ["x"]
+
+    def test_unknown_types_are_unverifiable_in_the_kwonly_path_too(self):
+        # The positional path treats an uninterpretable type name as
+        # unverifiable; the keyword-only path compared raw tokens and
+        # would false-decline (CR on #114).
+        spec = {
+            "type": "T",
+            "form": "tagged",
+            "constructors": [
+                {"name": "Node", "args": ["Widget", "Gadget"], "fields": ["a", "b"]}
+            ],
+        }
+        src = (
+            "from dataclasses import dataclass\nclass T: pass\n"
+            "@dataclass(kw_only=True)\nclass Node(T):\n"
+            "    a: Widget\n    b: Gadget\n"
+        )
+        assert resolve_names(src, spec, "python") == {"Node": "Node"}
+
     def test_scalar_shape_mismatch_is_caught(self):
         # `(String, Self)` against a canonical `(Int, Self)` used to pass
         # because neither side was SELF, and the wrapper then rendered an
@@ -626,7 +672,7 @@ class TestIdiomsThatUsedToDecline:
             )
         assert resolve_names(
             "type MyList = MyNil | MyCons(int, MyList)", LIST, "ailang"
-        )
+        ) == {"Nil": "MyNil", "Cons": "MyCons"}
 
     def test_a_languages_own_scalar_spelling_is_not_a_mismatch(self):
         # Enforcing equality must not false-decline Python's `str`

--- a/vera_bench/adt_render.py
+++ b/vera_bench/adt_render.py
@@ -161,11 +161,19 @@ def _elem_type(spec: dict) -> str:
 
 
 def _dataclass_aliases(tree: object) -> set[str]:
-    """Names in this module that actually refer to dataclasses.dataclass."""
+    """Module-scope names that actually refer to dataclasses.dataclass.
+
+    Only top-level bindings count, and a later top-level rebinding
+    removes one: an import nested inside a function does not authorise a
+    module-level decorator of the same name, and a module-level `def dc`
+    shadowing an earlier import means `@dc(...)` is not a dataclass at
+    all. Getting this wrong builds a positional constructor by keyword.
+    """
     import ast
 
     names = set()
-    for node in ast.walk(tree):
+    body = getattr(tree, "body", [])
+    for node in body:
         if isinstance(node, ast.ImportFrom) and node.module == "dataclasses":
             for a in node.names:
                 if a.name == "dataclass":
@@ -174,6 +182,12 @@ def _dataclass_aliases(tree: object) -> set[str]:
             for a in node.names:
                 if a.name == "dataclasses":
                     names.add((a.asname or a.name) + ".dataclass")
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.discard(node.name)
+        elif isinstance(node, ast.Assign):
+            for t in node.targets:
+                if isinstance(t, ast.Name):
+                    names.discard(t.id)
     return names
 
 
@@ -316,6 +330,18 @@ _TS_DISC = re.compile(r"""\b(?:readonly\s+)?(tag|kind)\s*:\s*["'](\w+)["']""")
 _TS_FIELD = re.compile(r"\b(?:readonly\s+)?(\w+)\s*:\s*([A-Za-z_][\w\[\]<>. ]*)")
 
 
+#: `type X = …` up to its terminating semicolon, and `interface X { … }`.
+_TS_DECL_REGION = re.compile(
+    r"\btype\s+\w+[^=;]*=\s*[^;]*;|\binterface\s+\w+[^{]*\{[^}]*(?:\{[^}]*\}[^}]*)*\}",
+    re.S,
+)
+
+
+def _ts_declaration_regions(source: str) -> list[str]:
+    """The type/interface declarations in a TypeScript source."""
+    return [m.group(0) for m in _TS_DECL_REGION.finditer(source)]
+
+
 def infer_ts_discriminant(source: str) -> str:
     """The discriminant key the solution uses — `tag` unless it says `kind`.
 
@@ -323,7 +349,18 @@ def infer_ts_discriminant(source: str) -> str:
     `{ tag: … }` object handed to code switching on `.kind` reads
     undefined and fails a correct solution.
     """
-    for block in _TS_BLOCK.finditer(strip_comments(source, "typescript")):
+    src = strip_comments(source, "typescript")
+    # A `type`/`interface` declaration outranks any object literal: a
+    # seed constant or example value written before the declaration
+    # would otherwise pick the discriminant, and the wrapper would build
+    # `{ kind: … }` objects against a `tag` union — the solution's own
+    # switch then reads undefined and a correct answer grades 0.
+    for region in _ts_declaration_regions(src):
+        for block in _TS_BLOCK.finditer(region):
+            disc = _TS_DISC.search(block.group(1))
+            if disc:
+                return disc.group(1)
+    for block in _TS_BLOCK.finditer(src):
         disc = _TS_DISC.search(block.group(1))
         if disc:
             return disc.group(1)

--- a/vera_bench/adt_render.py
+++ b/vera_bench/adt_render.py
@@ -160,12 +160,65 @@ def _elem_type(spec: dict) -> str:
     return "Int"
 
 
-def _ctor_call(name: str, rendered: list[str], language: str) -> str:
+def python_kwonly_fields(source: str) -> dict[str, list[str]]:
+    """Keyword-only parameter names per class, for kw_only dataclasses.
+
+    `@dataclass(kw_only=True)` is legal Python 3.10+ and nothing in the
+    prompt forbids it, but a positional `Cons(1, Nil())` raises
+    TypeError against it — a correct solution graded wrong. Where the
+    constructor is keyword-only we emit keyword form using the
+    solution's OWN names.
+    """
+    import ast
+
+    out: dict[str, list[str]] = {}
+    try:
+        tree = ast.parse(strip_comments(source, "python"))
+    except SyntaxError:
+        return out
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        init = next(
+            (
+                n
+                for n in node.body
+                if isinstance(n, ast.FunctionDef) and n.name == "__init__"
+            ),
+            None,
+        )
+        if init is not None:
+            if init.args.kwonlyargs and len(init.args.args) <= 1:
+                out[node.name] = [a.arg for a in init.args.kwonlyargs]
+            continue
+        kw_only = any(
+            isinstance(d, ast.Call)
+            and any(
+                k.arg == "kw_only" and getattr(k.value, "value", False) is True
+                for k in d.keywords
+            )
+            for d in node.decorator_list
+        )
+        if kw_only:
+            out[node.name] = [
+                n.target.id for n in node.body if isinstance(n, ast.AnnAssign)
+            ]
+    return out
+
+
+def _ctor_call(
+    name: str,
+    rendered: list[str],
+    language: str,
+    kwargs: list[str] | None = None,
+) -> str:
     """Apply a constructor, respecting each language's nullary form."""
     if not rendered:
         # Python constructors are classes and must be instantiated; the
         # others name a nullary constructor bare.
         return f"{name}()" if language == "python" else name
+    if kwargs and len(kwargs) == len(rendered):
+        return f"{name}({', '.join(f'{k}={v}' for k, v in zip(kwargs, rendered))})"
     return f"{name}({', '.join(rendered)})"
 
 
@@ -173,8 +226,9 @@ def _ctor_call(name: str, rendered: list[str], language: str) -> str:
 #: union — in a type alias, an interface, or a value literal. `kind` is
 #: accepted alongside `tag`: it is at least as common a discriminant in
 #: the wild, and a model using it is entirely correct.
-_TS_TAGGED = re.compile(r"""\{\s*(tag|kind)\s*:\s*["'](\w+)["']([^}]*)\}""")
-_TS_FIELD = re.compile(r"(\w+)\s*:\s*([A-Za-z_][\w\[\]<>. ]*)")
+_TS_BLOCK = re.compile(r"\{([^{}]*)\}")
+_TS_DISC = re.compile(r"""\b(?:readonly\s+)?(tag|kind)\s*:\s*["'](\w+)["']""")
+_TS_FIELD = re.compile(r"\b(?:readonly\s+)?(\w+)\s*:\s*([A-Za-z_][\w\[\]<>. ]*)")
 
 
 def infer_ts_discriminant(source: str) -> str:
@@ -184,8 +238,11 @@ def infer_ts_discriminant(source: str) -> str:
     `{ tag: … }` object handed to code switching on `.kind` reads
     undefined and fails a correct solution.
     """
-    m = _TS_TAGGED.search(strip_comments(source, "typescript"))
-    return m.group(1) if m else "tag"
+    for block in _TS_BLOCK.finditer(strip_comments(source, "typescript")):
+        disc = _TS_DISC.search(block.group(1))
+        if disc:
+            return disc.group(1)
+    return "tag"
 
 
 def infer_ts_fields(source: str) -> dict[str, list[tuple[str, str | None]]]:
@@ -208,15 +265,28 @@ def infer_ts_fields(source: str) -> dict[str, list[tuple[str, str | None]]]:
     source = strip_comments(source, "typescript")
     fields: dict[str, list[tuple[str, str | None]]] = {}
     typed: dict[str, bool] = {}
-    for match in _TS_TAGGED.finditer(source):
-        tag, body = match.group(2), match.group(3)
+    for block in _TS_BLOCK.finditer(source):
+        body = block.group(1)
+        disc = _TS_DISC.search(body)
+        if not disc:
+            continue
+        tag = disc.group(2)
+        # The discriminant may sit anywhere in the block and may be
+        # `readonly` — an idiomatic declaration that used to be
+        # invisible, ungrading every correct solution written that way.
         pairs: list[tuple[str, str | None]] = []
-        names = re.findall(r"(\w+)\s*:", body)
+        # The discriminant is excluded before judging whether this block
+        # is a DECLARATION: its value is a string literal, never a type,
+        # so counting it would make every declaration look untyped and
+        # silently disable type-based field alignment.
+        names = [
+            n
+            for n in re.findall(r"\b(?:readonly\s+)?(\w+)\s*:", body)
+            if n not in ("tag", "kind")
+        ]
         types = {n: t.strip() for n, t in _TS_FIELD.findall(body)}
         is_decl = bool(names) and all(n in types for n in names)
         for n in names:
-            if n in ("tag", "kind"):  # a nested literal's discriminant
-                continue
             pairs.append((n, types.get(n) if is_decl else None))
         if (
             tag not in fields
@@ -307,6 +377,7 @@ def render(
     qualifier: str = "",
     ts_fields: dict[str, list[tuple[str, str | None]]] | None = None,
     ts_disc: str = "tag",
+    py_kwonly: dict[str, list[str]] | None = None,
 ) -> str:
     """Render `value` as a literal of the problem's ADT in `language`.
 
@@ -342,7 +413,10 @@ def render(
         out = _ctor_call(actual(spec["empty"]), [], language)
         for item in reversed(items):
             out = _ctor_call(
-                actual(spec["cons"]), [_scalar(item, elem, language), out], language
+                actual(spec["cons"]),
+                [_scalar(item, elem, language), out],
+                language,
+                (py_kwonly or {}).get(actual(spec["cons"])),
             )
         return out
 
@@ -350,7 +424,9 @@ def render(
     rendered = [
         _scalar(a, t, language)
         if t in _SCALARS
-        else render(a, spec, language, names, native, qualifier, ts_fields, ts_disc)
+        else render(
+            a, spec, language, names, native, qualifier, ts_fields, ts_disc, py_kwonly
+        )
         for a, t in zip(args, ctor["args"])
     ]
     if language == "typescript":
@@ -360,7 +436,9 @@ def render(
             f"{f}: {v}" for f, v in zip(fields, rendered)
         ]
         return "{ " + ", ".join(parts) + " }"
-    return _ctor_call(actual(name), rendered, language)
+    return _ctor_call(
+        actual(name), rendered, language, (py_kwonly or {}).get(actual(name))
+    )
 
 
 def render_args(
@@ -373,6 +451,7 @@ def render_args(
     qualifier: str = "",
     ts_fields: dict[str, list[tuple[str, str | None]]] | None = None,
     ts_disc: str = "tag",
+    py_kwonly: dict[str, list[str]] | None = None,
 ) -> list[str]:
     """Render a whole argument list, ADT parameters included."""
     if spec is None:
@@ -389,7 +468,15 @@ def render_args(
         if type_name == adt_type:
             out.append(
                 render(
-                    value, spec, language, names, native, qualifier, ts_fields, ts_disc
+                    value,
+                    spec,
+                    language,
+                    names,
+                    native,
+                    qualifier,
+                    ts_fields,
+                    ts_disc,
+                    py_kwonly,
                 )
             )
         elif type_name in _SCALARS:
@@ -414,8 +501,88 @@ _DECL = {
     "typescript": re.compile(r"""\b(?:tag|kind)\s*:\s*["'](\w+)["']"""),
     "aver": re.compile(r"^\s{2,}(\w+)\s*(?:\([^)]*\))?\s*$", re.M),
     # A type may span lines: `type X =` followed by `| Ctor…` lines.
-    "ailang": re.compile(r"^type\s+\w+\s*=\s*(.+(?:\n[ \t]*\|[^\n]*)*)", re.M),
+    # `type MyList[a] = …` is the generic form AILANG's own prompt
+    # teaches; the parameter list used to block the match entirely.
+    "ailang": re.compile(
+        r"^type\s+\w+\s*(?:\[[^\]]*\])?\s*=\s*(.+(?:\n[ \t]*\|[^\n]*)*)", re.M
+    ),
 }
+
+
+def declared_shape(source: str, language: str) -> dict[str, tuple[str, ...]]:
+    """Declared constructor argument SHAPES, where the language shows them.
+
+    Arity alone cannot catch the case that matters: `Cons(List, Int)` is
+    a swap, not a count mismatch, and rendering the canonical order into
+    it produces a call that fails at runtime — recorded as the model's
+    wrong answer. Types are normalised so a self-reference reads as SELF
+    and scalars compare case-insensitively, letting a spec's
+    `["Int", "List"]` be compared with what the solution actually wrote.
+
+    A constructor absent from the result is UNVERIFIABLE, not nullary —
+    Python without annotations, for instance. Callers must not treat a
+    missing entry as a mismatch.
+    """
+    src = strip_comments(source, language)
+    out: dict[str, tuple[str, ...]] = {}
+
+    def norm(t: str, self_names: object) -> str:
+        if isinstance(self_names, str):
+            self_names = {self_names}
+        t = t.strip().split(":")[-1].strip().rstrip(",")
+        t = re.sub(r"\[[^\]]*\]", "", t).strip()
+        lowered = {n.lower() for n in self_names}
+        return "SELF" if t.lower() in lowered else t.lower()
+
+    if language in ("aver", "ailang"):
+        for decl in re.finditer(r"\btype\s+(\w+)", src):
+            self_name = decl.group(1)
+            body = src[decl.end() :]
+            nxt = re.search(r"\btype\s+\w+", body)
+            if nxt:
+                body = body[: nxt.start()]
+            for name, args in re.findall(r"\b(\w+)\s*\(([^)]*)\)", body):
+                parts = [a for a in args.split(",") if a.strip()]
+                out.setdefault(name, tuple(norm(a, self_name) for a in parts))
+    if language == "python":
+        import ast
+
+        try:
+            tree = ast.parse(src)
+        except SyntaxError:
+            return {}
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            init = next(
+                (
+                    n
+                    for n in node.body
+                    if isinstance(n, ast.FunctionDef) and n.name == "__init__"
+                ),
+                None,
+            )
+            # A Python ADT's recursive reference is the BASE class
+            # (`tail: List`), not the constructor's own class.
+            selfish = {node.name} | {
+                b.id for b in node.bases if isinstance(b, ast.Name)
+            }
+            if init is not None:
+                params = init.args.posonlyargs + init.args.args[1:]
+                params += init.args.kwonlyargs
+                if all(p.annotation is not None for p in params) and params:
+                    out[node.name] = tuple(
+                        norm(ast.unparse(p.annotation).strip("\"'"), selfish)
+                        for p in params
+                    )
+            else:
+                fields = [n for n in node.body if isinstance(n, ast.AnnAssign)]
+                if fields:
+                    out[node.name] = tuple(
+                        norm(ast.unparse(f.annotation).strip("\"'"), selfish)
+                        for f in fields
+                    )
+    return out
 
 
 def declared_names(source: str, language: str) -> list[str]:
@@ -456,6 +623,17 @@ def uses_native_collection(source: str, spec: dict) -> bool:
     return not (wanted <= declared)
 
 
+def _uses_ailang_prelude(source: str, spec: dict) -> bool:
+    """Whether an AILANG solution leans on a prelude type it never declares."""
+    names = [c["name"] for c in spec.get("constructors", [])]
+    if not names:
+        return False
+    declared = {n.lower() for n in declared_names(source, "ailang")}
+    if any(n.lower() in declared for n in names):
+        return False
+    return all(re.search(rf"\b{re.escape(n)}\b", source) for n in names)
+
+
 def resolve_names(source: str, spec: dict, language: str) -> dict[str, str]:
     """Map canonical constructor names onto the ones the solution declares.
 
@@ -466,6 +644,11 @@ def resolve_names(source: str, spec: dict, language: str) -> dict[str, str]:
     type_name = spec.get("type", "")
     source = strip_comments(source, language)
     if language == "aver" and re.search(rf"\b{re.escape(type_name)}<", source):
+        return {}
+    if language == "ailang" and _uses_ailang_prelude(source, spec):
+        # Option/Some/None come from the auto-imported prelude, so there
+        # is no declaration to match — the canonical names ARE the
+        # prelude's, and a correct solution using them used to decline.
         return {}
     declared = declared_names(source, language)
     lowered = {d.lower(): d for d in declared}
@@ -488,6 +671,29 @@ def resolve_names(source: str, spec: dict, language: str) -> dict[str, str]:
         raise Unsupported(
             f"cannot map constructor {want!r} onto {declared or 'no declaration'}"
         )
+    # Shape validation, the guard the Vera side has had since #112: a
+    # solution declaring Cons(List, Int) — swapped but internally
+    # consistent and spec-legal — was rendered against the canonical
+    # order and graded WRONG. A mapping we cannot build a correct call
+    # for is a decline, not the model's failure.
+    shapes = declared_shape(source, language)
+    type_name = spec.get("type", "")
+    for want in spec.get("constructors", []):
+        actual = mapping.get(want["name"])
+        declared = shapes.get(actual)
+        if declared is None:
+            continue  # unverifiable in this language, not a mismatch
+        wanted = tuple(
+            "SELF" if a.lower() == type_name.lower() else a.lower()
+            for a in want.get("args", [])
+        )
+        if len(declared) != len(wanted) or any(
+            d != w and "SELF" in (d, w) for d, w in zip(declared, wanted)
+        ):
+            raise Unsupported(
+                f"constructor {want['name']} is declared as {declared}, "
+                f"expected {wanted}"
+            )
     if len(set(mapping.values())) != len(mapping):
         # Two canonical names resolved onto one declared constructor —
         # whichever call gets built is wrong for one of them, and it
@@ -615,6 +821,7 @@ def adt_call(problem: dict, source: str, language: str, args: list) -> str | Non
     qualifier = declared_type(source, language, spec)
     ts_fields = infer_ts_fields(source) if language == "typescript" else None
     ts_disc = infer_ts_discriminant(source) if language == "typescript" else "tag"
+    py_kwonly = python_kwonly_fields(source) if language == "python" else None
     return ", ".join(
         render_args(
             args,
@@ -626,6 +833,7 @@ def adt_call(problem: dict, source: str, language: str, args: list) -> str | Non
             qualifier,
             ts_fields,
             ts_disc,
+            py_kwonly,
         )
     )
 
@@ -647,8 +855,17 @@ def adt_expected(
     qualifier = declared_type(source, language, spec)
     ts_fields = infer_ts_fields(source) if language == "typescript" else None
     ts_disc = infer_ts_discriminant(source) if language == "typescript" else "tag"
+    py_kwonly = python_kwonly_fields(source) if language == "python" else None
     return render(
-        expected, spec, language, names, native, qualifier, ts_fields, ts_disc
+        expected,
+        spec,
+        language,
+        names,
+        native,
+        qualifier,
+        ts_fields,
+        ts_disc,
+        py_kwonly,
     )
 
 

--- a/vera_bench/adt_render.py
+++ b/vera_bench/adt_render.py
@@ -290,15 +290,38 @@ def align_kwonly(
         if actual in fields:
             field_names = fields[actual]
             declared = shapes.get(actual)
+            canonical = ctor.get("fields", [])
             if declared is None or len(declared) != len(field_names):
+                # A keyword-only constructor must NEVER fall through to
+                # positional rendering — that is a TypeError published as
+                # the model's wrong answer. Types are unavailable here
+                # (an unannotated keyword-only __init__, say), so the
+                # canonical names are the only way to order the fields:
+                # use them when they biject, and decline otherwise.
+                if canonical and set(canonical) == set(field_names):
+                    out[actual] = list(canonical)
+                elif not field_names:
+                    out[actual] = []
+                else:
+                    raise Unsupported(
+                        f"cannot align keyword-only fields {field_names} for "
+                        f"{actual}: no readable argument types and the "
+                        f"declared names do not match {canonical}"
+                    )
                 continue
             wanted = [
                 "SELF" if a.lower() == type_name.lower() else a.lower()
                 for a in ctor.get("args", [])
             ]
             if len(wanted) != len(field_names):
-                continue
-            canonical_fields = ctor.get("fields", [])
+                # Arity disagreement on a keyword-only constructor: a
+                # genuine mismatch, and again never a positional
+                # fallback.
+                raise Unsupported(
+                    f"constructor {ctor['name']} declares {len(field_names)} "
+                    f"keyword-only field(s), expected {len(wanted)}"
+                )
+            canonical_fields = canonical
             if len(set(wanted)) != len(wanted):
                 # Two arguments share a type — `Branch(Tree, Tree)` — so
                 # types cannot say which declared field is which, and

--- a/vera_bench/adt_render.py
+++ b/vera_bench/adt_render.py
@@ -677,12 +677,29 @@ def resolve_names(source: str, spec: dict, language: str) -> dict[str, str]:
     # order and graded WRONG. A mapping we cannot build a correct call
     # for is a decline, not the model's failure.
     shapes = declared_shape(source, language)
+    kwonly = python_kwonly_fields(source) if language == "python" else {}
     type_name = spec.get("type", "")
     for want in spec.get("constructors", []):
         actual = mapping.get(want["name"])
         declared = shapes.get(actual)
         if declared is None:
             continue  # unverifiable in this language, not a mismatch
+        if actual in kwonly:
+            # A keyword-only constructor is built by NAME, so the order
+            # it declares its fields in carries no meaning — comparing
+            # positionally would decline a correct solution that simply
+            # listed them differently. Compare as multisets: a genuine
+            # arity or type mismatch is still caught.
+            wanted_set = sorted(
+                "SELF" if a.lower() == type_name.lower() else a.lower()
+                for a in want.get("args", [])
+            )
+            if sorted(declared) != wanted_set:
+                raise Unsupported(
+                    f"constructor {want['name']} is declared as {declared}, "
+                    f"expected {tuple(wanted_set)} in some order"
+                )
+            continue
         wanted = tuple(
             "SELF" if a.lower() == type_name.lower() else a.lower()
             for a in want.get("args", [])

--- a/vera_bench/adt_render.py
+++ b/vera_bench/adt_render.py
@@ -249,8 +249,12 @@ def python_kwonly_fields(source: str) -> dict[str, list[str]]:
             for d in node.decorator_list
         )
         if kw_only:
+            # `obj.attr: int` is a legal annotated assignment whose
+            # target is an Attribute, not a Name — reading .id crashed.
             out[node.name] = [
-                n.target.id for n in node.body if isinstance(n, ast.AnnAssign)
+                n.target.id
+                for n in node.body
+                if isinstance(n, ast.AnnAssign) and isinstance(n.target, ast.Name)
             ]
     return out
 
@@ -259,6 +263,7 @@ def align_kwonly(
     fields: dict[str, list[str]],
     source: str,
     spec: dict,
+    names: dict[str, str] | None = None,
 ) -> dict[str, list[str]]:
     """Reorder keyword-only field names into CANONICAL argument order.
 
@@ -274,17 +279,24 @@ def align_kwonly(
     """
     shapes = declared_shape(source, "python")
     type_name = spec.get("type", "")
+    names = names or {}
     out: dict[str, list[str]] = {}
     for ctor in spec.get("constructors", []):
-        for actual, names in fields.items():
+        # Only the class this constructor actually resolved to. Scanning
+        # every keyword-only class meant an unrelated helper dataclass
+        # of the same arity hit the ambiguity branch and declined the
+        # whole problem.
+        actual = names.get(ctor["name"], ctor["name"])
+        if actual in fields:
+            field_names = fields[actual]
             declared = shapes.get(actual)
-            if declared is None or len(declared) != len(names):
+            if declared is None or len(declared) != len(field_names):
                 continue
             wanted = [
                 "SELF" if a.lower() == type_name.lower() else a.lower()
                 for a in ctor.get("args", [])
             ]
-            if len(wanted) != len(names):
+            if len(wanted) != len(field_names):
                 continue
             canonical_fields = ctor.get("fields", [])
             if len(set(wanted)) != len(wanted):
@@ -295,15 +307,15 @@ def align_kwonly(
                 # when the solution used the canonical ones; otherwise
                 # decline, because guessing reverses the children
                 # silently.
-                if canonical_fields and set(canonical_fields) == set(names):
+                if canonical_fields and set(canonical_fields) == set(field_names):
                     out[actual] = list(canonical_fields)
                     continue
                 raise Unsupported(
-                    f"cannot align keyword-only fields {names} for "
+                    f"cannot align keyword-only fields {field_names} for "
                     f"{actual}: {len(wanted)} arguments share a type and "
                     f"the declared names do not match {canonical_fields}"
                 )
-            remaining = list(zip(names, declared))
+            remaining = list(zip(field_names, declared))
             ordered: list[str] = []
             for want in wanted:
                 match = next(
@@ -318,12 +330,12 @@ def align_kwonly(
                 # fall back to positional — that raises TypeError and is
                 # published as the model's wrong answer.
                 raise Unsupported(
-                    f"cannot align keyword-only fields {names} for {actual}"
+                    f"cannot align keyword-only fields {field_names} for {actual}"
                 )
             out[actual] = ordered
     # Nullary constructors carry no fields and need no alignment.
-    for actual, names in fields.items():
-        if not names:
+    for actual, field_names in fields.items():
+        if not field_names:
             out.setdefault(actual, [])
     return out
 
@@ -880,6 +892,22 @@ def resolve_names(source: str, spec: dict, language: str) -> dict[str, str]:
     shapes = declared_shape(source, language)
     kwonly = python_kwonly_fields(source) if language == "python" else {}
     type_name = spec.get("type", "")
+
+    def _mismatch(d: str, w: str) -> bool:
+        """Whether two normalised types genuinely disagree.
+
+        An unrecognised type name is UNVERIFIABLE in both the positional
+        and the keyword-only path — comparing raw tokens there would
+        false-decline a solution whose type names we simply cannot
+        interpret.
+        """
+        if d == w:
+            return False
+        if "SELF" in (d, w):
+            return True
+        dk, wk = _SCALAR_EQUIV.get(d), _SCALAR_EQUIV.get(w)
+        return bool(dk and wk and dk != wk)
+
     for want in spec.get("constructors", []):
         actual = mapping.get(want["name"])
         declared = shapes.get(actual)
@@ -894,33 +922,23 @@ def resolve_names(source: str, spec: dict, language: str) -> dict[str, str]:
             def _key(t: str) -> str:
                 return "SELF" if t == "SELF" else _SCALAR_EQUIV.get(t, t)
 
-            wanted_set = sorted(
+            wanted_sorted = sorted(
                 _key("SELF" if a.lower() == type_name.lower() else a.lower())
                 for a in want.get("args", [])
             )
-            if sorted(_key(d) for d in declared) != wanted_set:
+            declared_sorted = sorted(_key(d) for d in declared)
+            if len(declared_sorted) != len(wanted_sorted) or any(
+                _mismatch(d, w) for d, w in zip(declared_sorted, wanted_sorted)
+            ):
                 raise Unsupported(
                     f"constructor {want['name']} is declared as {declared}, "
-                    f"expected {tuple(wanted_set)} in some order"
+                    f"expected {tuple(wanted_sorted)} in some order"
                 )
             continue
         wanted = tuple(
             "SELF" if a.lower() == type_name.lower() else a.lower()
             for a in want.get("args", [])
         )
-
-        def _mismatch(d: str, w: str) -> bool:
-            if d == w:
-                return False
-            if "SELF" in (d, w):
-                return True
-            # Both are concrete: compare through the equivalence table so
-            # Python's `str` matches a canonical `String`, while a
-            # genuine string-vs-int difference is caught. An unrecognised
-            # type name stays unverifiable rather than becoming a false
-            # decline.
-            dk, wk = _SCALAR_EQUIV.get(d), _SCALAR_EQUIV.get(w)
-            return bool(dk and wk and dk != wk)
 
         if len(declared) != len(wanted) or any(
             _mismatch(d, w) for d, w in zip(declared, wanted)
@@ -1057,7 +1075,7 @@ def adt_call(problem: dict, source: str, language: str, args: list) -> str | Non
     ts_fields = infer_ts_fields(source) if language == "typescript" else None
     ts_disc = infer_ts_discriminant(source) if language == "typescript" else "tag"
     py_kwonly = (
-        align_kwonly(python_kwonly_fields(source), source, spec)
+        align_kwonly(python_kwonly_fields(source), source, spec, names)
         if language == "python"
         else None
     )
@@ -1095,7 +1113,7 @@ def adt_expected(
     ts_fields = infer_ts_fields(source) if language == "typescript" else None
     ts_disc = infer_ts_discriminant(source) if language == "typescript" else "tag"
     py_kwonly = (
-        align_kwonly(python_kwonly_fields(source), source, spec)
+        align_kwonly(python_kwonly_fields(source), source, spec, names)
         if language == "python"
         else None
     )

--- a/vera_bench/adt_render.py
+++ b/vera_bench/adt_render.py
@@ -259,6 +259,24 @@ def python_kwonly_fields(source: str) -> dict[str, list[str]]:
     return out
 
 
+def _type_mismatch(declared: str, wanted: str) -> bool:
+    """Whether two normalised types genuinely disagree.
+
+    Module-level so `resolve_names` and `align_kwonly` cannot drift
+    apart: a solution whose `head: str` satisfied the shape guard used
+    to fail the alignment loop's raw `==` and decline anyway. An
+    unrecognised type name is UNVERIFIABLE everywhere rather than a
+    mismatch — comparing raw tokens would false-decline a solution whose
+    type names we simply cannot interpret.
+    """
+    if declared == wanted:
+        return False
+    if "SELF" in (declared, wanted):
+        return True
+    dk, wk = _SCALAR_EQUIV.get(declared), _SCALAR_EQUIV.get(wanted)
+    return bool(dk and wk and dk != wk)
+
+
 def align_kwonly(
     fields: dict[str, list[str]],
     source: str,
@@ -347,7 +365,12 @@ def align_kwonly(
             ordered: list[str] = []
             for want in wanted:
                 match = next(
-                    (i for i, (_, t) in enumerate(remaining) if t == want), None
+                    (
+                        i
+                        for i, (_, t) in enumerate(remaining)
+                        if not _type_mismatch(t, want)
+                    ),
+                    None,
                 )
                 if match is None:
                     ordered = []
@@ -809,8 +832,13 @@ def declared_shape(source: str, language: str) -> dict[str, tuple[str, ...]]:
                 b.id for b in node.bases if isinstance(b, ast.Name)
             }
             if init is not None:
-                params = init.args.posonlyargs + init.args.args[1:]
-                params += init.args.kwonlyargs
+                # The instance parameter is the first POSITIONAL one,
+                # which lands in posonlyargs for `def __init__(self, /,
+                # *, ...)` — a legal signature whose `self` used to be
+                # read as an extra argument, giving the constructor one
+                # too many and declining a correct solution.
+                positional = init.args.posonlyargs + init.args.args
+                params = positional[1:] + init.args.kwonlyargs
                 if all(p.annotation is not None for p in params) and params:
                     out[node.name] = tuple(
                         norm(ast.unparse(p.annotation).strip("\"'"), selfish)
@@ -921,21 +949,6 @@ def resolve_names(source: str, spec: dict, language: str) -> dict[str, str]:
     kwonly = python_kwonly_fields(source) if language == "python" else {}
     type_name = spec.get("type", "")
 
-    def _mismatch(d: str, w: str) -> bool:
-        """Whether two normalised types genuinely disagree.
-
-        An unrecognised type name is UNVERIFIABLE in both the positional
-        and the keyword-only path — comparing raw tokens there would
-        false-decline a solution whose type names we simply cannot
-        interpret.
-        """
-        if d == w:
-            return False
-        if "SELF" in (d, w):
-            return True
-        dk, wk = _SCALAR_EQUIV.get(d), _SCALAR_EQUIV.get(w)
-        return bool(dk and wk and dk != wk)
-
     for want in spec.get("constructors", []):
         actual = mapping.get(want["name"])
         declared = shapes.get(actual)
@@ -956,7 +969,7 @@ def resolve_names(source: str, spec: dict, language: str) -> dict[str, str]:
             )
             declared_sorted = sorted(_key(d) for d in declared)
             if len(declared_sorted) != len(wanted_sorted) or any(
-                _mismatch(d, w) for d, w in zip(declared_sorted, wanted_sorted)
+                _type_mismatch(d, w) for d, w in zip(declared_sorted, wanted_sorted)
             ):
                 raise Unsupported(
                     f"constructor {want['name']} is declared as {declared}, "
@@ -969,7 +982,7 @@ def resolve_names(source: str, spec: dict, language: str) -> dict[str, str]:
         )
 
         if len(declared) != len(wanted) or any(
-            _mismatch(d, w) for d, w in zip(declared, wanted)
+            _type_mismatch(d, w) for d, w in zip(declared, wanted)
         ):
             raise Unsupported(
                 f"constructor {want['name']} is declared as {declared}, "

--- a/vera_bench/adt_render.py
+++ b/vera_bench/adt_render.py
@@ -330,16 +330,42 @@ _TS_DISC = re.compile(r"""\b(?:readonly\s+)?(tag|kind)\s*:\s*["'](\w+)["']""")
 _TS_FIELD = re.compile(r"\b(?:readonly\s+)?(\w+)\s*:\s*([A-Za-z_][\w\[\]<>. ]*)")
 
 
-#: `type X = …` up to its terminating semicolon, and `interface X { … }`.
-_TS_DECL_REGION = re.compile(
-    r"\btype\s+\w+[^=;]*=\s*[^;]*;|\binterface\s+\w+[^{]*\{[^}]*(?:\{[^}]*\}[^}]*)*\}",
-    re.S,
-)
+_TS_DECL_START = re.compile(r"\b(type|interface)\s+\w+")
 
 
 def _ts_declaration_regions(source: str) -> list[str]:
-    """The type/interface declarations in a TypeScript source."""
-    return [m.group(0) for m in _TS_DECL_REGION.finditer(source)]
+    """The type/interface declarations in a TypeScript source.
+
+    Scanned with brace depth rather than matched by regex: `;` is also
+    the field separator INSIDE a union member, so a pattern ending at
+    the first semicolon truncated `type List = { tag: "Cons";` — no
+    complete block remained in the region, inference fell through to the
+    whole-source scan, and an object literal could pick the discriminant
+    again. That is the very failure the declaration-first rule exists to
+    prevent.
+
+    A `type` runs to its terminating semicolon at depth 0 (or to the end
+    of the source); an `interface` runs to its closing brace.
+    """
+    regions: list[str] = []
+    for m in _TS_DECL_START.finditer(source):
+        kind, i, depth, started = m.group(1), m.end(), 0, False
+        while i < len(source):
+            ch = source[i]
+            if ch in "{([":
+                depth += 1
+                started = True
+            elif ch in "})]":
+                depth -= 1
+                if kind == "interface" and started and depth == 0:
+                    i += 1
+                    break
+            elif ch == ";" and depth == 0:
+                i += 1
+                break
+            i += 1
+        regions.append(source[m.start() : i])
+    return regions
 
 
 def infer_ts_discriminant(source: str) -> str:
@@ -401,10 +427,14 @@ def infer_ts_fields(source: str) -> dict[str, list[tuple[str, str | None]]]:
         # is a DECLARATION: its value is a string literal, never a type,
         # so counting it would make every declaration look untyped and
         # silently disable type-based field alignment.
+        # Only the key this block actually discriminates on is dropped:
+        # excluding both spellings deleted a payload field legitimately
+        # named `kind` under a `tag` union, leaving the constructor an
+        # argument short.
         names = [
             n
             for n in re.findall(r"\b(?:readonly\s+)?(\w+)\s*:", body)
-            if n not in ("tag", "kind")
+            if n != disc.group(1)
         ]
         types = {n: t.strip() for n, t in _TS_FIELD.findall(body)}
         is_decl = bool(names) and all(n in types for n in names)

--- a/vera_bench/adt_render.py
+++ b/vera_bench/adt_render.py
@@ -272,10 +272,15 @@ def align_kwonly(
     value to the wrong field — `Cons(tail=1, head=Nil())` — which is a
     mis-grade, strictly worse than the false decline this ordering
     tolerance replaced. Fields are matched to arguments by declared
-    type, exactly as the TypeScript path aligns its own. A constructor
-    that cannot be aligned is dropped, so it renders positionally and
-    any real mismatch surfaces as an honest failure rather than a
-    silently scrambled call.
+    type, exactly as the TypeScript path aligns its own.
+
+    A constructor that cannot be aligned raises `Unsupported`, leaving
+    the problem ungraded. It is deliberately NOT dropped: dropping falls
+    back to positional rendering, which a keyword-only class rejects
+    with `TypeError` — published as the model's wrong answer. Where
+    types are unreadable the canonical field names are used instead,
+    when they biject with the declared ones, so that case is still
+    graded rather than declined.
     """
     shapes = declared_shape(source, "python")
     type_name = spec.get("type", "")
@@ -300,7 +305,7 @@ def align_kwonly(
                 # use them when they biject, and decline otherwise.
                 if canonical and set(canonical) == set(field_names):
                     out[actual] = list(canonical)
-                elif not field_names:
+                elif not field_names and not canonical:
                     out[actual] = []
                 else:
                     raise Unsupported(

--- a/vera_bench/adt_render.py
+++ b/vera_bench/adt_render.py
@@ -286,6 +286,23 @@ def align_kwonly(
             ]
             if len(wanted) != len(names):
                 continue
+            canonical_fields = ctor.get("fields", [])
+            if len(set(wanted)) != len(wanted):
+                # Two arguments share a type — `Branch(Tree, Tree)` — so
+                # types cannot say which declared field is which, and
+                # declaration order is not a proxy for semantic order
+                # once reordering is allowed. Names can still resolve it
+                # when the solution used the canonical ones; otherwise
+                # decline, because guessing reverses the children
+                # silently.
+                if canonical_fields and set(canonical_fields) == set(names):
+                    out[actual] = list(canonical_fields)
+                    continue
+                raise Unsupported(
+                    f"cannot align keyword-only fields {names} for "
+                    f"{actual}: {len(wanted)} arguments share a type and "
+                    f"the declared names do not match {canonical_fields}"
+                )
             remaining = list(zip(names, declared))
             ordered: list[str] = []
             for want in wanted:
@@ -296,8 +313,14 @@ def align_kwonly(
                     ordered = []
                     break
                 ordered.append(remaining.pop(match)[0])
-            if ordered or not wanted:
-                out[actual] = ordered
+            if not ordered and wanted:
+                # A keyword-only constructor we cannot order must not
+                # fall back to positional — that raises TypeError and is
+                # published as the model's wrong answer.
+                raise Unsupported(
+                    f"cannot align keyword-only fields {names} for {actual}"
+                )
+            out[actual] = ordered
     # Nullary constructors carry no fields and need no alignment.
     for actual, names in fields.items():
         if not names:
@@ -661,6 +684,26 @@ _DECL = {
 }
 
 
+#: Each language's spelling of the same scalar, mapped to one token, so
+#: a declared shape can be compared with the spec's for EQUALITY rather
+#: than only for self-reference. Without this, `Cons(String, Self)`
+#: against a canonical `Cons(Int, Self)` passed validation and the
+#: wrapper rendered an integer into a string field.
+_SCALAR_EQUIV = {
+    "int": "int",
+    "nat": "int",
+    "integer": "int",
+    "number": "int",
+    "str": "string",
+    "string": "string",
+    "bool": "bool",
+    "boolean": "bool",
+    "float": "float",
+    "float64": "float",
+    "double": "float",
+}
+
+
 def declared_shape(source: str, language: str) -> dict[str, tuple[str, ...]]:
     """Declared constructor argument SHAPES, where the language shows them.
 
@@ -694,6 +737,12 @@ def declared_shape(source: str, language: str) -> dict[str, tuple[str, ...]]:
             if nxt:
                 body = body[: nxt.start()]
             for name, args in re.findall(r"\b(\w+)\s*\(([^)]*)\)", body):
+                # `[^)]*` cannot see a nested application, and splitting
+                # on commas would flatten it into the wrong arity.
+                # Unverifiable beats wrong: leave it out and the shape
+                # guard skips this constructor.
+                if "(" in args:
+                    continue
                 parts = [a for a in args.split(",") if a.strip()]
                 out.setdefault(name, tuple(norm(a, self_name) for a in parts))
     if language == "python":
@@ -842,11 +891,14 @@ def resolve_names(source: str, spec: dict, language: str) -> dict[str, str]:
             # positionally would decline a correct solution that simply
             # listed them differently. Compare as multisets: a genuine
             # arity or type mismatch is still caught.
+            def _key(t: str) -> str:
+                return "SELF" if t == "SELF" else _SCALAR_EQUIV.get(t, t)
+
             wanted_set = sorted(
-                "SELF" if a.lower() == type_name.lower() else a.lower()
+                _key("SELF" if a.lower() == type_name.lower() else a.lower())
                 for a in want.get("args", [])
             )
-            if sorted(declared) != wanted_set:
+            if sorted(_key(d) for d in declared) != wanted_set:
                 raise Unsupported(
                     f"constructor {want['name']} is declared as {declared}, "
                     f"expected {tuple(wanted_set)} in some order"
@@ -856,8 +908,22 @@ def resolve_names(source: str, spec: dict, language: str) -> dict[str, str]:
             "SELF" if a.lower() == type_name.lower() else a.lower()
             for a in want.get("args", [])
         )
+
+        def _mismatch(d: str, w: str) -> bool:
+            if d == w:
+                return False
+            if "SELF" in (d, w):
+                return True
+            # Both are concrete: compare through the equivalence table so
+            # Python's `str` matches a canonical `String`, while a
+            # genuine string-vs-int difference is caught. An unrecognised
+            # type name stays unverifiable rather than becoming a false
+            # decline.
+            dk, wk = _SCALAR_EQUIV.get(d), _SCALAR_EQUIV.get(w)
+            return bool(dk and wk and dk != wk)
+
         if len(declared) != len(wanted) or any(
-            d != w and "SELF" in (d, w) for d, w in zip(declared, wanted)
+            _mismatch(d, w) for d, w in zip(declared, wanted)
         ):
             raise Unsupported(
                 f"constructor {want['name']} is declared as {declared}, "

--- a/vera_bench/adt_render.py
+++ b/vera_bench/adt_render.py
@@ -160,6 +160,39 @@ def _elem_type(spec: dict) -> str:
     return "Int"
 
 
+def _dataclass_aliases(tree: object) -> set[str]:
+    """Names in this module that actually refer to dataclasses.dataclass."""
+    import ast
+
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "dataclasses":
+            for a in node.names:
+                if a.name == "dataclass":
+                    names.add(a.asname or a.name)
+        elif isinstance(node, ast.Import):
+            for a in node.names:
+                if a.name == "dataclasses":
+                    names.add((a.asname or a.name) + ".dataclass")
+    return names
+
+
+def _is_dataclass_decorator(func: object, aliases: set[str]) -> bool:
+    """Whether a decorator expression resolves to dataclasses.dataclass.
+
+    An unrelated decorator that happens to take a `kw_only` keyword would
+    otherwise be read as one, and the constructor built by keyword
+    against a positional signature.
+    """
+    import ast
+
+    if isinstance(func, ast.Name):
+        return func.id in aliases
+    if isinstance(func, ast.Attribute):
+        return ast.unparse(func) in aliases
+    return False
+
+
 def python_kwonly_fields(source: str) -> dict[str, list[str]]:
     """Keyword-only parameter names per class, for kw_only dataclasses.
 
@@ -176,6 +209,7 @@ def python_kwonly_fields(source: str) -> dict[str, list[str]]:
         tree = ast.parse(strip_comments(source, "python"))
     except SyntaxError:
         return out
+    aliases = _dataclass_aliases(tree)
     for node in ast.walk(tree):
         if not isinstance(node, ast.ClassDef):
             continue
@@ -193,6 +227,7 @@ def python_kwonly_fields(source: str) -> dict[str, list[str]]:
             continue
         kw_only = any(
             isinstance(d, ast.Call)
+            and _is_dataclass_decorator(d.func, aliases)
             and any(
                 k.arg == "kw_only" and getattr(k.value, "value", False) is True
                 for k in d.keywords
@@ -203,6 +238,56 @@ def python_kwonly_fields(source: str) -> dict[str, list[str]]:
             out[node.name] = [
                 n.target.id for n in node.body if isinstance(n, ast.AnnAssign)
             ]
+    return out
+
+
+def align_kwonly(
+    fields: dict[str, list[str]],
+    source: str,
+    spec: dict,
+) -> dict[str, list[str]]:
+    """Reorder keyword-only field names into CANONICAL argument order.
+
+    `rendered` values are built in the spec's argument order while the
+    names come from the declaration, so zipping them directly bound each
+    value to the wrong field — `Cons(tail=1, head=Nil())` — which is a
+    mis-grade, strictly worse than the false decline this ordering
+    tolerance replaced. Fields are matched to arguments by declared
+    type, exactly as the TypeScript path aligns its own. A constructor
+    that cannot be aligned is dropped, so it renders positionally and
+    any real mismatch surfaces as an honest failure rather than a
+    silently scrambled call.
+    """
+    shapes = declared_shape(source, "python")
+    type_name = spec.get("type", "")
+    out: dict[str, list[str]] = {}
+    for ctor in spec.get("constructors", []):
+        for actual, names in fields.items():
+            declared = shapes.get(actual)
+            if declared is None or len(declared) != len(names):
+                continue
+            wanted = [
+                "SELF" if a.lower() == type_name.lower() else a.lower()
+                for a in ctor.get("args", [])
+            ]
+            if len(wanted) != len(names):
+                continue
+            remaining = list(zip(names, declared))
+            ordered: list[str] = []
+            for want in wanted:
+                match = next(
+                    (i for i, (_, t) in enumerate(remaining) if t == want), None
+                )
+                if match is None:
+                    ordered = []
+                    break
+                ordered.append(remaining.pop(match)[0])
+            if ordered or not wanted:
+                out[actual] = ordered
+    # Nullary constructors carry no fields and need no alignment.
+    for actual, names in fields.items():
+        if not names:
+            out.setdefault(actual, [])
     return out
 
 
@@ -838,7 +923,11 @@ def adt_call(problem: dict, source: str, language: str, args: list) -> str | Non
     qualifier = declared_type(source, language, spec)
     ts_fields = infer_ts_fields(source) if language == "typescript" else None
     ts_disc = infer_ts_discriminant(source) if language == "typescript" else "tag"
-    py_kwonly = python_kwonly_fields(source) if language == "python" else None
+    py_kwonly = (
+        align_kwonly(python_kwonly_fields(source), source, spec)
+        if language == "python"
+        else None
+    )
     return ", ".join(
         render_args(
             args,
@@ -872,7 +961,11 @@ def adt_expected(
     qualifier = declared_type(source, language, spec)
     ts_fields = infer_ts_fields(source) if language == "typescript" else None
     ts_disc = infer_ts_discriminant(source) if language == "typescript" else "tag"
-    py_kwonly = python_kwonly_fields(source) if language == "python" else None
+    py_kwonly = (
+        align_kwonly(python_kwonly_fields(source), source, spec)
+        if language == "python"
+        else None
+    )
     return render(
         expected,
         spec,

--- a/vera_bench/runner.py
+++ b/vera_bench/runner.py
@@ -1279,6 +1279,11 @@ def _strip_module_effects(code: str) -> str:
 def _interpolation_safe(value: object, language: str) -> None:
     """Refuse a string the target language would re-interpolate.
 
+    Recurses: a test-case argument is often a list or a tagged
+    constructor, and VB-T2-006 passes a list of strings today, so a
+    top-level-only check missed the values that actually reach the
+    interpolator.
+
     The Aver call is built inside `Console.print("{fn(...)}")` and
     AILANG's strings interpolate `${...}`, so a test-case string
     containing those markers is EVALUATED rather than passed — the
@@ -1286,6 +1291,14 @@ def _interpolation_safe(value: object, language: str) -> None:
     specifies. Declining beats grading against an argument we did not
     send.
     """
+    if isinstance(value, dict):  # a tagged constructor: {"Some": [...]}
+        for nested in value.values():
+            _interpolation_safe(nested, language)
+        return
+    if isinstance(value, (list, tuple)):
+        for nested in value:
+            _interpolation_safe(nested, language)
+        return
     if not isinstance(value, str):
         return
     if language == "aver" and ("{" in value or "}" in value):

--- a/vera_bench/runner.py
+++ b/vera_bench/runner.py
@@ -793,6 +793,8 @@ def _evaluate_aver_code(
         # Unsupported declines the whole problem to ungraded, same
         # contract as every other evaluator.
         try:
+            for _a in args:
+                _interpolation_safe(_a, "aver")
             adt_args = _adt_call(problem, code_without_main, "aver", args)
             printed = _adt_printed(problem, code_without_main, "aver", expected)
         except Unsupported as e:
@@ -1110,6 +1112,8 @@ def _evaluate_ailang_code(
         expected = tc.get("expected")
         # Same ADT and @Unit handling as the Aver evaluator above.
         try:
+            for _a in args:
+                _interpolation_safe(_a, "ailang")
             adt_args = _adt_call(problem, code_without_main, "ailang", args)
             printed = _adt_printed(problem, code_without_main, "ailang", expected)
         except Unsupported as e:
@@ -1270,6 +1274,24 @@ def _strip_module_effects(code: str) -> str:
             continue
         out.append(line)
     return "\n".join(out)
+
+
+def _interpolation_safe(value: object, language: str) -> None:
+    """Refuse a string the target language would re-interpolate.
+
+    The Aver call is built inside `Console.print("{fn(...)}")` and
+    AILANG's strings interpolate `${...}`, so a test-case string
+    containing those markers is EVALUATED rather than passed — the
+    function is silently called with a different value than the case
+    specifies. Declining beats grading against an argument we did not
+    send.
+    """
+    if not isinstance(value, str):
+        return
+    if language == "aver" and ("{" in value or "}" in value):
+        raise Unsupported(f"aver would re-interpolate {value!r}")
+    if language == "ailang" and "${" in value:
+        raise Unsupported(f"ailang would re-interpolate {value!r}")
 
 
 def _aver_literal(value) -> str:


### PR DESCRIPTION
Fixes every confirmed finding in #113 — the adversarial-review defects that needed more than a small patch. All of them are grading fairness: a correct model answer recorded as wrong, or a legal idiom ungraded.

## The critical: shape validation in the four non-Vera languages

`resolve_names` matched constructors by **name** and never checked declared shape. A solution writing `Cons(List, Int)` — a swap, internally consistent, and permitted by the problem statement, which prescribes no argument order — had canonical-order arguments rendered into it and failed at runtime as *the model's wrong answer*. Vera has declined exactly this since #112.

Arity alone cannot catch a swap, so `declared_shape` reads argument **types** where the language shows them: Aver and AILANG declarations, annotated Python including dataclass fields, normalising self-references so a spec's `["Int", "List"]` compares against what the solution actually wrote. Unannotated Python stays permissive — unreadable is not the same as wrong, and declining it would ungrade correct solutions wholesale.

## Idioms the languages' own documentation teaches

| idiom | was | now |
|---|---|---|
| TS `readonly` members | invisible to inference | read |
| TS discriminant not first | invisible | read |
| AILANG `type MyList[a] = …` | never matched | matched |
| AILANG prelude `Option`/`Some`/`None` | declined (nothing to match) | recognised |
| `@dataclass(kw_only=True)` | `TypeError`, graded 1/4 | built by keyword |

The TS fix has a subtlety worth noting: the discriminant must be excluded *before* judging whether a block is a declaration, because its value is a string literal rather than a type — counting it made every declaration look untyped and silently disabled type-based field alignment.

## Also

- A test-case string containing `{…}` or `${…}` was silently **re-evaluated** by Aver's and AILANG's interpolation, calling the function with a different value than the case specifies. Declines now, rather than grading against an argument we did not send.
- `rerun_failed.py` looked for the canonical file's stem in a scratch tree that names its output with *current* versions, so under any drift a repaired row kept pointing at the original failed attempt's stored code.
- One finding needed no work: the Aver builtin-mix case was already fixed by `dd95fc5`'s spec-aware `uses_native_collection` — verified before touching it.

## Numbers

888 tests · validate 60/60 · python/typescript/aver/ailang baselines 60 passing, zero failures · published v0.0.16 numbers reproduce exactly.

This is the last blocker before a full-60 sweep, and the intended content of the **v0.0.18 tag** once merged.

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened ADT grading and name resolution by validating declared constructor shapes, including swapped/inconsistent cases, and aligning Python `@dataclass(kw_only=True)` field ordering.
  * Improved TypeScript discriminant and field inference, including `readonly` handling and declaration-region scanning; tightened AILANG generic and prelude behaviour.
  * Prevented Aver/AILANG wrapper interpolation problems by rejecting unsafe `{…}` / `${…}` strings, including nested cases.
* **Tests**
  * Expanded ADT renderer coverage for shape guards, previously-declined idioms, keyword-only dataclasses, and interpolation safety.
* **Chores**
  * Improved failed-run re-run code recovery and updated changelog entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->