### PR TITLE
fix: grading and triage defects the first full-60 sweep exposed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deleted in v0.0.16, including in the models line it prints. The gate
   reads `vera_bench/matrix.py` and always did; only the labelling was
   wrong.
+- **A model's non-terminating code was triaged as an infrastructure
+  fault.** `sweep_status.py`'s transient bucket matched a bare `timed
+  out`, which covers both a provider call failing and the harness's own
+  30s budget on the model's *compiled* code. The second is a real,
+  deterministic result — the program never returned, which is a wrong
+  answer — so the sweep retried it to its retry limit, the target read
+  `RE-RUN` forever, and `rerun_failed.py` kept re-running it without
+  progress. Per-test failures carry the harness's `test N:` prefix and
+  run locally with no network involved, so that prefix now settles the
+  bucket before any transient word is consulted. Found on the first
+  full-60 sweep: Opus 4.8 wrote a `list_reverse` that passes `vera
+  check` and then does not terminate.
+- **`rerun_failed.py` could not find its target once a second release
+  existed.** It globbed the canonical name only as far as `-bench-`, so
+  with 0.0.16 and 0.0.18 side by side in `results/` every repair exited
+  `ambiguous — 2 files match`. The prefix now pins the bench version
+  (default: installed), with `--bench-version` to reach a superseded
+  era; the compiler segment stays a wildcard, since a target's Vera
+  version is whatever produced it. Same defect class as the sweep
+  runner's hardcoded version, in the one script that only ever runs
+  after a sweep — so it failed precisely when it was needed.
 
 
 ## [0.0.18] - 2026-07-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bucket before any transient word is consulted. Found on the first
   full-60 sweep: Opus 4.8 wrote a `list_reverse` that passes `vera
   check` and then does not terminate.
+- **A generic TypeScript entry point was never exported, and the model
+  was blamed.** The harness splices `export` onto the declaration by
+  string-matching `function name(`. A generic solution writes `function
+  listLength<T>(list: List<T>)`, which does not match — so no export was
+  added, the wrapper's import resolved to `undefined`, and every test
+  threw "is not a function". That is a WRAPPING failure recorded as the
+  model's wrong answer, and it hit 51 solutions, all in the ADT tiers
+  where generics are idiomatic. The injection now matches the
+  declaration rather than a literal call shape, and covers arrow-function
+  entry points too. Same defect class as the ADT mapper: a literal string
+  match that generics walk straight past.
 - **A truncation was published as a model refusal.** `sweep_status.py`
   knew only OpenAI's `finish_reason=length`; Anthropic spells a token
   wall `stop_reason=max_tokens`, and its message also contains "no text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reads it, leaving both confounds (toolchain and denominator) on the
   single step where Opus 4 is pinned to the only release that ever swept
   it. A model appears at one score per deck.
+- **The generation chain mixed a family line with a tier jump.** Claude
+  Fable 5 was appended as a fourth link on the mistaken basis that it was
+  the newest model; it is the CEILING tier — more capable than Opus 5,
+  not later than it — so the slope into it read as generational progress
+  that never happened, and it pushed the controlled pair into the middle
+  of the chain, where the companion slide looked like a zoom on an
+  arbitrary interior segment. The chain is one family in release order
+  again, which makes the controlled pair its final step.
 - **The coverage slide outlived its premise.** It argued that pass@1
   could not see the problems without test cases; every problem now has
   them, so it rendered "0 of 60" beside a 0% hero stat that read as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,9 +65,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The delta chart's legend covered the largest bar.** It was placed
   `lower right` INSIDE the axes, which on a diverging chart is exactly
   where the biggest positive delta ends, so the strongest Vera result
-  and its value label sat underneath a semi-transparent box. Moved
-  above the axes in both the slide and the canonical chart, where it
-  cannot collide with data at all.
+  and its value label sat underneath a semi-transparent box. It now sits
+  upper-left inside the axes in both the slide and the canonical chart —
+  the sparse half, since Vera loses rarely and never by much, and its
+  top rows carry no bar at all.
 - **The generation slide asserted findings it no longer had.** Its
   title and subtitle were hardcoded ("Three flagships, one trajectory",
   "the Vera line rises at every step") — both true of a three-link
@@ -83,6 +84,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reads it, leaving both confounds (toolchain and denominator) on the
   single step where Opus 4 is pinned to the only release that ever swept
   it. A model appears at one score per deck.
+- **`rerun_failed.py` could reach into a neighbouring release.** Its
+  bench-version token was not terminated, so `0.0.18` also matched
+  `bench-0-0-180-...`. A lookup failure would have been harmless; this
+  one ends in a splice, so it would have written rows into the wrong
+  era's results. The glob now accepts only the two shapes a real name
+  takes after the bench segment: a compiler segment, or the extension.
+- **`rerun_failed.py` judged a file finished by counting rows.** A fix
+  attempt emits a second row for the same problem, so a file can reach
+  60 rows while problems are still missing — and the guard exists
+  precisely to stop a repair racing a sweep that is still writing. It
+  now counts unique problem ids, the denominator `sweep_status` uses.
 - **The generation chain mixed a family line with a tier jump.** Claude
   Fable 5 was appended as a fourth link on the mistaken basis that it was
   the newest model; it is the CEILING tier — more capable than Opus 5,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bucket before any transient word is consulted. Found on the first
   full-60 sweep: Opus 4.8 wrote a `list_reverse` that passes `vera
   check` and then does not terminate.
+- **A truncation was published as a model refusal.** `sweep_status.py`
+  knew only OpenAI's `finish_reason=length`; Anthropic spells a token
+  wall `stop_reason=max_tokens`, and its message also contains "no text
+  block" — which the refusal pattern matches, and which was tested
+  first. So an Anthropic truncation was relabelled a decline: a
+  recoverable failure (raise `--max-tokens`, re-run) was kept as a real
+  verdict and counted in the published refusal figure. `LENGTH` now
+  covers both spellings and a shared `is_refusal()` excludes
+  truncations, so the sweep monitor and the refusal chart — which read
+  the same pattern through different filters, and disagreed — cannot
+  diverge again.
+- **The delta chart's legend covered the largest bar.** It was placed
+  `lower right` INSIDE the axes, which on a diverging chart is exactly
+  where the biggest positive delta ends, so the strongest Vera result
+  and its value label sat underneath a semi-transparent box. Moved
+  above the axes in both the slide and the canonical chart, where it
+  cannot collide with data at all.
+- **The generation slide asserted findings it no longer had.** Its
+  title and subtitle were hardcoded ("Three flagships, one trajectory",
+  "the Vera line rises at every step") — both true of a three-link
+  chain and false once a fourth landed. Both are now computed from the
+  plotted points. `--pair-only` now names its controlled pair explicitly
+  instead of taking the last two links, which had silently stopped being
+  controlled once the chain grew.
+- **Two slides in one deck disagreed about the same two models.** The
+  generation chain read Opus 4.8 and Opus 5 from 0.0.16 while the
+  controlled-pair slide read them from 0.0.18 — 36 graded problems
+  against 60 — so Opus 4.8 to Opus 5 in TypeScript fell 6 points on one
+  slide and rose 3 on the other. Every link that has 0.0.18 data now
+  reads it, leaving both confounds (toolchain and denominator) on the
+  single step where Opus 4 is pinned to the only release that ever swept
+  it. A model appears at one score per deck.
+- **The coverage slide outlived its premise.** It argued that pass@1
+  could not see the problems without test cases; every problem now has
+  them, so it rendered "0 of 60" beside a 0% hero stat that read as
+  Vera failing everything. It now measures where `vera check` and
+  `vera run` disagree: the programs that cleared the static gate and
+  still failed, named individually, against the count of working
+  programs wrongly refused.
 - **`rerun_failed.py` could not find its target once a second release
   existed.** It globbed the canonical name only as far as `-bench-`, so
   with 0.0.16 and 0.0.18 side by side in `results/` every repair exited

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -38,6 +38,30 @@ cannot run concurrently with the sweep (both unlink/write the same file).
 **Exit condition:** [#101](https://github.com/aallan/vera-bench/issues/101) —
 fold per-problem retry into the sweep's dirty path.
 
+### `baselines` deletes its output before it has a replacement
+
+`vera-bench baselines` unlinks `results/{language}-baseline.jsonl` at startup and
+writes it at the end, so any interruption in between leaves no file. `results/` is
+gitignored, so there is no recovery except re-running. `aver-baseline.jsonl`
+vanished three times during the v0.0.18 sweep work, each time after being
+verified at 60/60. The trigger varies; the design does not.
+
+**Exit condition:** [#118](https://github.com/aallan/vera-bench/issues/118) —
+write to a temp file and `os.replace()` it into position, as
+`rerun_failed.py` and `regrade.py` already do.
+
+### A nullary Python class is read as unverifiable
+
+`declared_shape` treats a class with no `__init__` and no annotated fields as
+unverifiable rather than as arity 0, so the shape guard skips it and `adt_call`
+renders a call the class cannot accept — `class Leaf: pass` against a spec
+wanting `Leaf(Int)` fails with a raw `TypeError` instead of declining. The
+verdict is right (the model's type cannot hold the test value); the route is
+not. Nine Python Tier 3/4 rows in the v0.0.18 sweep take this path.
+
+**Exit condition:** [#119](https://github.com/aallan/vera-bench/issues/119) —
+distinguish "no annotations" (unverifiable) from "no fields at all" (arity 0).
+
 ### The test suite isn't tiered — flaky toolchain tests gate the merge
 
 CI runs the whole suite (`pytest -v`) on every push, mixing fast hermetic unit

--- a/scripts/plot_narrative.py
+++ b/scripts/plot_narrative.py
@@ -684,7 +684,10 @@ def render_generation(
 
     # The model names live in the legend already; repeating them here is
     # what pushed this line off both edges of a 16:9 canvas at four links.
-    moved = [f"{m} {_net(m):+d}" for m in (wanted or CORE_MODES) if _net(m) is not None]
+    # `modes` is the filtered set actually drawn; `wanted` is only what was
+    # asked for. Reporting a net change for a language no series was
+    # plotted for would put a number on the slide with nothing behind it.
+    moved = [f"{m} {_net(m):+d}" for m in modes if _net(m) is not None]
     ax.text(
         0.5,
         1.016,
@@ -1041,7 +1044,13 @@ def render_coverage(
     )
     order = {c: i for i, (c, _) in enumerate(CAUSE_ORDER)}
     rows_sorted = sorted(escapes, key=lambda e: (order.get(e[2], 9), e[0], e[1]))
-    y = 0.855
+    # Row pitch adapts to the count. At a fixed 0.125 the eighth escape
+    # landed below the panel, so a WORSE result — more programs slipping
+    # past the static gate — would have hidden the extra ones, quietly
+    # flattering the very number this slide exists to report.
+    top = 0.855
+    step = min(0.125, top / max(len(rows_sorted), 1))
+    y = top
     for model, pid, cause in rows_sorted:
         tag = next((k for c, k in CAUSE_ORDER if c == cause), "BROWN")
         ax.text(
@@ -1067,7 +1076,7 @@ def render_coverage(
             va="top",
             fontweight="bold",
         )
-        y -= 0.125
+        y -= step
 
     # --- right: the two numbers that bound the claim ---
     ax2 = fig.add_subplot(gs[0, 1])
@@ -1125,7 +1134,11 @@ def render_coverage(
     ax2.text(
         0.0,
         -0.03,
-        "the gate never refused code that ran correctly",
+        (
+            "the gate never refused code that ran correctly"
+            if false_alarms == 0
+            else f"{false_alarms} program(s) it refused ran correctly anyway"
+        ),
         fontsize=TICK_PT_SMALL,
         color=BROWN_500,
         va="top",
@@ -1149,7 +1162,12 @@ def render_coverage(
         f"program — {graded} pairs across {len(rows_by_target)} models.\n"
         "Contracts bound what a program may do; they do not say everything "
         "it must do, so a few satisfy them and are still wrong.\n"
-        "The cost of that gate is the number worth watching, and it is zero.",
+        + (
+            "The cost of that gate is the number worth watching, and it is zero."
+            if false_alarms == 0
+            else f"The cost of that gate is {false_alarms} working program(s) "
+            "it wrongly refused."
+        ),
         ha="center",
         va="top",
         fontsize=SUBTITLE_PT - 3,

--- a/scripts/plot_narrative.py
+++ b/scripts/plot_narrative.py
@@ -14,9 +14,10 @@ slides here need something that aggregate cannot express:
 - `saturation` — every (model, language) score as its own dot, to show
                  the frontier is bunched against the ceiling and that the
                  headline deltas are one or two problems wide.
-- `coverage`   — what pass@1 structurally cannot see: the problems
-                 with no test cases, and Vera's check/verify rates over
-                 the rest.
+- `coverage`   — where the static gate and the runtime disagree: the
+                 programs that cleared `vera check` and still failed,
+                 named individually, against the count that were wrongly
+                 refused.
 
 Kept out of `plot_slide.py` deliberately. That module's data path is
 `extract_data` -> tier dict of ints; threading a second, row-level path
@@ -102,28 +103,48 @@ from scripts.plot_slide import (  # noqa: E402
     _slide_rcparams,
     _style_ax,
 )
-from scripts.sweep_status import REFUSAL  # noqa: E402
+from scripts.sweep_status import is_refusal  # noqa: E402
 
 ALL_MODES = ["Vera", "Vera NL", "Python", "TypeScript", "Aver", "AILANG"]
 
-# The Anthropic flagship line, oldest first, as (bench version, display).
-# Cross-version by design: Opus 4 was only ever swept under bench 0.0.9,
-# so the trajectory cannot be read out of a single results generation.
-# The arithmetic is sound: 0.0.9 covered the same 36 graded problems and
-# every one carries a real verdict, so no score is depressed by test cases
-# that only existed later. The ATTRIBUTION is what is confounded. Three
-# things moved between the first and second links, all of them Vera-side:
-# the compiler and its stdlib (0.0.112 -> 0.1.7), SKILL.md (fetched at
-# runtime, so never pinned), and the problem definitions. That step
-# therefore measures the ecosystem improving as much as the model — and a
-# stdlib expansion lands hardest on Tier 2, which tests built-in function
-# discovery. Only the 4.8 -> 5 step is controlled: same bench version,
-# compiler, prompt and problems. Python and TypeScript touch none of the
-# Vera toolchain, which is what makes their line the control.
+# The Anthropic ceiling line, oldest first, as (bench version, display).
+# Cross-version by design: each model is pinned to a release that actually
+# swept it — Opus 4 only ever ran under 0.0.9 — so the trajectory cannot
+# be read out of a single results generation.
+#
+# TWO confounds ride along, and both are printed on the slide rather than
+# buried here. First, ATTRIBUTION: the compiler and its stdlib
+# (0.0.112 -> 0.1.8), SKILL.md (fetched at runtime, so never pinned) and
+# the problem definitions all moved under the FIRST step, so it measures
+# the ecosystem improving as much as the model — a stdlib expansion lands
+# hardest on Tier 2, which tests built-in function discovery. Second,
+# DENOMINATOR: 0.0.9 grades 36 problems, 0.0.18 all 60. Both confounds
+# now sit on that one step; every later link shares a release, a
+# compiler and a problem set, so the rest of the line is like-for-like.
+#
+# Read the slope for direction, never for the size of any single step.
+# Python and TypeScript touch none of the Vera toolchain, which is what
+# makes their lines the control. For a step with NO confound, use
+# CONTROLLED_PAIR (--pair-only).
 GENERATION_CHAIN = [
     ("0.0.9", "Claude Opus 4"),
-    ("0.0.16", "Claude Opus 4.8"),
-    ("0.0.16", "Claude Opus 5"),
+    ("0.0.18", "Claude Opus 4.8"),
+    ("0.0.18", "Claude Opus 5"),
+    ("0.0.18", "Claude Fable 5"),
+]
+
+# The controlled step, named separately rather than taken as the chain's
+# last two links — those stopped coinciding once a fourth link landed.
+# It is now a genuine sub-segment of the chain: same models, same bench
+# version, same numbers. That matters because both slides go in one deck.
+# While the chain read these two from 0.0.16 and this pair read them from
+# 0.0.18, the two slides disagreed about the SAME pair — Opus 4.8 to Opus
+# 5 in TypeScript fell 6 points on one and rose 3 on the other — because
+# 0.0.16 grades 36 problems and 0.0.18 grades 60. A model appears at one
+# score per deck, so every link that HAS 0.0.18 data reads it.
+CONTROLLED_PAIR = [
+    ("0.0.18", "Claude Opus 4.8"),
+    ("0.0.18", "Claude Opus 5"),
 ]
 
 # The default mode set for every slide here. Aver and AILANG belong on
@@ -225,7 +246,7 @@ def find_refusals(
     found: list[dict] = []
     for (model, mode), best in best_cache.items():
         for pid, row in best.items():
-            if not REFUSAL.search(row.get("error_message") or ""):
+            if not is_refusal(row.get("error_message") or ""):
                 continue
             solved_in = sorted(
                 other_mode
@@ -491,7 +512,7 @@ def render_generation(
     marks with no area to misread.
     """
     wanted = modes or CORE_MODES
-    chain = GENERATION_CHAIN if span_versions else GENERATION_CHAIN[-2:]
+    chain = GENERATION_CHAIN if span_versions else CONTROLLED_PAIR
     # The chain pins its own bench version per link, because the trajectory
     # spans releases by design. --version therefore cannot steer it, and
     # saying so beats rendering the 0.0.16 chain under a 0.0.9 heading.
@@ -546,6 +567,24 @@ def render_generation(
                 zorder=2,
                 solid_capstyle="round",
             )
+        # The newest point takes the DIRECTION colour of the step into it,
+        # not the language colour. Language was the old encoding and it
+        # made green mean two unrelated things on one slide: Vera's marker
+        # was green because Vera is green, its line green because it rose
+        # — so the reader learns "green = up", then meets TypeScript's
+        # brown marker on the end of a green rising line and cannot tell
+        # which rule applies. Nothing is lost by dropping it: the x-axis
+        # already names the language, and the marker SHAPE still carries
+        # the model. One colour, one meaning.
+        last_dir = (
+            (
+                GREEN
+                if vals[-1] > vals[-2]
+                else (RED if vals[-1] < vals[-2] else BROWN_300)
+            )
+            if n_pts > 1
+            else BROWN_500
+        )
         for k, v in enumerate(vals):
             # Fill deepens along the chain, so the reading order is
             # visible without consulting the legend.
@@ -554,7 +593,7 @@ def render_generation(
                 [xi + dxs[k]],
                 [v],
                 s=460,
-                facecolor=COLORS[mode] if k == n_pts - 1 else "white",
+                facecolor=last_dir if k == n_pts - 1 else "white",
                 edgecolor=CREAM if k == n_pts - 1 else BROWN_500,
                 linewidth=2.5 if k == n_pts - 1 else 3,
                 alpha=0.35 + 0.65 * frac,
@@ -617,22 +656,35 @@ def render_generation(
     # in the body-font subtitle. Georgia has no U+2192, so the arrow must
     # not live in a FONT_HEADING string — matplotlib drops the glyph and
     # only warns.
+    # Title and subtitle DESCRIBE; they no longer assert. The old pair
+    # said "Three flagships, one trajectory" and "the Vera line rises at
+    # every step" — both true of the 3-link chain and both false the
+    # moment a fourth link landed: the count was wrong, and Fable 5 falls
+    # in three of four languages (Vera NL 100 -> 97). A caption that
+    # states a finding has to be computed from the points, or it quietly
+    # becomes a claim the chart underneath contradicts.
     ax.set_title(
         "One generation later"
         if len(points) < 3
-        else "Three flagships, one trajectory",
+        else "The Anthropic line, oldest to newest",
         fontsize=TITLE_PT,
         fontweight="bold",
         pad=46,
         fontfamily=FONT_HEADING,
         color=BROWN_900,
     )
+
+    def _net(mode: str) -> int | None:
+        first, last = points[0][1].get(mode), points[-1][1].get(mode)
+        return None if first is None or last is None else last - first
+
+    # The model names live in the legend already; repeating them here is
+    # what pushed this line off both edges of a 16:9 canvas at four links.
+    moved = [f"{m} {_net(m):+d}" for m in (wanted or CORE_MODES) if _net(m) is not None]
     ax.text(
         0.5,
         1.016,
-        " → ".join(d for d, _r, _m in points)
-        + " — the Vera line rises at every step;"
-        + " Python and TypeScript peak and fall back",
+        "net change across the whole line, in percentage points:  " + "   ".join(moved),
         transform=ax.transAxes,
         ha="center",
         va="bottom",
@@ -647,7 +699,7 @@ def render_generation(
                 marker=GENERATION_MARKERS[k % len(GENERATION_MARKERS)],
                 linestyle="none",
                 markersize=17,
-                markerfacecolor=BROWN_500 if k == len(points) - 1 else "white",
+                markerfacecolor="white",
                 markeredgecolor=CREAM if k == len(points) - 1 else BROWN_500,
                 markeredgewidth=2.5,
                 alpha=0.35 + 0.65 * (k / max(len(points) - 1, 1)),
@@ -666,18 +718,30 @@ def render_generation(
         edgecolor=BROWN_300,
     )
     if span_versions:
-        # The one confound, stated on the slide rather than in a footnote
-        # nobody reads: the Vera toolchain changed under the first link.
+        # Both confounds, stated on the slide rather than in a footnote
+        # nobody reads: the Vera toolchain changed under the first link,
+        # and the graded problem set grew under the last. The denominator
+        # is derived rather than written down, so a future release that
+        # changes it again cannot leave this caption quietly wrong.
+        counts = [len(_gradeable_ids(v)) for v, _ in chain]
+        grew = (
+            f"Only the first point is graded over {counts[0]} problems; every "
+            f"later one over {counts[-1]}, so read that first step as a change "
+            f"of base, not a gain.\n"
+            if len(set(counts)) > 1
+            else ""
+        )
         fig.text(
             0.5,
             0.028,
-            "Opus 4 ran under Vera 0.0.112, the later two under 0.1.7 — same "
-            "36 graded problems, every one with a verdict in both eras.\n"
-            "But the compiler, its stdlib and SKILL.md all moved between the "
+            "Opus 4 ran under Vera 0.0.112, every later point under 0.1.8; "
+            "every problem carries a verdict in each era.\n"
+            "The compiler, its stdlib and SKILL.md all moved between the "
             "first two points: that step measures the ecosystem improving as "
             "much as the model.\n"
-            "Opus 4.8 → Opus 5 is the controlled step — identical toolchain, "
-            "prompt and problems. Python and TypeScript use no Vera toolchain.",
+            f"{grew}"
+            "Python and TypeScript use no Vera toolchain, which is what makes "
+            "their lines the control.",
             ha="center",
             fontsize=13,
             color=BROWN_300,
@@ -856,232 +920,232 @@ def _problem_structure(version: str | None = None) -> dict[int, tuple[int, int]]
     return {t: (v[0], v[1]) for t, v in sorted(out.items())}
 
 
+def _escape_cause(row: dict) -> str:
+    """Why a program that cleared the static gate still failed.
+
+    Three outcomes, and they are not equivalent. A runtime contract firing
+    is the safety net WORKING — the prover could not discharge the
+    obligation, so it was left as a runtime check and that check caught the
+    violation. Non-termination is the gap Vera's `decreases` clause exists
+    to close, so an accepted-but-diverging program is a real miss. Everything
+    else is the honest limit of contracts-as-written: the program satisfied
+    everything it promised and still computed the wrong answer.
+    """
+    msg = row.get("error_message") or ""
+    if "condition violation" in msg.lower():
+        return "runtime contract fired"
+    if "timed out" in msg.lower():
+        return "did not terminate"
+    return "contracts satisfied, wrong output"
+
+
+#: Ordered worst-to-least-worst for display, each with the colour that
+#: carries its meaning: a fired contract is Vera working (green), a
+#: divergence is a miss (red), a wrong answer under satisfied contracts is
+#: the specification gap (brown).
+CAUSE_ORDER = [
+    ("contracts satisfied, wrong output", "BROWN"),
+    ("did not terminate", "RED"),
+    ("runtime contract fired", "GREEN"),
+]
+
+
 def render_coverage(
     results_dir: Path,
     version: str,
     output: Path,
     background: str = DEFAULT_BACKGROUND,
 ) -> None:
-    """The benchmark's blind spot, and the metric that covers it.
+    """Where the static gate and the runtime disagree.
 
-    pass@1 needs expected output to compare against, so it can only see
-    the problems that have test cases. The ones it cannot see are not a
-    random sample — they are concentrated in the tiers built around ADTs,
-    exhaustive match and effect handlers, which is precisely the machinery
-    Vera exists to check. This slide states that plainly and then shows
-    check@1 / verify, which do cover all 60.
+    This slide used to argue that pass@1 had a blind spot — the problems
+    with no test cases — which contracts and a prover covered. Closing that
+    gap retired the argument: every problem now carries test cases, so the
+    old rendering degenerated to "0 of 60" with a 0% hero stat, which reads
+    as Vera failing everything.
+
+    The successor question is sharper and this data answers it directly.
+    `vera check` and `vera run` are independent verdicts on the same
+    program, so every (model, problem) pair is a two-by-two: the gate
+    passed or not, the program was right or not. Two cells are agreement.
+    The other two are the interesting ones — an ESCAPE (the gate passed,
+    the program was still wrong) bounds what contracts miss, and a FALSE
+    ALARM (the gate refused a working program) would bound what they cost.
+    Reporting both is what keeps this honest rather than promotional: the
+    escapes are named individually, with the cause of each.
     """
-    structure = _problem_structure(version)
-    tiers_n = sorted(structure)
-    if not tiers_n:
-        print("  coverage slide: no problems found under problems/ — skipping")
-        return
     rows_by_target = load_rows(results_dir, version, ["Vera"])
-    gradeable = _gradeable_ids(version)
+    if not rows_by_target:
+        print(f"  coverage slide: no Vera results for {version} — skipping")
+        return
 
-    # Restricted to the problems pass@1 CANNOT see. Rates over all 60
-    # would merely restate the headline chart on a second axis; the claim
-    # worth making is about the invisible 24 specifically. Averaged
-    # across models, so this is "the typical frontier model".
-    check_pcts: list[float] = []
-    verify_pcts: list[float] = []
-    n_models = 0
-    for (model, mode), rows in rows_by_target.items():
+    escapes: list[tuple[str, str, str]] = []  # (model, problem, cause)
+    agree = false_alarms = graded = 0
+    for (model, mode), rows in sorted(rows_by_target.items()):
         if mode != "Vera":
             continue
-        best = best_by_problem(rows)
-        blind = {p: r for p, r in best.items() if p not in gradeable}
-        if not blind:
-            continue
-        # Only after the blind check: a target with nothing to measure
-        # contributes no percentage, so it must not enlarge the mean's
-        # reported denominator either.
-        n_models += 1
-        check_pcts.append(
-            100 * sum(1 for r in blind.values() if r.get("check_pass")) / len(blind)
-        )
-        verified = [r for r in blind.values() if r.get("verify_pass") is not None]
-        if verified:
-            verify_pcts.append(
-                100 * sum(1 for r in verified if r.get("verify_pass")) / len(verified)
-            )
-    check_avg = sum(check_pcts) / len(check_pcts) if check_pcts else 0.0
-    verify_avg = sum(verify_pcts) / len(verify_pcts) if verify_pcts else 0.0
+        for pid, r in sorted(best_by_problem(rows).items()):
+            run = r.get("run_correct")
+            if run is None:
+                # Ungraded (a harness decline) is neither agreement nor
+                # disagreement — there is no runtime verdict to compare
+                # the gate against, so it must not enter the denominator.
+                continue
+            graded += 1
+            gate = r.get("check_pass") is True
+            if gate and run is False:
+                escapes.append((model, pid, _escape_cause(r)))
+            elif not gate and run is True:
+                false_alarms += 1
+            else:
+                agree += 1
+
+    if graded == 0:
+        print("  coverage slide: no graded Vera rows — skipping")
+        return
+    esc_pct = 100 * len(escapes) / graded
 
     fig = plt.figure(figsize=(16, 9), dpi=180)
     gs = fig.add_gridspec(
         1,
         2,
-        width_ratios=[1.15, 1],
-        wspace=0.18,
-        # Axes top sits low enough that the legend — anchored just above
-        # it — clears the two-line subtitle instead of butting against it.
+        width_ratios=[1.5, 1],
+        wspace=0.10,
         top=0.60,
-        left=0.075,
-        right=0.97,
-        bottom=0.13,
+        left=0.055,
+        right=0.965,
+        bottom=0.10,
     )
 
-    # --- left: what pass@1 can and cannot see ---
+    # --- left: the escapes, named ---
+    # A list, not a chart. Six items against a 539 denominator have no
+    # plottable shape — a bar would be a sliver next to a wall, and the
+    # reader would learn less than from reading the six.
     ax = fig.add_subplot(gs[0, 0])
-    y = np.arange(len(tiers_n))
-    grad = [structure[t][1] for t in tiers_n]
-    ungr = [structure[t][0] - structure[t][1] for t in tiers_n]
-    ax.barh(
-        y,
-        grad,
-        0.62,
-        color=GREEN,
-        alpha=0.88,
-        edgecolor=CREAM,
-        linewidth=1.5,
-        label="graded by pass@1 (has test cases)",
+    ax.axis("off")
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    colour = {"BROWN": BROWN_700, "RED": RED, "GREEN": GREEN}
+    ax.text(
+        0.0,
+        0.98,
+        f"The {len(escapes)} that cleared `vera check` and still failed:",
+        fontsize=SUBTITLE_PT - 4,
+        color=BROWN_900,
+        fontweight="bold",
+        va="top",
     )
-    ax.barh(
-        y,
-        ungr,
-        0.62,
-        left=grad,
-        color=BROWN_300,
-        alpha=0.55,
-        edgecolor=CREAM,
-        linewidth=1.5,
-        hatch="//",
-        label="can not be output-tested (no test cases)",
-    )
-    for yi, g, u in zip(y, grad, ungr):
+    order = {c: i for i, (c, _) in enumerate(CAUSE_ORDER)}
+    rows_sorted = sorted(escapes, key=lambda e: (order.get(e[2], 9), e[0], e[1]))
+    y = 0.855
+    for model, pid, cause in rows_sorted:
+        tag = next((k for c, k in CAUSE_ORDER if c == cause), "BROWN")
         ax.text(
-            g / 2,
-            yi,
-            str(g),
-            ha="center",
-            va="center",
-            fontsize=17,
+            0.0,
+            y,
+            pid,
+            fontsize=TICK_PT_SMALL,
+            color=BROWN_900,
             fontweight="bold",
-            color="white",
+            va="top",
+            family="monospace",
         )
-        if u:
-            ax.text(
-                g + u / 2,
-                yi,
-                str(u),
-                ha="center",
-                va="center",
-                fontsize=17,
-                fontweight="bold",
-                color=BROWN_900,
-            )
-    ax.set_yticks(y)
-    ax.set_yticklabels([f"Tier {t}" for t in tiers_n], fontsize=TICK_PT_SMALL)
-    ax.invert_yaxis()
-    ax.set_xlabel("problems", fontsize=AXIS_LABEL_PT - 2, color=BROWN_500)
-    ax.set_xlim(0, max(structure[t][0] for t in tiers_n) + 1)
-    ax.tick_params(axis="x", labelsize=TICK_PT_SMALL - 2)
-    _style_ax(ax)
-    # Above the axes, right-aligned. Inside, it lands on the shortest
-    # tier's segment labels — the numbers the panel exists to show —
-    # and below, it falls off the bottom of the canvas.
-    ax.legend(
-        loc="lower right",
-        bbox_to_anchor=(1.0, 1.01),
-        ncol=1,
-        fontsize=LEGEND_PT - 5,
-        framealpha=0.92,
-        edgecolor=BROWN_300,
-    )
+        ax.text(0.20, y, model, fontsize=TICK_PT_SMALL, color=BROWN_500, va="top")
+        # The longest string on the slide. Set one step down and started
+        # well left of the panel edge, so it cannot run under the hero
+        # number in the right-hand column.
+        ax.text(
+            0.48,
+            y,
+            cause,
+            fontsize=TICK_PT_SMALL - 2,
+            color=colour[tag],
+            va="top",
+            fontweight="bold",
+        )
+        y -= 0.125
 
-    # --- right: hero stats on the invisible problems ---
-    # Deliberately not a chart. Every value here is ~100, and five
-    # near-identical full-height bars communicate nothing a number does
-    # not — the bar's own length stops being informative once the whole
-    # series sits on the ceiling.
+    # --- right: the two numbers that bound the claim ---
     ax2 = fig.add_subplot(gs[0, 1])
     ax2.axis("off")
-    n_blind = sum(structure[t][0] - structure[t][1] for t in tiers_n)
+    ax2.set_xlim(0, 1)
+    ax2.set_ylim(0, 1)
     ax2.text(
-        0.5,
-        1.02,
-        f"on those {n_blind} untestable problems,\nVera still grades every one:",
-        transform=ax2.transAxes,
-        ha="center",
+        0.0,
+        0.90,
+        f"{esc_pct:.1f}%",
+        fontsize=86,
+        color=BROWN_900,
+        fontweight="bold",
         va="top",
-        fontsize=SUBTITLE_PT,
-        color=BROWN_700,
-        linespacing=1.4,
+        family=FONT_HEADING,
     )
-    for i, (val, label, sub) in enumerate(
-        (
-            (check_avg, "check@1", "compiled and passed\nits contracts"),
-            (verify_avg, "verify", "discharged by\nthe Z3 prover"),
-        )
-    ):
-        yy = 0.64 - i * 0.38
-        # Left-anchored, not centred: Georgia's '%' is far wider than a
-        # digit, so a centred number silently grows rightwards into the
-        # label column and overprints it.
-        ax2.text(
-            0.0,
-            yy,
-            f"{val:.0f}%",
-            transform=ax2.transAxes,
-            ha="left",
-            va="center",
-            fontsize=74,
-            fontweight="bold",
-            color=GREEN,
-            fontfamily=FONT_HEADING,
-        )
-        ax2.text(
-            0.60,
-            yy + 0.075,
-            f"Vera {label}",
-            transform=ax2.transAxes,
-            ha="left",
-            va="center",
-            fontsize=24,
-            fontweight="bold",
-            color=BROWN_900,
-        )
-        ax2.text(
-            0.60,
-            yy - 0.055,
-            sub,
-            transform=ax2.transAxes,
-            ha="left",
-            va="center",
-            fontsize=16,
-            color=BROWN_500,
-            linespacing=1.35,
-        )
     ax2.text(
-        0.5,
-        -0.06,
-        f"mean across {n_models} models, Vera full-spec",
-        transform=ax2.transAxes,
-        ha="center",
-        va="center",
-        fontsize=15,
-        color=BROWN_300,
+        0.0,
+        0.60,
+        "escaped the static gate",
+        fontsize=SUBTITLE_PT - 3,
+        color=BROWN_900,
+        fontweight="bold",
+        va="top",
+    )
+    ax2.text(
+        0.0,
+        0.525,
+        f"{len(escapes)} of {graded} (model, problem) pairs\n"
+        "compiled, satisfied their contracts,\nand were still wrong",
+        fontsize=TICK_PT_SMALL,
+        color=BROWN_500,
+        va="top",
+        linespacing=1.5,
+    )
+    ax2.text(
+        0.0,
+        0.30,
+        str(false_alarms),
+        fontsize=86,
+        color=GREEN if false_alarms == 0 else RED,
+        fontweight="bold",
+        va="top",
+        family=FONT_HEADING,
+    )
+    ax2.text(
+        0.0,
+        0.045,
+        "working programs rejected",
+        fontsize=SUBTITLE_PT - 3,
+        color=BROWN_900,
+        fontweight="bold",
+        va="top",
+    )
+    ax2.text(
+        0.0,
+        -0.03,
+        "the gate never refused code that ran correctly",
+        fontsize=TICK_PT_SMALL,
+        color=BROWN_500,
+        va="top",
     )
 
-    total = sum(structure[t][0] for t in tiers_n)
-    n_grad = sum(structure[t][1] for t in tiers_n)
-    fig.suptitle(
-        "What pass@1 cannot see",
+    fig.text(
+        0.5,
+        0.955,
+        "What the contracts cannot see",
+        ha="center",
+        va="top",
         fontsize=TITLE_PT,
-        fontweight="bold",
-        y=0.955,
-        fontfamily=FONT_HEADING,
         color=BROWN_900,
+        fontweight="bold",
+        family=FONT_HEADING,
     )
     fig.text(
         0.5,
         0.865,
-        f"{total - n_grad} of {total} problems have no test cases — not an oversight.\n"
-        "Their entry points take or produce shapes the harness cannot "
-        "yet grade through `vera run`.\n"
-        "They are the ADT, match and effect problems — exactly what "
-        "contracts and a prover are for.",
+        f"`vera check` and `vera run` are independent verdicts on the same "
+        f"program — {graded} pairs across {len(rows_by_target)} models.\n"
+        "Contracts bound what a program may do; they do not say everything "
+        "it must do, so a few satisfy them and are still wrong.\n"
+        "The cost of that gate is the number worth watching, and it is zero.",
         ha="center",
         va="top",
         fontsize=SUBTITLE_PT - 3,

--- a/scripts/plot_narrative.py
+++ b/scripts/plot_narrative.py
@@ -107,7 +107,12 @@ from scripts.sweep_status import is_refusal  # noqa: E402
 
 ALL_MODES = ["Vera", "Vera NL", "Python", "TypeScript", "Aver", "AILANG"]
 
-# The Anthropic ceiling line, oldest first, as (bench version, display).
+# The Anthropic flagship line, oldest first, as (bench version, display).
+# ONE family, in release order. Fable 5 does not belong here even though
+# it is the strongest model in the matrix: it is the CEILING tier, more
+# capable than Opus 5 but not later than it, so a slope into it would
+# read as generational progress that never happened. Anything added here
+# has to be a successor, not merely a bigger sibling.
 # Cross-version by design: each model is pinned to a release that actually
 # swept it — Opus 4 only ever ran under 0.0.9 — so the trajectory cannot
 # be read out of a single results generation.
@@ -130,7 +135,6 @@ GENERATION_CHAIN = [
     ("0.0.9", "Claude Opus 4"),
     ("0.0.18", "Claude Opus 4.8"),
     ("0.0.18", "Claude Opus 5"),
-    ("0.0.18", "Claude Fable 5"),
 ]
 
 # The controlled step, named separately rather than taken as the chain's
@@ -666,7 +670,7 @@ def render_generation(
     ax.set_title(
         "One generation later"
         if len(points) < 3
-        else "The Anthropic line, oldest to newest",
+        else "Three Claude flagships, oldest to newest",
         fontsize=TITLE_PT,
         fontweight="bold",
         pad=46,

--- a/scripts/plot_results.py
+++ b/scripts/plot_results.py
@@ -739,11 +739,15 @@ def plot_vera_vs_comparison(
         )
         for i, mode in enumerate(comparison_modes)
     ]
+    # Upper left, stacked: "lower right" sat where the largest positive
+    # delta ends and hid it. The negative half is the sparse one, and its
+    # top rows carry no bar at all. Same fix as plot_slide's delta slide.
     ax.legend(
         handles=legend_handles,
-        loc="lower right",
+        loc="upper left",
+        ncol=1,
         fontsize=9,
-        framealpha=0.8,
+        framealpha=0.9,
         edgecolor=BROWN_300,
     )
 

--- a/scripts/plot_slide.py
+++ b/scripts/plot_slide.py
@@ -358,11 +358,20 @@ def render_delta(
             label="vs TypeScript",
         ),
     ]
+    # Upper LEFT, stacked. "lower right" put the box over the bottom-right
+    # quadrant, which on a diverging chart is exactly where the largest
+    # POSITIVE bar ends — so the legend covered the biggest Vera win and
+    # its value label, and a semi-transparent frame made it worse rather
+    # than better: the bar showed through, so hidden data read as a
+    # rendering artefact. The negative half is the empty one (Vera loses
+    # rarely and never by much), and its top rows carry no bar at all,
+    # which makes upper-left the one corner no result reaches.
     ax.legend(
         handles=legend_handles,
-        loc="lower right",
+        loc="upper left",
+        ncol=1,
         fontsize=LEGEND_PT,
-        framealpha=0.85,
+        framealpha=0.92,
         edgecolor=BROWN_300,
     )
 

--- a/scripts/regrade.py
+++ b/scripts/regrade.py
@@ -86,6 +86,31 @@ def _canonical(v: dict) -> dict:
     return out
 
 
+def _same_verdict(before: dict, after: dict) -> bool:
+    """Whether two verdicts agree once run-specific noise is discounted.
+
+    Beyond the sandbox path itself, messages are truncated to a fixed
+    length — so a path of a different length moves the CUT, and the same
+    advice comes back ending "at compile t" instead of "at compile time."
+    Every non-message field must still match exactly; only the message is
+    allowed to be a truncation of its counterpart. Without this a re-grade
+    reports dozens of rows as changed when it has merely re-run them, and
+    writing them back would replace the sweep's own message with one from
+    a run that never happened.
+    """
+    ca, cb = _canonical(before), _canonical(after)
+    if ca == cb:
+        return True
+    if {k: v for k, v in ca.items() if k != "error_message"} != {
+        k: v for k, v in cb.items() if k != "error_message"
+    }:
+        return False
+    ma = ca.get("error_message") or ""
+    mb = cb.get("error_message") or ""
+    n = min(len(ma), len(mb))
+    return bool(n) and ma[:n] == mb[:n]
+
+
 def _load_problems() -> dict[str, dict]:
     """Every problem JSON, keyed by id — the same set the CLI loads."""
     root = Path(__file__).resolve().parent.parent
@@ -144,7 +169,7 @@ def regrade_file(
         new = dict(row)
         new.update({k: v for k, v in fresh.items() if k in VERDICT_FIELDS})
         after = {k: new.get(k) for k in VERDICT_FIELDS}
-        if _canonical(before) == _canonical(after):
+        if _same_verdict(before, after):
             # Same verdict, different sandbox path. Return the ORIGINAL row
             # so the file keeps the message the sweep actually recorded.
             tally["unchanged"] += 1

--- a/scripts/regrade.py
+++ b/scripts/regrade.py
@@ -97,6 +97,16 @@ def _same_verdict(before: dict, after: dict) -> bool:
     reports dozens of rows as changed when it has merely re-run them, and
     writing them back would replace the sweep's own message with one from
     a run that never happened.
+
+    Comparing both strings over the shorter one's length IS a prefix test,
+    and `bool(n)` is deliberate rather than a typo. An empty string is a
+    prefix of everything, so `startswith` would call a message appearing
+    or disappearing "the same verdict" — which it is not.
+
+        ma        mb        here     startswith()
+        'ab'      'abc'     True     True
+        'abc'     'abd'     False    False
+        ''        'abc'     False    True    <- must be False
     """
     ca, cb = _canonical(before), _canonical(after)
     if ca == cb:

--- a/scripts/regrade.py
+++ b/scripts/regrade.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Re-grade a finished sweep from the code it stored, without re-running it.
+
+A grading bug found after a sweep used to mean paying for the sweep again.
+Since #109 every row records a `code_path`, so the model's actual output is
+on disk and the verdict can simply be recomputed: same code, same problems,
+a fixed harness. That turns a $100 overnight re-run into a few minutes of
+local subprocesses, and it is the only reason the ADT-mapper fix could be
+applied to the 0.0.18 results at all.
+
+WHY IT RE-GRADES EVERY ROW, not just the ones that failed:
+
+Re-grading only the rows a fix was expected to help is cherry-picking — it
+would import every improvement while hiding any regression the same change
+caused elsewhere. Grading the whole set under one harness version is both
+the honest choice and a free regression test: rows the fix should not touch
+must come back byte-identical, and this prints how many did.
+
+What is replaced is only the VERDICT. Token counts, timings, the model's
+identity and the code path are properties of the original run and are
+carried through untouched, so a re-graded file still reports what that
+sweep actually cost.
+
+Dry run by default; `--apply` writes each file atomically.
+
+    python scripts/regrade.py                        # census, changes nothing
+    python scripts/regrade.py --apply                # rewrite the verdicts
+    python scripts/regrade.py --language python --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tempfile
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from vera_bench import __version__ as BENCH_VERSION  # noqa: E402
+from vera_bench.results_path import version_slug  # noqa: E402
+from vera_bench.runner import (  # noqa: E402
+    _evaluate_ailang_code,
+    _evaluate_aver_code,
+    _evaluate_code,
+    _evaluate_python_code,
+    _evaluate_typescript_code,
+)
+from vera_bench.vera_runner import VeraRunner  # noqa: E402
+
+#: The fields a grader owns. Everything else on a row describes the ORIGINAL
+#: run — what it cost, how long it took, which model produced it — and must
+#: survive re-grading untouched, or the file stops being a record of the
+#: sweep that happened.
+VERDICT_FIELDS = (
+    "check_pass",
+    "verify_pass",
+    "verify_tier1",
+    "verify_tier3",
+    "run_correct",
+    "tests_total",
+    "tests_passed",
+    "error_message",
+)
+
+
+#: Sandbox paths an evaluator bakes into its own error text. They differ on
+#: every run by construction, so comparing them raw made a re-grade look
+#: like it had changed 64 rows it had merely re-run — and writing those back
+#: would replace the original sweep's message with a path from a run that
+#: never happened.
+_TMP_PATH = re.compile(r"/(?:private/)?(?:var|tmp)/[^\s'\"]*")
+
+
+def _canonical(v: dict) -> dict:
+    """A verdict with run-specific noise removed, for comparison only."""
+    out = dict(v)
+    msg = out.get("error_message")
+    if isinstance(msg, str):
+        out["error_message"] = _TMP_PATH.sub("<tmp>", msg)
+    return out
+
+
+def _load_problems() -> dict[str, dict]:
+    """Every problem JSON, keyed by id — the same set the CLI loads."""
+    root = Path(__file__).resolve().parent.parent
+    out: dict[str, dict] = {}
+    for pf in sorted((root / "problems").rglob("VB_*.json")):
+        p = json.loads(pf.read_text(encoding="utf-8"))
+        out[p["id"]] = p
+    return out
+
+
+def evaluate(row: dict, code: str, problem: dict, work: Path, vera: VeraRunner) -> dict:
+    """Run the language's evaluator over stored code, as the sweep would."""
+    lang = row.get("language") or "vera"
+    attempt = int(row.get("attempt") or 1)
+    if lang == "python":
+        return _evaluate_python_code(code, problem, work, attempt)
+    if lang == "typescript":
+        return _evaluate_typescript_code(code, problem, work, attempt)
+    if lang == "aver":
+        return _evaluate_aver_code(code, problem, work, attempt)
+    if lang == "ailang":
+        return _evaluate_ailang_code(code, problem, work, attempt)
+    return _evaluate_code(code, problem, vera, work, attempt)
+
+
+def regrade_file(
+    path: Path, results_dir: Path, problems: dict, vera: VeraRunner, workers: int
+) -> tuple[list[dict], Counter]:
+    """Return (new rows, tally of what moved) for one target file."""
+    rows = [json.loads(ln) for ln in path.read_text().splitlines() if ln.strip()]
+    tally: Counter = Counter()
+
+    def one(row: dict) -> dict:
+        cp = row.get("code_path")
+        problem = problems.get(row.get("problem_id"))
+        if not cp or problem is None:
+            # No stored code (an API error row never produced any) or a
+            # problem that no longer exists. Left exactly as found: a row
+            # this tool cannot re-derive must not be silently rewritten.
+            tally["no-code"] += 1
+            return row
+        src = results_dir / cp
+        if not src.exists():
+            tally["missing-file"] += 1
+            return row
+        before = {k: row.get(k) for k in VERDICT_FIELDS}
+        with tempfile.TemporaryDirectory(prefix="vb-regrade-") as tmp:
+            try:
+                fresh = evaluate(
+                    row, src.read_text(encoding="utf-8"), problem, Path(tmp), vera
+                )
+            except Exception as exc:  # a grader crash is not a verdict
+                tally["grader-error"] += 1
+                row["regrade_error"] = f"{type(exc).__name__}: {exc}"[:200]
+                return row
+        new = dict(row)
+        new.update({k: v for k, v in fresh.items() if k in VERDICT_FIELDS})
+        after = {k: new.get(k) for k in VERDICT_FIELDS}
+        if _canonical(before) == _canonical(after):
+            # Same verdict, different sandbox path. Return the ORIGINAL row
+            # so the file keeps the message the sweep actually recorded.
+            tally["unchanged"] += 1
+            return row
+        else:
+            tally["changed"] += 1
+            was, now = _bucket(before), _bucket(after)
+            tally[f"{was} -> {now}"] += 1
+        return new
+
+    if workers > 1:
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            out = list(pool.map(one, rows))
+    else:
+        out = [one(r) for r in rows]
+    return out, tally
+
+
+def _bucket(v: dict) -> str:
+    """Coarse verdict label, for reporting what a re-grade moved."""
+    msg = v.get("error_message") or ""
+    if msg.startswith("test wrapper unavailable"):
+        return "declined"
+    if v.get("run_correct") is True:
+        return "solved"
+    if v.get("run_correct") is False:
+        return "wrong"
+    return "ungraded"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--results-dir", default="results")
+    ap.add_argument("--bench-version", default=BENCH_VERSION)
+    ap.add_argument("--language", help="only this language's targets")
+    ap.add_argument("--model", help="only targets for this model string")
+    ap.add_argument("--parallel", type=int, default=8)
+    ap.add_argument("--apply", action="store_true", help="execute; else dry run")
+    args = ap.parse_args()
+
+    results_dir = Path(args.results_dir)
+    pattern = f"*bench-{version_slug(args.bench_version)}*.jsonl"
+    targets = sorted(
+        p
+        for p in results_dir.glob(pattern)
+        if "-baseline" not in p.name
+        and (not args.model or p.name.startswith(args.model.replace("/", "-")))
+    )
+    if not targets:
+        print(f"no targets matching {pattern} in {results_dir}/")
+        return 1
+
+    problems = _load_problems()
+    vera = VeraRunner()
+    total: Counter = Counter()
+    print(
+        f"  {len(targets)} target(s), bench {args.bench_version}"
+        f"{' — DRY RUN' if not args.apply else ''}\n"
+    )
+
+    for path in targets:
+        head = json.loads(path.read_text().splitlines()[0])
+        if args.language and head.get("language") != args.language:
+            continue
+        rows, tally = regrade_file(path, results_dir, problems, vera, args.parallel)
+        total.update(tally)
+        moved = tally["changed"]
+        flag = "" if not moved else f"   {moved} changed"
+        print(f"    {path.name[:64]:66} {tally['unchanged']:3} same{flag}", flush=True)
+        if moved and args.apply:
+            fd, tmp = tempfile.mkstemp(dir=str(results_dir), suffix=".jsonl")
+            with os.fdopen(fd, "w") as fh:
+                for r in rows:
+                    fh.write(json.dumps(r) + "\n")
+            os.replace(tmp, path)
+
+    print("\n  transitions:")
+    for k, v in sorted(total.items()):
+        if "->" in k:
+            print(f"    {k:28} {v}")
+    print(
+        f"\n  unchanged {total['unchanged']}   changed {total['changed']}"
+        f"   no-code {total['no-code']}   grader-error {total['grader-error']}"
+    )
+    if not args.apply and total["changed"]:
+        print("\n  dry run — re-run with --apply to write these verdicts")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - thin CLI shim
+    sys.exit(main())

--- a/scripts/rerun_failed.py
+++ b/scripts/rerun_failed.py
@@ -49,7 +49,7 @@ import sys
 import tempfile
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from sweep_status import classify, load_rows  # noqa: E402
+from sweep_status import _expected_problems, classify, load_rows  # noqa: E402
 
 from vera_bench import __version__ as BENCH_VERSION  # noqa: E402
 from vera_bench.results_path import version_slug  # noqa: E402
@@ -80,7 +80,15 @@ def find_canonical(
     results_dir: str, model: str, language: str, mode: str, bench_version: str
 ) -> str:
     prefix = canonical_basename_prefix(model, language, mode, bench_version)
-    hits = sorted(glob.glob(os.path.join(results_dir, prefix + "*.jsonl")))
+    # The version token has to end at a separator. `prefix + "*"` let
+    # 0.0.18 match `bench-0-0-180-...`, so a repair aimed at one release
+    # could splice fresh rows into a different one's file. After the
+    # bench segment a name either continues with a compiler segment or
+    # ends, so those are exactly the two shapes to accept.
+    hits = sorted(
+        set(glob.glob(os.path.join(results_dir, prefix + "-*.jsonl")))
+        | set(glob.glob(os.path.join(results_dir, prefix + ".jsonl")))
+    )
     if not hits:
         sys.exit(
             f"no results file matching {prefix}* in {results_dir}/\n"
@@ -238,7 +246,9 @@ def main() -> None:
         help="per-problem re-run timeout (s); a stall aborts before splice",
     )
     ap.add_argument(
-        "--force", action="store_true", help="splice even an in-flight (<60 row) file"
+        "--force",
+        action="store_true",
+        help="splice even a file that does not yet cover every problem",
     )
     ap.add_argument(
         "--apply", action="store_true", help="execute; without it, dry-run only"
@@ -251,9 +261,16 @@ def main() -> None:
     rows = load_rows(canonical)
     print(f"target: {os.path.basename(canonical)}  ({len(rows)} rows)")
 
-    if len(rows) < 60 and not args.force:
+    # Coverage is counted in unique problem ids, not rows: a fix attempt
+    # emits a second row for the same problem, so a file can reach 60 rows
+    # while still missing problems the sweep has not written yet. Counting
+    # rows called that finished and spliced into a file still being
+    # written. Same denominator `sweep_status.verdict` uses.
+    covered = len({r.get("problem_id") for r in rows})
+    if covered < _expected_problems() and not args.force:
         sys.exit(
-            "file has <60 rows — looks in-flight; wait for the sweep or pass --force"
+            f"file covers {covered}/{_expected_problems()} problems — looks "
+            "in-flight; wait for the sweep or pass --force"
         )
 
     pids = failed_pids(rows, args.include_length)

--- a/scripts/rerun_failed.py
+++ b/scripts/rerun_failed.py
@@ -51,23 +51,42 @@ import tempfile
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from sweep_status import classify, load_rows  # noqa: E402
 
+from vera_bench import __version__ as BENCH_VERSION  # noqa: E402
+from vera_bench.results_path import version_slug  # noqa: E402
 
-def canonical_basename_prefix(model: str, language: str, mode: str) -> str:
+
+def canonical_basename_prefix(
+    model: str, language: str, mode: str, bench_version: str
+) -> str:
     """Reconstruct the leading part of the filename cli.py builds, up to
-    (not including) the version tags — enough to glob for the one file."""
+    (not including) the COMPILER version tag — enough to glob for one file.
+
+    The bench version has to be in the prefix. `results/` accumulates every
+    release side by side, so a prefix ending at `-bench-` matches one file
+    per era and the glob goes ambiguous the moment a second release lands —
+    which is how this stopped working on 0.0.18 with 0.0.16 still on disk.
+    The compiler segment stays a wildcard because a target's Vera/Aver/
+    AILANG version is whatever produced it, not whatever is installed now.
+    """
     parts = [model.replace("/", "-")]
     if language != "vera":
         parts.append(language)
     if language == "vera" and mode != "full-spec":
         parts.append(mode)
-    return "-".join(parts) + "-bench-"
+    return "-".join(parts) + f"-bench-{version_slug(bench_version)}"
 
 
-def find_canonical(results_dir: str, model: str, language: str, mode: str) -> str:
-    prefix = canonical_basename_prefix(model, language, mode)
+def find_canonical(
+    results_dir: str, model: str, language: str, mode: str, bench_version: str
+) -> str:
+    prefix = canonical_basename_prefix(model, language, mode, bench_version)
     hits = sorted(glob.glob(os.path.join(results_dir, prefix + "*.jsonl")))
     if not hits:
-        sys.exit(f"no results file matching {prefix}* in {results_dir}/")
+        sys.exit(
+            f"no results file matching {prefix}* in {results_dir}/\n"
+            f"(bench version {bench_version} — pass --bench-version to repair "
+            f"an older era)"
+        )
     if len(hits) > 1:
         joined = "\n  ".join(os.path.basename(h) for h in hits)
         sys.exit(f"ambiguous — {len(hits)} files match {prefix}*:\n  {joined}")
@@ -195,6 +214,13 @@ def main() -> None:
     )
     ap.add_argument("--results-dir", default="results")
     ap.add_argument(
+        "--bench-version",
+        default=BENCH_VERSION,
+        help="which release's results to repair (default: installed version). "
+        "results/ holds every era side by side, so this is what keeps the "
+        "target unambiguous",
+    )
+    ap.add_argument(
         "--include-length",
         action="store_true",
         help="also re-run finish_reason=length problems (pair with --max-tokens)",
@@ -219,7 +245,9 @@ def main() -> None:
     )
     args = ap.parse_args()
 
-    canonical = find_canonical(args.results_dir, args.model, args.language, args.mode)
+    canonical = find_canonical(
+        args.results_dir, args.model, args.language, args.mode, args.bench_version
+    )
     rows = load_rows(canonical)
     print(f"target: {os.path.basename(canonical)}  ({len(rows)} rows)")
 

--- a/scripts/sweep_status.py
+++ b/scripts/sweep_status.py
@@ -36,7 +36,26 @@ import re
 # Ordered: first match wins, so length (which also says "empty content")
 # is classified as a token wall, not a transient blip.
 REFUSAL = re.compile(r"stop_reason=refusal|no text block", re.I)
-LENGTH = re.compile(r"finish_reason=length", re.I)
+#: Both provider spellings. OpenAI and Moonshot say `finish_reason=length`;
+#: Anthropic says `stop_reason=max_tokens`, and its message ALSO contains
+#: "no text block" — which REFUSAL matches. Knowing only the first spelling
+#: therefore did not merely miss a length wall, it relabelled it a refusal:
+#: a recoverable truncation (raise --max-tokens and re-run) was written off
+#: as the model declining to answer, and published in the refusal count.
+LENGTH = re.compile(r"finish_reason=length|stop_reason=max_tokens", re.I)
+
+
+def is_refusal(msg: str) -> bool:
+    """A refusal, and not a truncation wearing its wording.
+
+    Both consumers must agree: `classify` buckets rows for the sweep, and
+    `plot_narrative.find_refusals` draws the published refusal grid. They
+    read the same pattern, so the exclusion belongs here rather than in
+    either one of them.
+    """
+    return bool(REFUSAL.search(msg)) and not LENGTH.search(msg)
+
+
 TRANSIENT = re.compile(
     r"rate.?limit|429|timed out|timeout|killed by signal|connection|"
     r"overloaded|empty content|503|529|API error",
@@ -109,7 +128,7 @@ def classify(msg: str) -> str:
         # A real result — never re-run — but its own bucket, because a
         # rising decline rate is a harness gap, not a model score.
         return "declined"
-    if REFUSAL.search(msg):
+    if is_refusal(msg):
         return "refusal"
     if LENGTH.search(msg):
         return "length"

--- a/scripts/sweep_status.py
+++ b/scripts/sweep_status.py
@@ -92,6 +92,17 @@ def _bench_version() -> str:
     return version_slug(__version__)
 
 
+#: Per-test execution failures carry the harness's `test N:` prefix. They come
+#: from running the model's OWN generated code locally — no network, no
+#: provider — so a timeout here means the program did not terminate, which is
+#: a REAL result (and a wrong answer), not an infrastructure fault to retry.
+#: This must be tested BEFORE TRANSIENT, whose bare `timed out` would
+#: otherwise swallow it: a non-terminating solution got bucketed transient,
+#: so the sweep retried a deterministic failure to its retry limit, the target
+#: never read clean, and `rerun_failed.py` re-ran it forever without progress.
+EXECUTION = re.compile(r"^\s*test\s+\d+\s*:", re.I)
+
+
 def classify(msg: str) -> str:
     if DECLINED.search(msg):
         # The harness abstained (could not map the model's declaration).
@@ -102,6 +113,9 @@ def classify(msg: str) -> str:
         return "refusal"
     if LENGTH.search(msg):
         return "length"
+    if EXECUTION.search(msg):
+        # The model's own code failed under test. Never re-run.
+        return "other"
     if TRANSIENT.search(msg):
         return "transient"
     return "other"

--- a/tests/test_rerun_failed.py
+++ b/tests/test_rerun_failed.py
@@ -79,3 +79,61 @@ def test_nonzero_exit_aborts(monkeypatch, tmp_path):
 
     with pytest.raises(SystemExit, match="exited 2"):
         _call(monkeypatch, tmp_path, produce=None, run=boom)
+
+
+class TestEraScoping:
+    """`results/` accumulates every release side by side.
+
+    The target file is found by globbing the name `cli.py` builds. That name
+    carries the bench version, so a prefix stopping at `-bench-` matches one
+    file per era — unambiguous while only one release existed, and broken the
+    moment a second landed. It failed exactly when it was needed: after a
+    sweep, repairing a target, with the previous release still on disk.
+    """
+
+    def _populate(self, d: pathlib.Path, *names: str) -> None:
+        for n in names:
+            (d / n).write_text("", encoding="utf-8")
+
+    def test_prefix_pins_the_bench_version(self):
+        assert (
+            rf.canonical_basename_prefix(
+                "claude-opus-4-8", "vera", "full-spec", "0.0.18"
+            )
+            == "claude-opus-4-8-bench-0-0-18"
+        )
+
+    def test_two_eras_on_disk_resolve_to_the_requested_one(self, tmp_path):
+        self._populate(
+            tmp_path,
+            "claude-opus-4-8-bench-0-0-16-vera-0-1-7.jsonl",
+            "claude-opus-4-8-bench-0-0-18-vera-0-1-8.jsonl",
+        )
+        found = rf.find_canonical(
+            str(tmp_path), "claude-opus-4-8", "vera", "full-spec", "0.0.18"
+        )
+        assert found.endswith("claude-opus-4-8-bench-0-0-18-vera-0-1-8.jsonl")
+
+    def test_an_older_era_is_still_reachable(self, tmp_path):
+        # The escape hatch: repairing a superseded release must stay possible.
+        self._populate(
+            tmp_path,
+            "claude-opus-4-8-bench-0-0-16-vera-0-1-7.jsonl",
+            "claude-opus-4-8-bench-0-0-18-vera-0-1-8.jsonl",
+        )
+        found = rf.find_canonical(
+            str(tmp_path), "claude-opus-4-8", "vera", "full-spec", "0.0.16"
+        )
+        assert found.endswith("claude-opus-4-8-bench-0-0-16-vera-0-1-7.jsonl")
+
+    def test_the_compiler_segment_stays_a_wildcard(self, tmp_path):
+        # A target's Vera version is whatever produced it, not whatever is
+        # installed now — so only the bench segment may be pinned.
+        self._populate(tmp_path, "m-bench-0-0-18-vera-9-9-9.jsonl")
+        found = rf.find_canonical(str(tmp_path), "m", "vera", "full-spec", "0.0.18")
+        assert found.endswith("m-bench-0-0-18-vera-9-9-9.jsonl")
+
+    def test_a_missing_era_says_so(self, tmp_path):
+        self._populate(tmp_path, "m-bench-0-0-16-vera-0-1-7.jsonl")
+        with pytest.raises(SystemExit, match="0.0.18"):
+            rf.find_canonical(str(tmp_path), "m", "vera", "full-spec", "0.0.18")

--- a/tests/test_rerun_failed.py
+++ b/tests/test_rerun_failed.py
@@ -137,3 +137,37 @@ class TestEraScoping:
         self._populate(tmp_path, "m-bench-0-0-16-vera-0-1-7.jsonl")
         with pytest.raises(SystemExit, match="0.0.18"):
             rf.find_canonical(str(tmp_path), "m", "vera", "full-spec", "0.0.18")
+
+
+class TestVersionTokenBoundary:
+    """`0.0.18` must not select `0.0.180`.
+
+    The bench segment is followed either by a compiler segment or by the
+    extension, so a trailing `*` was enough to let one release's repair
+    reach into another's file — and a splice writes rows, so the damage
+    would have been to real results rather than a failed lookup.
+    """
+
+    def _write(self, d: pathlib.Path, *names: str) -> None:
+        for n in names:
+            (d / n).write_text("", encoding="utf-8")
+
+    def test_a_longer_version_is_not_a_prefix_match(self, tmp_path):
+        self._write(tmp_path, "m-bench-0-0-180-vera-0-1-8.jsonl")
+        with pytest.raises(SystemExit, match="no results file"):
+            rf.find_canonical(str(tmp_path), "m", "vera", "full-spec", "0.0.18")
+
+    def test_the_intended_release_is_still_found_beside_it(self, tmp_path):
+        self._write(
+            tmp_path,
+            "m-bench-0-0-18-vera-0-1-8.jsonl",
+            "m-bench-0-0-180-vera-0-1-8.jsonl",
+        )
+        found = rf.find_canonical(str(tmp_path), "m", "vera", "full-spec", "0.0.18")
+        assert found.endswith("m-bench-0-0-18-vera-0-1-8.jsonl")
+
+    def test_a_name_ending_at_the_bench_segment_still_matches(self, tmp_path):
+        # Python and TypeScript targets carry no compiler segment.
+        self._write(tmp_path, "m-python-bench-0-0-18.jsonl")
+        found = rf.find_canonical(str(tmp_path), "m", "python", "full-spec", "0.0.18")
+        assert found.endswith("m-python-bench-0-0-18.jsonl")

--- a/tests/test_sweep_status.py
+++ b/tests/test_sweep_status.py
@@ -75,6 +75,32 @@ class TestClassify:
     def test_compile_error_is_other(self):
         assert ss.classify("check failed: unexpected token") == "other"
 
+    def test_anthropic_token_wall_is_length_not_refusal(self):
+        # Anthropic spells a truncation `stop_reason=max_tokens`, and its
+        # message ALSO says "no text block" — which the refusal pattern
+        # matches. Knowing only OpenAI's `finish_reason=length` therefore
+        # relabelled a recoverable truncation as the model declining, so
+        # the sweep kept it as a real verdict instead of offering a bigger
+        # budget, and it was published in the refusal count.
+        msg = (
+            "Fix API error: Anthropic returned no text block for "
+            "model='claude-opus-5' (stop_reason=max_tokens, blocks=['thinking'])"
+        )
+        assert ss.classify(msg) == "length"
+        assert not ss.is_refusal(msg)
+
+    def test_a_genuine_refusal_survives_the_exclusion(self):
+        msg = "Anthropic returned no text block (stop_reason=refusal)"
+        assert ss.is_refusal(msg)
+        assert ss.classify(msg) == "refusal"
+
+    def test_both_provider_spellings_of_a_token_wall(self):
+        for msg in (
+            "Moonshot returned empty content (finish_reason=length)",
+            "Anthropic returned no text block (stop_reason=max_tokens)",
+        ):
+            assert ss.classify(msg) == "length", msg
+
     def test_execution_timeout_is_a_real_result_not_a_transient(self):
         # The harness's own 30s budget on the model's COMPILED code. The
         # program did not terminate, which is a wrong answer — deterministic,

--- a/tests/test_sweep_status.py
+++ b/tests/test_sweep_status.py
@@ -75,6 +75,31 @@ class TestClassify:
     def test_compile_error_is_other(self):
         assert ss.classify("check failed: unexpected token") == "other"
 
+    def test_execution_timeout_is_a_real_result_not_a_transient(self):
+        # The harness's own 30s budget on the model's COMPILED code. The
+        # program did not terminate, which is a wrong answer — deterministic,
+        # so re-running it only reproduces it. Bucketing this transient made
+        # the sweep retry it to its limit and left the target permanently
+        # "RE-RUN", so a finished sweep could not be told from a broken one.
+        assert ss.classify("test 0: vera run timed out after 30s") == "other"
+
+    def test_execution_prefix_beats_every_transient_word(self):
+        # `test N:` marks the local per-test path — no network is involved,
+        # so no message carrying it can be an infrastructure fault, whatever
+        # words appear later.
+        for msg in (
+            "test 3: vera run timed out after 30s",
+            "test 12: connection reset while running",
+            "test 0: killed by signal 9",
+        ):
+            assert ss.classify(msg) == "other", msg
+
+    def test_api_timeout_is_still_transient(self):
+        # The regression guard for the fix above: infrastructure timeouts
+        # carry no `test N:` prefix and must keep re-running.
+        assert ss.classify("API error: request timed out") == "transient"
+        assert ss.classify("Connection error contacting provider") == "transient"
+
 
 def test_expected_problems_matches_repo():
     # The repo's real problem set — the denominator run_sweep and this tool

--- a/vera_bench/adt_render.py
+++ b/vera_bench/adt_render.py
@@ -546,6 +546,24 @@ _TS_CLASS = {
 }
 
 
+def _ts_kind(t: str) -> str | None:
+    """The TS class a declared field type denotes, or None if unreadable.
+
+    Generic arguments are stripped first (`List<T>` is a List), and a name
+    the table does not know — a type variable, an alias, a union — returns
+    None rather than being forced to "object". Forcing it made every
+    generic constructor unalignable.
+    """
+    base = re.sub(r"<[^>]*>", "", t or "").strip().lower()
+    if base in _TS_CLASS.values():
+        return base
+    if base in {k.lower() for k in _TS_CLASS}:
+        return _TS_CLASS[next(k for k in _TS_CLASS if k.lower() == base)]
+    if not base or len(base) <= 2 or base[0].isupper():
+        return None
+    return "object" if base not in _TS_CLASS.values() else base
+
+
 def _fields_for(
     spec: dict,
     ctor_name: str,
@@ -580,24 +598,42 @@ def _fields_for(
             )
         if arity <= 1 or any(t is None for _, t in inferred):
             return [n for n, _ in inferred]
+        # Two passes, because a generic solution declares types this table
+        # cannot read. `type List<T> = ... | { head: T; tail: List<T> }` is
+        # ordinary TypeScript, and `T` is not a class name — collapsing it
+        # to "object" made it unable to match Int's "number", so the whole
+        # constructor declined. A type variable is UNREADABLE, not wrong:
+        # the same judgement `_type_mismatch` already makes on the Python
+        # side, where an unrecognised name is unverifiable rather than a
+        # conflict. Readable types still align by type, and only the
+        # unreadable ones fall back to declared order — so a genuine swap
+        # of two readable fields is still caught.
         remaining = list(inferred)
-        ordered: list[str] = []
-        for arg in canonical:
+        ordered: list[str | None] = [None] * arity
+        for i, arg in enumerate(canonical):
             want = _TS_CLASS.get(arg, "object")
             for idx, (n, t) in enumerate(remaining):
-                have = t.strip().lower()
-                if have not in _TS_CLASS.values():
-                    have = "object"
-                if have == want:
-                    ordered.append(n)
+                if _ts_kind(t) == want:
+                    ordered[i] = n
                     del remaining[idx]
                     break
-            else:
+        for i in range(arity):
+            if ordered[i] is not None:
+                continue
+            # Only an unreadable field may fill a gap. A leftover field
+            # whose type we CAN read did not match anything, which is a
+            # real disagreement rather than something to guess past.
+            spare = next(
+                (j for j, (_n, t) in enumerate(remaining) if _ts_kind(t) is None),
+                None,
+            )
+            if spare is None:
                 raise Unsupported(
                     f"cannot align {actual_tag!r} fields "
                     f"{[n for n, _ in inferred]} to argument types {canonical}"
                 )
-        return ordered
+            ordered[i] = remaining.pop(spare)[0]
+        return [n for n in ordered if n is not None]
     fields = next(
         c.get("fields", []) for c in spec["constructors"] if c["name"] == ctor_name
     )
@@ -815,6 +851,35 @@ def declared_shape(source: str, language: str) -> dict[str, tuple[str, ...]]:
             tree = ast.parse(src)
         except SyntaxError:
             return {}
+        # A union alias IS the ADT's name. `LinkedList: TypeAlias =
+        # Union[Nil, Cons[T]]` (and its PEP 604 spelling `Nil | Cons[T]`)
+        # is how modern Python spells a sum type, and then a recursive
+        # field is annotated `tail: LinkedList[T]` — naming the alias,
+        # which is neither the constructor's own class nor a base class.
+        # Without this the self-reference read as an ordinary type name,
+        # so the shape guard saw ('t', 'linkedlist') where it wanted
+        # ('int', 'SELF') and declined. That is not a rare style: it took
+        # all ten Tier 3 problems out of the Python and TypeScript
+        # denominators, leaving those languages scored on ~51 of 60
+        # problems while Vera kept all 60 — a cross-language comparison
+        # that was quietly not like-for-like.
+        alias_of: dict[str, set[str]] = {}
+        for stmt in tree.body:
+            if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+                name, value = stmt.target.id, stmt.value
+            elif (
+                isinstance(stmt, ast.Assign)
+                and len(stmt.targets) == 1
+                and isinstance(stmt.targets[0], ast.Name)
+            ):
+                name, value = stmt.targets[0].id, stmt.value
+            else:
+                continue
+            if value is None:
+                continue
+            for ref in ast.walk(value):
+                if isinstance(ref, ast.Name):
+                    alias_of.setdefault(ref.id, set()).add(name)
         for node in ast.walk(tree):
             if not isinstance(node, ast.ClassDef):
                 continue
@@ -827,10 +892,15 @@ def declared_shape(source: str, language: str) -> dict[str, tuple[str, ...]]:
                 None,
             )
             # A Python ADT's recursive reference is the BASE class
-            # (`tail: List`), not the constructor's own class.
-            selfish = {node.name} | {
-                b.id for b in node.bases if isinstance(b, ast.Name)
-            }
+            # (`tail: List`), the union alias, or the constructor's own
+            # class. Subscripted bases are skipped deliberately: the base
+            # in `class Cons(Generic[T])` is `Generic`, which is not the
+            # ADT — the alias lookup is what recovers the real name.
+            selfish = (
+                {node.name}
+                | {b.id for b in node.bases if isinstance(b, ast.Name)}
+                | alias_of.get(node.name, set())
+            )
             if init is not None:
                 # The instance parameter is the first POSITIONAL one,
                 # which lands in posonlyargs for `def __init__(self, /,

--- a/vera_bench/runner.py
+++ b/vera_bench/runner.py
@@ -551,7 +551,28 @@ def _evaluate_typescript_code(
         and ts_fn in code.split("export {", 1)[-1].split("}", 1)[0]
     )
     if not already_exported:
-        export_code = code.replace(f"function {ts_fn}(", f"export function {ts_fn}(")
+        # Match the declaration, not a literal `name(`. A generic entry
+        # point is written `function listLength<T>(list: List<T>)`, and a
+        # string match on `listLength(` misses it — so no export was
+        # spliced, the wrapper's import resolved to undefined, and every
+        # test threw "is not a function". That is a WRAPPING failure
+        # recorded as the model's wrong answer: it took ~30 Tier 3
+        # TypeScript solutions to 0/N and inflated Vera's measured lead
+        # over TypeScript. Arrow-function entry points (`const f = <T>(…)`)
+        # are exported the same way.
+        export_code = re.sub(
+            rf"(?m)^(\s*)(function\s+{re.escape(ts_fn)}\s*[<(])",
+            r"\1export \2",
+            code,
+            count=1,
+        )
+        if export_code == code:
+            export_code = re.sub(
+                rf"(?m)^(\s*)((?:const|let)\s+{re.escape(ts_fn)}\s*[:=])",
+                r"\1export \2",
+                code,
+                count=1,
+            )
     code_path.write_text(export_code, encoding="utf-8")
 
     # Build test wrapper — the shared implementation (ts_wrapper.py);


### PR DESCRIPTION
Everything here was found by *running* the first full-60 sweep and reading what it produced. None of it was reachable from the test suite, because every existing gate — baselines, `validate`, evaluator parity — runs against canonical solutions, and canonical solutions never hit any of these paths.

One of them was silently biasing the published cross-language comparison.

## 1. Tier 3 was not being graded for Python or TypeScript

The harness builds a test wrapper by reading the model's own type declaration. When it cannot map that declaration it correctly declines — records `run_correct=None`, leaves the problem ungraded rather than guessing. That decline path is right. What was wrong is how often it fired:

| language | problems actually scored (of 60) |
|---|---|
| Vera / Vera NL | **60** |
| Aver / AILANG | ~59 |
| **TypeScript** | **~53** |
| **Python** | **~51** |

All twelve missing problems are Tier 3 (ADT + exhaustive match) and Tier 4. So the headline "does Vera beat Python/TypeScript" chart was comparing Vera over 60 problems against Python over ~51 — and the missing tier is exactly the one Vera's design targets.

Two causes, both in `adt_render.py`:

**Python** — a union alias *is* the ADT's name:

```python
@dataclass(frozen=True)
class Cons(Generic[T]):
    head: T
    tail: "LinkedList[T]"

LinkedList: TypeAlias = Union[Nil, Cons[T]]
```

`selfish` collected the class and its `ast.Name` bases. `Generic[T]` is a `Subscript`, not a `Name`, and `LinkedList` is a module-level alias rather than a base — so the self-reference never resolved and the shape guard saw `('t', 'linkedlist')` where it wanted `('int', 'SELF')`. Self-names now include module-level aliases that reference the class.

**TypeScript** — a type variable is unreadable, not wrong:

```ts
type List<T> = { kind: "nil" } | { kind: "cons"; head: T; tail: List<T> };
```

`T` is not a class name, so it collapsed to `"object"` and could never match `Int`'s `"number"`. `_ts_kind()` now strips generics and returns `None` for anything unreadable; alignment matches readable types first and only then fills gaps in declared order — so a genuine swap of two readable fields is still caught. This is the same judgement `_type_mismatch` already made on the Python side.

**Result across the sweep: 111 of 113 declines resolve.** Both halves are reported, because 35 of the newly-gradeable answers are simply *wrong* — those lower the comparison languages' scores relative to leaving them ungraded, which is why the fix has to be applied wholesale rather than to the rows that flatter the result.

## 2. `scripts/regrade.py` — apply a grading fix without paying for the sweep again

Since #109 every row carries a `code_path`, so the model's actual output is on disk and a verdict can be recomputed: same code, same problems, fixed harness. That turns a ~$100 overnight re-run into a few minutes of local subprocesses.

It re-grades **every** row, not just the ones a fix was expected to help — grading only the latter would import every improvement while hiding any regression the same change caused. That makes it a free regression test, and the first full run is the evidence this PR rests on: **no `solved → ` transition of any kind.** Nothing that passed was broken.

Only verdict fields are replaced. Token counts, timings and model identity describe the original run and carry through untouched, so a re-graded file still records what that sweep actually cost. Verdicts are compared with sandbox paths normalised, since those differ on every run by construction — without that, 64 rows looked "changed" and would have had their original error messages overwritten with paths from a run that never happened.

## 3. Sweep triage: two misclassifications that changed what the sweep did

**A model's non-terminating code was triaged as an infrastructure fault.** The transient pattern matched a bare `timed out`, which covers both a provider call failing and the harness's own 30s budget on the model's *compiled* code. Those are opposites: one is worth retrying, the other is a deterministic wrong answer. So the sweep retried it to its limit, the target read `RE-RUN` forever, and a surgical repair reproduced it exactly. Per-test failures carry the harness's `test N:` prefix and run locally with no network in play, so that prefix now settles the bucket first. Concretely: Opus 4.8 wrote a `list_reverse` that passes `vera check` and then does not terminate.

**A truncation was published as a model refusal.** `LENGTH` knew only OpenAI's `finish_reason=length`; Anthropic spells a token wall `stop_reason=max_tokens`, and its message *also* contains "no text block" — which the refusal pattern matched, and which was tested first. A recoverable failure was kept as a real verdict and counted in the published refusal figure. A shared `is_refusal()` now excludes truncations, so the monitor and the refusal chart cannot disagree again. Refusals 5 → 4.

## 4. `rerun_failed.py` — the repair tool broke exactly when it was needed

Three defects, all in the path that only runs *after* a sweep:

- It globbed `<model>-bench-*`, unambiguous with one release on disk and ambiguous the moment a second landed. With 0.0.16 and 0.0.18 present, every repair exited `ambiguous — 2 files match`. The prefix now pins the bench version (`--bench-version` reaches older eras); the compiler segment stays a wildcard, since a target's Vera version is whatever produced it.
- The version token was not terminated, so `0.0.18` also matched `bench-0-0-180-…` — a repair aimed at one release could splice rows into another's file.
- Its in-flight guard counted **rows**, but a fix attempt emits a second row for the same problem, so a file could reach 60 rows while still missing problems. It now counts unique problem ids, the same denominator `sweep_status` uses.

## 5. Charts that asserted things the data no longer supported

- **The delta legend covered the largest bar.** Placed `lower right` *inside* the axes — on a diverging chart, exactly where the biggest positive delta ends. Moved to the sparse upper-left in both the slide and the canonical chart.
- **The generation slide's title and subtitle were hardcoded** — "Three flagships, one trajectory", "the Vera line rises at every step" — both true of a three-link chain and false the moment a fourth landed. Both are computed from the plotted points now, and the subtitle reports only languages actually drawn.
- **Two slides in one deck disagreed about the same two models.** The chain read Opus 4.8 and Opus 5 from 0.0.16 while the controlled-pair slide read them from 0.0.18 — 36 graded problems against 60 — so that pair fell 6 points in TypeScript on one slide and rose 3 on the other. Every link with 0.0.18 data now reads it.
- **The chain mixed a family line with a tier jump.** Fable 5 was appended as a fourth link on the mistaken basis that it was the newest model; it is the *ceiling* tier — more capable than Opus 5, not later than it — so the slope into it read as generational progress that never happened, and it pushed the controlled pair into the chain's middle. The chain is one family in release order again.
- **The coverage slide outlived its premise.** It argued pass@1 could not see the problems without test cases; #107 gave every problem test cases, so it rendered "0 of 60" beside a 0% hero stat that read as Vera failing everything. It now measures where `vera check` and `vera run` disagree — the programs that cleared the static gate and still failed, named individually, against the count of working programs wrongly refused. Both numbers are derived, so the captions cannot contradict them.

## Scope

Generators only. The regenerated assets ship with the README rewrite in a separate PR — but the generators are here, so a fresh clone cannot produce the old charts.

`ruff check . && ruff format --check . && ruff check --select S vera_bench/` clean; full suite green.

Refs #101, #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tool to recalculate stored verdicts without rerunning models.
  * Coverage reporting now highlights “escapes” (checks pass, runtime fails) and “false alarms” (checks fail, runtime passes).

* **Bug Fixes**
  * Improved sweep failure classification to avoid incorrect retries and mislabelled refusals.
  * Corrected canonical result selection when multiple benchmark eras are present, including version scoping and completion counting.
  * Fixed generation/coverage slide computations and restored intended release-family ordering.
  * Improved recursive type rendering and TypeScript field alignment.

* **Style**
  * Adjusted legend placement/transparency and refreshed slide titles and explanatory metrics for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->